### PR TITLE
Add geometry inspector panel including mesh stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2505,6 +2506,7 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.2.0.tgz",
       "integrity": "sha512-esZe+E9T/aYEM4HlBkirr/yRE8qWTp9WUsLISyHHMCHKlJv85uc5N4wwKw+Ay0QeTSITw6T9Q3Svpu383Q+CSQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.28.9",
@@ -3066,6 +3068,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3075,6 +3078,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
       "devOptional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3096,6 +3100,7 @@
       "version": "0.160.0",
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.160.0.tgz",
       "integrity": "sha512-jWlbUBovicUKaOYxzgkLlhkiEQJkhCVvg4W2IYD2trqD2om3VK4DGLpHH5zQHNr7RweZK/5re/4IVhbhvxbV9w==",
+      "peer": true,
       "dependencies": {
         "@types/stats.js": "*",
         "@types/webxr": "*",
@@ -3162,6 +3167,7 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -3421,6 +3427,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3667,6 +3674,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -4219,7 +4227,8 @@
     "node_modules/embla-carousel": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
-      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA=="
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -4323,6 +4332,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5923,6 +5933,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6089,6 +6100,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6245,6 +6257,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6262,6 +6275,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7037,6 +7051,7 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7134,7 +7149,8 @@
     "node_modules/three": {
       "version": "0.160.1",
       "resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
-      "integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ=="
+      "integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -7283,6 +7299,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7458,6 +7475,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -7663,6 +7681,7 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/src/components/viewer/OpenSCADViewer.tsx
+++ b/src/components/viewer/OpenSCADViewer.tsx
@@ -2,7 +2,7 @@ import { useOpenSCAD } from '@/hooks/useOpenSCAD';
 import { useCallback, useEffect, useState, useRef } from 'react';
 import { ThreeScene } from '@/components/viewer/ThreeScene';
 import { STLLoader } from 'three/addons/loaders/STLLoader.js';
-import { BufferGeometry } from 'three';
+import { BufferGeometry, Vector3 } from 'three';
 import { Loader2, CircleAlert, Wrench } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import OpenSCADError from '@/lib/OpenSCADError';
@@ -33,6 +33,13 @@ export function OpenSCADViewer() {
     useOpenSCAD();
   const { getMeshFile, hasMeshFile } = useMeshFiles();
   const [geometry, setGeometry] = useState<BufferGeometry | null>(null);
+  const [geometryStats, setGeometryStats] = useState<{
+    size: { x: number; y: number; z: number };
+    center: { x: number; y: number; z: number };
+    vertexCount: number;
+    triangleCount: number;
+    byteSize: number;
+  } | null>(null);
   const { mutate: sendMessage } = useSendContentMutation({ conversation });
   // Track which files (and their versions) we've written to avoid re-writing
   // Maps filename -> Blob instance
@@ -84,12 +91,33 @@ export function OpenSCADViewer() {
       output.arrayBuffer().then((buffer) => {
         const loader = new STLLoader();
         const geom = loader.parse(buffer);
+        geom.computeBoundingBox();
+        const bbox = geom.boundingBox;
+        const size = new Vector3();
+        const center = new Vector3();
+        if (bbox) {
+          bbox.getSize(size);
+          bbox.getCenter(center);
+        }
+        // Center geometry for viewing after stats are captured
         geom.center();
         geom.computeVertexNormals();
         setGeometry(geom);
+        const vertexCount = geom.attributes.position?.count ?? 0;
+        const triangleCount = geom.index
+          ? geom.index.count / 3
+          : vertexCount / 3;
+        setGeometryStats({
+          size: { x: size.x, y: size.y, z: size.z },
+          center: { x: center.x, y: center.y, z: center.z },
+          vertexCount,
+          triangleCount,
+          byteSize: output.size,
+        });
       });
     } else {
       setGeometry(null);
+      setGeometryStats(null);
     }
   }, [output, setBlob]);
 
@@ -109,7 +137,7 @@ export function OpenSCADViewer() {
     conversation.current_message_leaf_id === currentMessage?.id;
 
   return (
-    <div className="h-full w-full bg-adam-neutral-700/50 shadow-lg backdrop-blur-sm transition-all duration-300 ease-in-out">
+    <div className="relative h-full w-full bg-adam-neutral-700/50 shadow-lg backdrop-blur-sm transition-all duration-300 ease-in-out">
       <div className="h-full w-full">
         {geometry ? (
           <div className="h-full w-full">
@@ -136,6 +164,30 @@ export function OpenSCADViewer() {
               </p>
             </div>
           </div>
+        )}
+      </div>
+      <div className="border-adam-neutral-600/60 pointer-events-none absolute right-3 top-3 rounded-md border bg-adam-neutral-800/70 px-3 py-2 text-[11px] text-adam-text-primary/80 shadow-lg backdrop-blur">
+        <div className="text-[10px] uppercase tracking-wide text-adam-text-primary/60">
+          Geometry Inspector
+        </div>
+        {geometryStats ? (
+          <div className="mt-1 space-y-0.5">
+            <div>
+              Size: {geometryStats.size.x.toFixed(2)},{' '}
+              {geometryStats.size.y.toFixed(2)},{' '}
+              {geometryStats.size.z.toFixed(2)}
+            </div>
+            <div>
+              Center: {geometryStats.center.x.toFixed(2)},{' '}
+              {geometryStats.center.y.toFixed(2)},{' '}
+              {geometryStats.center.z.toFixed(2)}
+            </div>
+            <div>Vertices: {geometryStats.vertexCount}</div>
+            <div>Triangles: {Math.floor(geometryStats.triangleCount)}</div>
+            <div>STL Size: {(geometryStats.byteSize / 1024).toFixed(1)} KB</div>
+          </div>
+        ) : (
+          <div className="mt-1 text-adam-text-primary/50">No geometry</div>
         )}
       </div>
     </div>


### PR DESCRIPTION
Adds a Geometry Inspector panel in the viewer that shows live mesh stats for the current STL:
- Bounding box size (X/Y/Z)
- Model center
- Vertex count
- Triangle count
- STL file size

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an on-canvas Geometry Inspector for STL outputs in the OpenSCAD viewer.
> 
> - Computes and displays `size (X/Y/Z)`, `center`, `vertexCount`, `triangleCount`, and `STL byteSize` after parsing with `STLLoader`
> - Calculates bounding box via `computeBoundingBox()` before recentring (`geom.center()`), then `computeVertexNormals()`; stores metrics in `geometryStats`
> - Renders a fixed overlay panel (top-right) with live stats; container made `relative` to position overlay
> - Minor: imports `Vector3`; defensive resets when no geometry
> - package-lock: adds `peer: true` metadata to numerous dependencies (React, ESLint, Tailwind, Three, Vite, etc.)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9118f5dced4bfeff737ca91b0256c40fd5c1688b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->