### PR TITLE
feat: Dockerize Vite application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,57 @@
+# Dependencies
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Build output
+dist
+build
+.next
+out
+
+# Testing
+coverage
+.nyc_output
+
+# Misc
+.DS_Store
+*.pem
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# Git
+.git
+.gitignore
+.gitattributes
+
+# CI/CD
+.github
+.gitlab-ci.yml
+
+# Documentation
+*.md
+README.md
+LICENSE
+CHANGELOG.md
+
+# Supabase
+supabase/.temp
+
+# Husky
+.husky
+
+# Other
+.editorconfig
+.eslintcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Build stage
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+
+# Copy custom nginx config
+COPY --from=builder /app/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy built assets from builder stage
+COPY --from=builder /app/dist/cadam /usr/share/nginx/html/cadam
+
+# Expose port 80
+EXPOSE 80
+
+# Start nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,34 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+
+    # Compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # Serve /cadam path
+    location /cadam {
+        alias /usr/share/nginx/html/cadam;
+        try_files $uri $uri/ /cadam/index.html;
+        index index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Root redirect to /cadam
+    location = / {
+        return 301 /cadam;
+    }
+}


### PR DESCRIPTION
## Summary
- Added multi-stage Dockerfile for building and serving the Vite app
- Configured nginx to properly handle SPA routing with `/cadam` base path
- Added `.dockerignore` to optimize Docker build context

## Docker Setup
The Dockerfile uses a two-stage build:
1. **Build stage**: Uses Node.js 20 Alpine to install dependencies and build the app
2. **Production stage**: Uses nginx Alpine to serve the static files

## Usage
```bash
# Build the image
docker build -t cadam .

# Run the container
docker run -p 8080:80 cadam

# Access the app at http://localhost:8080/cadam
```

## Test plan
- [ ] Build Docker image successfully
- [ ] Run container and verify app loads at `/cadam`
- [ ] Test SPA routing works correctly
- [ ] Verify static assets are cached properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)