### PR TITLE
Add model statistics panel with dimensions and filament estimates

### DIFF
--- a/src/components/ParametricEditor.tsx
+++ b/src/components/ParametricEditor.tsx
@@ -17,6 +17,7 @@ import { ViewerSection } from '@/components/viewer/ViewerSection';
 import { ParameterSection } from '@/components/parameter/ParameterSection';
 import { useBlob } from '@/contexts/BlobContext';
 import { useColor } from '@/contexts/ColorContext';
+import { DimensionsProvider } from '@/contexts/DimensionsContext';
 
 const PANEL_SIZES = {
   CHAT: {
@@ -155,6 +156,7 @@ export function ParametricEditor() {
       maxSize: adjustedMaxSize,
     };
   }, [containerWidth]);
+
   const hasArtifact = useMemo(
     () => !!currentMessage?.content.artifact,
     [currentMessage],
@@ -194,118 +196,120 @@ export function ParametricEditor() {
   }, []);
 
   return (
-    <div
-      className="flex h-full w-full overflow-hidden bg-[#292828]"
-      ref={setContainerRef}
-    >
-      <PanelGroup
-        key={hasArtifact ? 'with-params' : 'no-params'}
-        direction="horizontal"
-        className="h-full w-full"
+    <DimensionsProvider>
+      <div
+        className="flex h-full w-full overflow-hidden bg-[#292828]"
+        ref={setContainerRef}
       >
-        <Panel
-          collapsible
-          ref={chatPanelRef}
-          defaultSize={chatPanelSizes.defaultSize}
-          minSize={chatPanelSizes.minSize}
-          maxSize={chatPanelSizes.maxSize}
-          id="chat-panel"
-          order={0}
+        <PanelGroup
+          key={hasArtifact ? 'with-params' : 'no-params'}
+          direction="horizontal"
+          className="h-full w-full"
         >
-          <div className="relative h-full">
-            <ChatSection messages={currentMessageBranch ?? []} />
-          </div>
-        </Panel>
-        <PanelResizeHandle className="resize-handle group relative">
-          {!isChatCollapsed && (
-            <div className="absolute left-1 top-1/2 z-50 -translate-y-1/2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-              <Button
-                variant="ghost"
-                className="rounded-l-none rounded-r-lg border-b border-r border-t border-gray-200/20 bg-adam-bg-secondary-dark p-2 text-adam-text-primary transition-colors dark:border-gray-800 [@media(hover:hover)]:hover:bg-adam-neutral-950 [@media(hover:hover)]:hover:text-adam-neutral-10"
-                onClick={handleChatCollapse}
-              >
-                <ChevronsRight className="h-5 w-5 rotate-180" />
-              </Button>
+          <Panel
+            collapsible
+            ref={chatPanelRef}
+            defaultSize={chatPanelSizes.defaultSize}
+            minSize={chatPanelSizes.minSize}
+            maxSize={chatPanelSizes.maxSize}
+            id="chat-panel"
+            order={0}
+          >
+            <div className="relative h-full">
+              <ChatSection messages={currentMessageBranch ?? []} />
             </div>
-          )}
-          {isChatCollapsed && (
-            <div className="absolute left-0 top-1/2 z-50 -translate-y-1/2">
-              <Button
-                aria-label="Expand chat panel"
-                onClick={handleChatExpand}
-                className="flex h-[100px] w-9 flex-col items-center rounded-l-none rounded-r-lg bg-adam-bg-secondary-dark px-1.5 py-2 text-adam-text-primary"
-              >
-                <ChevronsRight className="h-5 w-5 text-white" />
-                <div className="flex flex-1 items-center justify-center">
-                  <span className="rotate-90 transform text-center text-base font-semibold text-white">
-                    Chat
-                  </span>
-                </div>
-              </Button>
-            </div>
-          )}
-        </PanelResizeHandle>
-        <Panel
-          defaultSize={
-            PANEL_SIZES.PREVIEW.DEFAULT +
-            (hasArtifact ? 0 : parametersPanelSizes.defaultSize)
-          }
-          minSize={
-            PANEL_SIZES.PREVIEW.MIN +
-            (hasArtifact ? 0 : parametersPanelSizes.minSize)
-          }
-          id="preview-panel"
-          order={1}
-        >
-          <ViewerSection />
-        </Panel>
-        {hasArtifact && (
-          <>
-            <PanelResizeHandle className="resize-handle group relative">
-              {!isParametersPanelCollapsed && (
-                <div className="absolute right-1 top-1/2 z-50 -translate-y-1/2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-                  <Button
-                    variant="ghost"
-                    className="rounded-l-lg rounded-r-none border-b border-l border-t border-gray-200/20 bg-adam-bg-secondary-dark p-2 text-adam-text-primary transition-colors dark:border-gray-800 [@media(hover:hover)]:hover:bg-adam-neutral-950 [@media(hover:hover)]:hover:text-adam-neutral-10"
-                    onClick={handleParametersCollapse}
-                  >
-                    <ChevronsRight className="h-5 w-5" />
-                  </Button>
-                </div>
-              )}
-              {isParametersPanelCollapsed && (
-                <div className="absolute right-0 top-1/2 z-50 -translate-y-1/2">
-                  <Button
-                    aria-label="Expand parameters panel"
-                    onClick={handleParametersExpand}
-                    className="flex h-[140px] w-9 flex-col items-center rounded-l-lg rounded-r-none bg-adam-bg-secondary-dark p-2 px-1.5 py-2 text-adam-text-primary"
-                  >
-                    <ChevronsRight className="mb-3 h-5 w-5 rotate-180 text-white" />
-                    <div className="flex flex-1 items-center justify-center">
-                      <span className="min-w-[100px] -rotate-90 transform text-center text-base font-semibold text-white">
-                        Parameters
-                      </span>
-                    </div>
-                  </Button>
-                </div>
-              )}
-            </PanelResizeHandle>
-            <Panel
-              collapsible
-              ref={parameterPanelRef}
-              defaultSize={parametersPanelSizes.defaultSize}
-              minSize={parametersPanelSizes.minSize}
-              maxSize={parametersPanelSizes.maxSize}
-              id="parameters-panel"
-              order={2}
-            >
-              <div className="relative h-full">
-                <ParameterSection />
+          </Panel>
+          <PanelResizeHandle className="resize-handle group relative">
+            {!isChatCollapsed && (
+              <div className="absolute left-1 top-1/2 z-50 -translate-y-1/2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                <Button
+                  variant="ghost"
+                  className="rounded-l-none rounded-r-lg border-b border-r border-t border-gray-200/20 bg-adam-bg-secondary-dark p-2 text-adam-text-primary transition-colors dark:border-gray-800 [@media(hover:hover)]:hover:bg-adam-neutral-950 [@media(hover:hover)]:hover:text-adam-neutral-10"
+                  onClick={handleChatCollapse}
+                >
+                  <ChevronsRight className="h-5 w-5 rotate-180" />
+                </Button>
               </div>
-            </Panel>
-          </>
-        )}
-      </PanelGroup>
-    </div>
+            )}
+            {isChatCollapsed && (
+              <div className="absolute left-0 top-1/2 z-50 -translate-y-1/2">
+                <Button
+                  aria-label="Expand chat panel"
+                  onClick={handleChatExpand}
+                  className="flex h-[100px] w-9 flex-col items-center rounded-l-none rounded-r-lg bg-adam-bg-secondary-dark px-1.5 py-2 text-adam-text-primary"
+                >
+                  <ChevronsRight className="h-5 w-5 text-white" />
+                  <div className="flex flex-1 items-center justify-center">
+                    <span className="rotate-90 transform text-center text-base font-semibold text-white">
+                      Chat
+                    </span>
+                  </div>
+                </Button>
+              </div>
+            )}
+          </PanelResizeHandle>
+          <Panel
+            defaultSize={
+              PANEL_SIZES.PREVIEW.DEFAULT +
+              (hasArtifact ? 0 : parametersPanelSizes.defaultSize)
+            }
+            minSize={
+              PANEL_SIZES.PREVIEW.MIN +
+              (hasArtifact ? 0 : parametersPanelSizes.minSize)
+            }
+            id="preview-panel"
+            order={1}
+          >
+            <ViewerSection />
+          </Panel>
+          {hasArtifact && (
+            <>
+              <PanelResizeHandle className="resize-handle group relative">
+                {!isParametersPanelCollapsed && (
+                  <div className="absolute right-1 top-1/2 z-50 -translate-y-1/2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                    <Button
+                      variant="ghost"
+                      className="rounded-l-lg rounded-r-none border-b border-l border-t border-gray-200/20 bg-adam-bg-secondary-dark p-2 text-adam-text-primary transition-colors dark:border-gray-800 [@media(hover:hover)]:hover:bg-adam-neutral-950 [@media(hover:hover)]:hover:text-adam-neutral-10"
+                      onClick={handleParametersCollapse}
+                    >
+                      <ChevronsRight className="h-5 w-5" />
+                    </Button>
+                  </div>
+                )}
+                {isParametersPanelCollapsed && (
+                  <div className="absolute right-0 top-1/2 z-50 -translate-y-1/2">
+                    <Button
+                      aria-label="Expand parameters panel"
+                      onClick={handleParametersExpand}
+                      className="flex h-[140px] w-9 flex-col items-center rounded-l-lg rounded-r-none bg-adam-bg-secondary-dark p-2 px-1.5 py-2 text-adam-text-primary"
+                    >
+                      <ChevronsRight className="mb-3 h-5 w-5 rotate-180 text-white" />
+                      <div className="flex flex-1 items-center justify-center">
+                        <span className="min-w-[100px] -rotate-90 transform text-center text-base font-semibold text-white">
+                          Parameters
+                        </span>
+                      </div>
+                    </Button>
+                  </div>
+                )}
+              </PanelResizeHandle>
+              <Panel
+                collapsible
+                ref={parameterPanelRef}
+                defaultSize={parametersPanelSizes.defaultSize}
+                minSize={parametersPanelSizes.minSize}
+                maxSize={parametersPanelSizes.maxSize}
+                id="parameters-panel"
+                order={2}
+              >
+                <div className="relative h-full">
+                  <ParameterSection />
+                </div>
+              </Panel>
+            </>
+          )}
+        </PanelGroup>
+      </div>
+    </DimensionsProvider>
   );
 }

--- a/src/components/parameter/ParameterSection.tsx
+++ b/src/components/parameter/ParameterSection.tsx
@@ -1,4 +1,12 @@
-import { RefreshCcw, Download, ChevronUp } from 'lucide-react';
+import {
+  RefreshCcw,
+  Download,
+  ChevronUp,
+  Box,
+  Ruler,
+  Scale,
+  DollarSign,
+} from 'lucide-react';
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -22,9 +30,11 @@ import { useCurrentMessage } from '@/contexts/CurrentMessageContext';
 import { downloadSTLFile, downloadOpenSCADFile } from '@/utils/downloadUtils';
 import { useChangeParameters } from '@/services/messageService';
 import { useBlob } from '@/contexts/BlobContext';
+import { useDimensions } from '@/contexts/DimensionsContext';
 
 export function ParameterSection() {
   const { blob } = useBlob();
+  const { dimensions, filamentEstimates } = useDimensions();
   const changeParameters = useChangeParameters();
   const { currentMessage } = useCurrentMessage();
   const parameters = currentMessage?.content.artifact?.parameters ?? [];
@@ -141,6 +151,83 @@ export function ParameterSection() {
             ))}
           </div>
         </ScrollArea>
+        {dimensions && (
+          <div className="border-t border-adam-neutral-700 px-6 py-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Box className="h-4 w-4 text-adam-blue" />
+              <span className="text-sm font-semibold text-adam-text-primary">
+                Dimensions
+              </span>
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-semibold text-red-400">X</span>
+                <span className="font-mono text-xs text-adam-text-primary">
+                  {dimensions.x.toFixed(2)} mm
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-semibold text-green-400">Y</span>
+                <span className="font-mono text-xs text-adam-text-primary">
+                  {dimensions.y.toFixed(2)} mm
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-semibold text-blue-400">Z</span>
+                <span className="font-mono text-xs text-adam-text-primary">
+                  {dimensions.z.toFixed(2)} mm
+                </span>
+              </div>
+              <div className="border-adam-neutral-600/50 mt-2 flex items-center gap-1.5 border-t pt-2">
+                <Ruler className="h-3 w-3 text-adam-text-secondary" />
+                <span className="text-xs text-adam-text-secondary">
+                  {dimensions.x.toFixed(2)} × {dimensions.y.toFixed(2)} ×{' '}
+                  {dimensions.z.toFixed(2)} mm
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+        {filamentEstimates && (
+          <div className="border-t border-adam-neutral-700 px-6 py-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Scale className="h-4 w-4 text-adam-blue" />
+              <span className="text-sm font-semibold text-adam-text-primary">
+                Print Estimates
+              </span>
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-adam-text-secondary">Volume</span>
+                <span className="font-mono text-xs text-adam-text-primary">
+                  {filamentEstimates.volumeCm3.toFixed(2)} cm³
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-adam-text-secondary">
+                  Filament
+                </span>
+                <span className="font-mono text-xs text-adam-text-primary">
+                  {filamentEstimates.weightGrams.toFixed(1)} g
+                </span>
+              </div>
+              <div className="border-adam-neutral-600/50 mt-2 flex items-center justify-between border-t pt-2">
+                <div className="flex items-center gap-1.5">
+                  <DollarSign className="h-3 w-3 text-green-400" />
+                  <span className="text-xs font-medium text-adam-text-primary">
+                    Est. Cost
+                  </span>
+                </div>
+                <span className="font-mono text-xs font-semibold text-green-400">
+                  ${filamentEstimates.costUSD.toFixed(2)}
+                </span>
+              </div>
+              <p className="mt-1 text-[10px] text-adam-text-secondary/60">
+                PLA @ $20/kg
+              </p>
+            </div>
+          </div>
+        )}
         <div className="flex flex-col gap-4 border-t border-adam-neutral-700 px-6 py-6">
           <div>
             <ColorPicker />

--- a/src/components/viewer/OpenSCADViewer.tsx
+++ b/src/components/viewer/OpenSCADViewer.tsx
@@ -14,7 +14,10 @@ import { useSendContentMutation } from '@/services/messageService';
 import { useBlob } from '@/contexts/BlobContext';
 import { useMeshFiles } from '@/contexts/MeshFilesContext';
 import { useDimensions } from '@/contexts/DimensionsContext';
-import { calculateFilamentEstimates } from '@/utils/meshUtils';
+import {
+  calculateFilamentEstimates,
+  calculateMeshVolume,
+} from '@/utils/meshUtils';
 
 // Extract import() filenames from OpenSCAD code
 function extractImportFilenames(code: string): string[] {
@@ -25,42 +28,6 @@ function extractImportFilenames(code: string): string[] {
     filenames.push(match[1]);
   }
   return filenames;
-}
-
-/**
- * Calculate the volume of a mesh from its BufferGeometry
- * Uses the signed tetrahedron volume method
- */
-function calculateMeshVolume(geometry: BufferGeometry): number {
-  const position = geometry.getAttribute('position');
-  if (!position) return 0;
-
-  let volume = 0;
-  const vertices = position.array;
-
-  // For each triangle, calculate signed volume of tetrahedron with origin
-  for (let i = 0; i < position.count; i += 3) {
-    const v0x = vertices[i * 3];
-    const v0y = vertices[i * 3 + 1];
-    const v0z = vertices[i * 3 + 2];
-
-    const v1x = vertices[(i + 1) * 3];
-    const v1y = vertices[(i + 1) * 3 + 1];
-    const v1z = vertices[(i + 1) * 3 + 2];
-
-    const v2x = vertices[(i + 2) * 3];
-    const v2y = vertices[(i + 2) * 3 + 1];
-    const v2z = vertices[(i + 2) * 3 + 2];
-
-    // Signed volume of tetrahedron formed by triangle and origin
-    volume +=
-      (v0x * (v1y * v2z - v2y * v1z) -
-        v1x * (v0y * v2z - v2y * v0z) +
-        v2x * (v0y * v1z - v1y * v0z)) /
-      6;
-  }
-
-  return Math.abs(volume);
 }
 
 export function OpenSCADViewer() {

--- a/src/components/viewer/OpenSCADViewer.tsx
+++ b/src/components/viewer/OpenSCADViewer.tsx
@@ -13,6 +13,8 @@ import { Content } from '@shared/types';
 import { useSendContentMutation } from '@/services/messageService';
 import { useBlob } from '@/contexts/BlobContext';
 import { useMeshFiles } from '@/contexts/MeshFilesContext';
+import { useDimensions } from '@/contexts/DimensionsContext';
+import { calculateFilamentEstimates } from '@/utils/meshUtils';
 
 // Extract import() filenames from OpenSCAD code
 function extractImportFilenames(code: string): string[] {
@@ -25,10 +27,47 @@ function extractImportFilenames(code: string): string[] {
   return filenames;
 }
 
+/**
+ * Calculate the volume of a mesh from its BufferGeometry
+ * Uses the signed tetrahedron volume method
+ */
+function calculateMeshVolume(geometry: BufferGeometry): number {
+  const position = geometry.getAttribute('position');
+  if (!position) return 0;
+
+  let volume = 0;
+  const vertices = position.array;
+
+  // For each triangle, calculate signed volume of tetrahedron with origin
+  for (let i = 0; i < position.count; i += 3) {
+    const v0x = vertices[i * 3];
+    const v0y = vertices[i * 3 + 1];
+    const v0z = vertices[i * 3 + 2];
+
+    const v1x = vertices[(i + 1) * 3];
+    const v1y = vertices[(i + 1) * 3 + 1];
+    const v1z = vertices[(i + 1) * 3 + 2];
+
+    const v2x = vertices[(i + 2) * 3];
+    const v2y = vertices[(i + 2) * 3 + 1];
+    const v2z = vertices[(i + 2) * 3 + 2];
+
+    // Signed volume of tetrahedron formed by triangle and origin
+    volume +=
+      (v0x * (v1y * v2z - v2y * v1z) -
+        v1x * (v0y * v2z - v2y * v0z) +
+        v2x * (v0y * v1z - v1y * v0z)) /
+      6;
+  }
+
+  return Math.abs(volume);
+}
+
 export function OpenSCADViewer() {
   const { conversation } = useConversation();
   const { currentMessage } = useCurrentMessage();
   const { setBlob } = useBlob();
+  const { setDimensions, setFilamentEstimates } = useDimensions();
   const { compileScad, writeFile, isCompiling, output, isError, error } =
     useOpenSCAD();
   const { getMeshFile, hasMeshFile } = useMeshFiles();
@@ -40,6 +79,7 @@ export function OpenSCADViewer() {
 
   const scadCode = currentMessage?.content.artifact?.code;
 
+  // Compile OpenSCAD code when it changes
   useEffect(() => {
     if (!scadCode) return;
 
@@ -78,6 +118,7 @@ export function OpenSCADViewer() {
     compileWithMeshFiles();
   }, [scadCode, compileScad, writeFile, getMeshFile, hasMeshFile]);
 
+  // Handle compiled output
   useEffect(() => {
     setBlob(output ?? null);
     if (output && output instanceof Blob) {
@@ -86,12 +127,31 @@ export function OpenSCADViewer() {
         const geom = loader.parse(buffer);
         geom.center();
         geom.computeVertexNormals();
+        geom.computeBoundingBox();
+
+        // Calculate and set dimensions
+        const box = geom.boundingBox;
+        if (box) {
+          setDimensions({
+            x: Math.round((box.max.x - box.min.x) * 100) / 100,
+            y: Math.round((box.max.y - box.min.y) * 100) / 100,
+            z: Math.round((box.max.z - box.min.z) * 100) / 100,
+          });
+        }
+
+        // Calculate volume and filament estimates
+        const volumeMm3 = calculateMeshVolume(geom);
+        const estimates = calculateFilamentEstimates(volumeMm3);
+        setFilamentEstimates(estimates);
+
         setGeometry(geom);
       });
     } else {
       setGeometry(null);
+      setDimensions(null);
+      setFilamentEstimates(null);
     }
-  }, [output, setBlob]);
+  }, [output, setBlob, setDimensions, setFilamentEstimates]);
 
   const fixError = useCallback(
     async (error: OpenSCADError) => {

--- a/src/components/viewer/OpenSCADViewer.tsx
+++ b/src/components/viewer/OpenSCADViewer.tsx
@@ -15,6 +15,7 @@ import { useBlob } from '@/contexts/BlobContext';
 import { useMeshFiles } from '@/contexts/MeshFilesContext';
 import { useDimensions } from '@/contexts/DimensionsContext';
 import {
+  calculateBoundingBox,
   calculateFilamentEstimates,
   calculateMeshVolume,
 } from '@/utils/meshUtils';
@@ -87,24 +88,23 @@ export function OpenSCADViewer() {
 
   // Handle compiled output
   useEffect(() => {
+    let cancelled = false;
     setBlob(output ?? null);
     if (output && output instanceof Blob) {
       output.arrayBuffer().then((buffer) => {
+        if (cancelled) return;
         const loader = new STLLoader();
         const geom = loader.parse(buffer);
-        geom.center();
-        geom.computeVertexNormals();
         geom.computeBoundingBox();
+        geom.computeVertexNormals();
 
-        // Calculate and set dimensions
-        const box = geom.boundingBox;
-        if (box) {
-          setDimensions({
-            x: Math.round((box.max.x - box.min.x) * 100) / 100,
-            y: Math.round((box.max.y - box.min.y) * 100) / 100,
-            z: Math.round((box.max.z - box.min.z) * 100) / 100,
-          });
+        // Calculate dimensions from original bounds before centering
+        if (geom.boundingBox) {
+          setDimensions(calculateBoundingBox(geom.boundingBox));
         }
+
+        // Center geometry for display
+        geom.center();
 
         // Calculate volume and filament estimates
         const volumeMm3 = calculateMeshVolume(geom);
@@ -118,6 +118,9 @@ export function OpenSCADViewer() {
       setDimensions(null);
       setFilamentEstimates(null);
     }
+    return () => {
+      cancelled = true;
+    };
   }, [output, setBlob, setDimensions, setFilamentEstimates]);
 
   const fixError = useCallback(
@@ -192,7 +195,7 @@ function FixWithAIButton({
           </p>
         </div>
       </div>
-      {fixError && error && error.name === 'OpenSCADError' && (
+      {fixError && error instanceof OpenSCADError && (
         <Button
           variant="ghost"
           className={cn(
@@ -204,11 +207,7 @@ function FixWithAIButton({
             'hover:shadow-[0_0_25px_rgba(0,166,255,0.4)]',
             'focus:outline-none focus:ring-2 focus:ring-adam-blue/30',
           )}
-          onClick={() => {
-            if (error && error.name === 'OpenSCADError') {
-              fixError?.(error as OpenSCADError);
-            }
-          }}
+          onClick={() => fixError(error)}
         >
           <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-adam-blue/20 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
           <Wrench className="h-4 w-4 transition-transform duration-300 group-hover:rotate-12" />

--- a/src/components/viewer/ViewerSection.tsx
+++ b/src/components/viewer/ViewerSection.tsx
@@ -8,6 +8,8 @@ export function ViewerSection() {
   const isLoading = useIsLoading();
   const { currentMessage: message } = useCurrentMessage();
 
+  const showViewer = message?.content.artifact?.code;
+
   return (
     <div className="flex h-full w-full items-center justify-center bg-adam-neutral-700">
       {isLoading ? (
@@ -19,7 +21,7 @@ export function ViewerSection() {
           {message?.content.images && Array.isArray(message.content.images) && (
             <ImageGallery imageIds={message.content.images} />
           )}
-          {message?.content.artifact?.code && <OpenSCADViewer />}
+          {showViewer && <OpenSCADViewer />}
         </div>
       )}
     </div>

--- a/src/contexts/DimensionsContext.tsx
+++ b/src/contexts/DimensionsContext.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import type { FilamentEstimates } from '@/utils/meshUtils';
+
+export type { FilamentEstimates };
+
+export interface Dimensions {
+  x: number;
+  y: number;
+  z: number;
+}
+
+interface DimensionsContextType {
+  dimensions: Dimensions | null;
+  setDimensions: (dimensions: Dimensions | null) => void;
+  filamentEstimates: FilamentEstimates | null;
+  setFilamentEstimates: (estimates: FilamentEstimates | null) => void;
+}
+
+const DimensionsContext = createContext<DimensionsContextType | undefined>(
+  undefined,
+);
+
+export function DimensionsProvider({ children }: { children: ReactNode }) {
+  const [dimensions, setDimensions] = useState<Dimensions | null>(null);
+  const [filamentEstimates, setFilamentEstimates] =
+    useState<FilamentEstimates | null>(null);
+
+  return (
+    <DimensionsContext.Provider
+      value={{
+        dimensions,
+        setDimensions,
+        filamentEstimates,
+        setFilamentEstimates,
+      }}
+    >
+      {children}
+    </DimensionsContext.Provider>
+  );
+}
+
+export function useDimensions() {
+  const context = useContext(DimensionsContext);
+  if (context === undefined) {
+    throw new Error('useDimensions must be used within a DimensionsProvider');
+  }
+  return context;
+}

--- a/src/contexts/DimensionsContext.tsx
+++ b/src/contexts/DimensionsContext.tsx
@@ -1,13 +1,8 @@
 import { createContext, useContext, useState, ReactNode } from 'react';
-import type { FilamentEstimates } from '@/utils/meshUtils';
+import type { FilamentEstimates, BoundingBox } from '@/utils/meshUtils';
 
 export type { FilamentEstimates };
-
-export interface Dimensions {
-  x: number;
-  y: number;
-  z: number;
-}
+export type Dimensions = BoundingBox;
 
 interface DimensionsContextType {
   dimensions: Dimensions | null;

--- a/src/utils/meshUtils.ts
+++ b/src/utils/meshUtils.ts
@@ -6,8 +6,10 @@ import * as THREE from 'three';
  * Uses the signed tetrahedron volume method
  */
 export function calculateMeshVolume(geometry: THREE.BufferGeometry): number {
-  const position = geometry.getAttribute('position');
-  if (!position) return 0;
+  // Handle indexed geometry by converting to non-indexed
+  const geo = geometry.index ? geometry.toNonIndexed() : geometry;
+  const position = geo.getAttribute('position');
+  if (!position || position.count % 3 !== 0) return 0;
 
   let volume = 0;
   const vertices = position.array;
@@ -41,6 +43,17 @@ export interface BoundingBox {
   x: number;
   y: number;
   z: number;
+}
+
+/**
+ * Calculate bounding box dimensions from a Three.js Box3
+ */
+export function calculateBoundingBox(box: THREE.Box3): BoundingBox {
+  return {
+    x: Math.round((box.max.x - box.min.x) * 100) / 100,
+    y: Math.round((box.max.y - box.min.y) * 100) / 100,
+    z: Math.round((box.max.z - box.min.z) * 100) / 100,
+  };
 }
 
 export interface FilamentEstimates {
@@ -95,13 +108,7 @@ export async function parseSTL(
   const geometry = loader.parse(buffer);
 
   geometry.computeBoundingBox();
-  const box = geometry.boundingBox!;
-
-  const boundingBox: BoundingBox = {
-    x: Math.round((box.max.x - box.min.x) * 100) / 100,
-    y: Math.round((box.max.y - box.min.y) * 100) / 100,
-    z: Math.round((box.max.z - box.min.z) * 100) / 100,
-  };
+  const boundingBox = calculateBoundingBox(geometry.boundingBox!);
 
   geometry.center();
   geometry.computeVertexNormals();

--- a/src/utils/meshUtils.ts
+++ b/src/utils/meshUtils.ts
@@ -1,6 +1,42 @@
 import { STLLoader } from 'three/addons/loaders/STLLoader.js';
 import * as THREE from 'three';
 
+/**
+ * Calculate the volume of a mesh from its BufferGeometry
+ * Uses the signed tetrahedron volume method
+ */
+export function calculateMeshVolume(geometry: THREE.BufferGeometry): number {
+  const position = geometry.getAttribute('position');
+  if (!position) return 0;
+
+  let volume = 0;
+  const vertices = position.array;
+
+  // For each triangle, calculate signed volume of tetrahedron with origin
+  for (let i = 0; i < position.count; i += 3) {
+    const v0x = vertices[i * 3];
+    const v0y = vertices[i * 3 + 1];
+    const v0z = vertices[i * 3 + 2];
+
+    const v1x = vertices[(i + 1) * 3];
+    const v1y = vertices[(i + 1) * 3 + 1];
+    const v1z = vertices[(i + 1) * 3 + 2];
+
+    const v2x = vertices[(i + 2) * 3];
+    const v2y = vertices[(i + 2) * 3 + 1];
+    const v2z = vertices[(i + 2) * 3 + 2];
+
+    // Signed volume of tetrahedron formed by triangle and origin
+    volume +=
+      (v0x * (v1y * v2z - v2y * v1z) -
+        v1x * (v0y * v2z - v2y * v0z) +
+        v2x * (v0y * v1z - v1y * v0z)) /
+      6;
+  }
+
+  return Math.abs(volume);
+}
+
 export interface BoundingBox {
   x: number;
   y: number;

--- a/src/utils/meshUtils.ts
+++ b/src/utils/meshUtils.ts
@@ -7,6 +7,41 @@ export interface BoundingBox {
   z: number;
 }
 
+export interface FilamentEstimates {
+  volumeCm3: number; // Volume in cubic centimeters
+  weightGrams: number; // Weight in grams
+  costUSD: number; // Estimated cost in USD
+}
+
+// PLA filament density: ~1.24 g/cm³
+const PLA_DENSITY_G_CM3 = 1.24;
+// Average PLA filament cost: ~$20/kg = $0.02/g
+const FILAMENT_COST_PER_GRAM = 0.02;
+
+/**
+ * Calculate filament estimates from model volume
+ * The mesh volume represents the actual material in the model as designed.
+ * @param volumeMm3 - Volume in cubic millimeters (actual mesh volume)
+ */
+export function calculateFilamentEstimates(
+  volumeMm3: number,
+): FilamentEstimates {
+  // Convert mm³ to cm³ (1 cm³ = 1000 mm³)
+  const volumeCm3 = volumeMm3 / 1000;
+
+  // Calculate weight using PLA density (1.24 g/cm³)
+  const weightGrams = volumeCm3 * PLA_DENSITY_G_CM3;
+
+  // Calculate cost
+  const costUSD = weightGrams * FILAMENT_COST_PER_GRAM;
+
+  return {
+    volumeCm3: Math.round(volumeCm3 * 100) / 100,
+    weightGrams: Math.round(weightGrams * 100) / 100,
+    costUSD: Math.round(costUSD * 100) / 100,
+  };
+}
+
 export interface STLProcessingResult {
   geometry: THREE.BufferGeometry;
   boundingBox: BoundingBox;


### PR DESCRIPTION
## Summary
Adds a statistics panel to the right sidebar that displays real-time model dimensions and print cost estimates when viewing generated 3D models.
The panel updates automatically based on the currently rendered mesh and provides quick, slicer-style feedback without leaving the viewer.

<img width="1255" height="801" alt="Screenshot 2026-01-26 at 1 04 30 PM" src="https://github.com/user-attachments/assets/2457c180-b800-4378-81cb-676daaa9812e" />

## Features
### Dimensions
Displays X, Y, Z dimensions (mm)
Color-coded to match 3D axes:
X: red
Y: green
Z: blue

### Print Estimates
- Model volume (cm³)
- Filament weight (grams), assuming PLA density (1.24 g/cm³)
- Estimated print cost (USD), based on $20/kg filament cost

## Implementation Details
- Introduced DimensionsContext to share dimension and estimate data between the 3D viewer and the sidebar UI
- Added utility functions in meshUtils.ts:
  - calculateMeshVolume() — computes mesh volume using the signed tetrahedron method
  - calculateFilamentEstimates() — derives filament weight and cost from volume
- Integrated the statistics panel into the existing ParameterSection component
- All calculations are performed client-side and update whenever the rendered mesh changes

## More screenshots
<img width="1256" height="800" alt="Screenshot 2026-01-26 at 1 11 15 PM" src="https://github.com/user-attachments/assets/0a3754e0-42c4-4dd9-9162-18aef3e8920e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new client-side mesh analysis (bounding box + volume) wired through shared context; risk is moderate due to potential performance/accuracy issues on large or non-manifold meshes and new state flow between viewer and sidebar.
> 
> **Overview**
> Adds a new **model statistics** readout (dimensions and basic PLA print estimates) to the right sidebar, rendered in `ParameterSection` when a compiled model is available.
> 
> Introduces `DimensionsContext` (provided by `ParametricEditor`) and updates `OpenSCADViewer` to compute bounding box dimensions, mesh volume, and derived filament/cost estimates from the compiled STL output, clearing these values when output is absent. `meshUtils` gains helpers for volume calculation, bounding box extraction, and filament estimate math, and `OpenSCADViewer` tightens error handling for the *Fix with AI* action and guards async parsing with a cancellation flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c3d7780de919bec941b61c050fc57793f241ca5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->