### PR TITLE
feat: add 2D export support for DXF and SVG formats

### DIFF
--- a/src/utils/downloadUtils.ts
+++ b/src/utils/downloadUtils.ts
@@ -94,3 +94,31 @@ export function downloadOpenSCADFile(
     mimeType: 'text/plain',
   });
 }
+
+/**
+ * Downloads DXF file from blob
+ */
+export function downloadDXFFile(
+  output: Blob,
+  currentMessage?: Message | null,
+): void {
+  downloadFile({
+    content: output,
+    filename: generateDownloadFilename({ currentMessage, extension: 'dxf' }),
+    mimeType: 'application/dxf',
+  });
+}
+
+/**
+ * Downloads SVG file from blob
+ */
+export function downloadSVGFile(
+  output: Blob,
+  currentMessage?: Message | null,
+): void {
+  downloadFile({
+    content: output,
+    filename: generateDownloadFilename({ currentMessage, extension: 'svg' }),
+    mimeType: 'image/svg+xml',
+  });
+}

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -7,6 +7,7 @@ import WorkspaceFile from '../lib/WorkspaceFile.ts';
 export const enum WorkerMessageType {
   PREVIEW = 'preview',
   EXPORT = 'export',
+  EXPORT_2D = 'export2d',
   FS_READ = 'fs.read',
   FS_WRITE = 'fs.write',
   FS_UNLINK = 'fs.unlink',
@@ -15,6 +16,7 @@ export const enum WorkerMessageType {
 type WorkerMessageDataMap = {
   [WorkerMessageType.PREVIEW]: OpenSCADWorkerMessageData;
   [WorkerMessageType.EXPORT]: OpenSCADWorkerMessageData;
+  [WorkerMessageType.EXPORT_2D]: Export2DMessageData;
   [WorkerMessageType.FS_READ]: FileSystemWorkerMessageData;
   [WorkerMessageType.FS_WRITE]: FileSystemWorkerMessageData;
   [WorkerMessageType.FS_UNLINK]: FileSystemWorkerMessageData;
@@ -40,6 +42,13 @@ export type WorkerResponseMessage = {
 export type OpenSCADWorkerMessageData = {
   code: string;
   fileType: string;
+  params: Parameter[];
+};
+
+export type Export2DMessageData = {
+  code: string;
+  format: 'dxf' | 'svg';
+  projection: 'flat' | 'cut';
   params: Parameter[];
 };
 

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -4,6 +4,7 @@ import {
   FileSystemWorkerMessageData,
   OpenSCADWorkerMessageData,
   OpenSCADWorkerResponseData,
+  Export2DMessageData,
   WorkerMessage,
   WorkerResponseMessage,
 } from './types';
@@ -31,6 +32,9 @@ self.onmessage = async (
         break;
       case 'export':
         result = await openscad.exportFile(data as OpenSCADWorkerMessageData);
+        break;
+      case 'export2d':
+        result = await openscad.export2D(data as Export2DMessageData);
         break;
       case 'fs.read':
         result = await openscad.readFile(data as FileSystemWorkerMessageData);


### PR DESCRIPTION
Add ability to export OpenSCAD models as 2D files using projection():
- DXF and SVG formats with two projection modes:
  - Top view (flat projection from above)
  - Cross-section (cut at Z=0 plane)
- Uses temporary worker to avoid interfering with 3D preview
- Properly handles module/function definitions in projection wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)