### PR TITLE
chore: update Claude Opus model from 4.6 to 4.7

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -246,8 +246,8 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'anthropic/claude-opus-4.6',
-    name: 'Claude Opus 4.6',
+    id: 'anthropic/claude-opus-4.7',
+    name: 'Claude Opus 4.7',
     description: 'Most powerful Anthropic model for complex reasoning',
     provider: 'Anthropic',
     supportsTools: true,


### PR DESCRIPTION
## Summary
- Updates the Claude Opus model ID from `anthropic/claude-opus-4.6` to `anthropic/claude-opus-4.7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Claude Opus model from `anthropic/claude-opus-4.6` to `anthropic/claude-opus-4.7` in `PARAMETRIC_MODELS`, updating both the `id` and display name to use the latest Anthropic model.

<sup>Written for commit 61167e0e98d80aa1ec4b725bced983e95d4c3230. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

