### PR TITLE
Personalize home page greeting with user's first name

### DIFF
--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -17,13 +17,20 @@ import { SelectedItemsContext } from '@/contexts/SelectedItemsContext';
 import posthog from 'posthog-js';
 import * as Sentry from '@sentry/react';
 import { useSendContentMutation } from '@/services/messageService';
+import { useProfile } from '@/services/profileService';
 
 export function PromptView() {
   const navigate = useNavigate();
   const { toast } = useToast();
   const { user, totalTokens, isLoading } = useAuth();
+  const { data: profile } = useProfile();
   const { isSidebarOpen } = useOutletContext<{ isSidebarOpen: boolean }>();
   const queryClient = useQueryClient();
+
+  const firstName = useMemo(() => {
+    const source = profile?.full_name || user?.email?.split('@')[0] || '';
+    return source.trim().split(/\s+/)[0] ?? '';
+  }, [profile?.full_name, user?.email]);
 
   const [type, setType] = useState<'parametric' | 'creative'>('parametric');
 
@@ -213,7 +220,8 @@ export function PromptView() {
                 isLoaded ? 'opacity-100' : 'opacity-0',
               )}
             >
-              {getTimeBasedGreeting}!
+              {getTimeBasedGreeting}
+              {firstName ? `, ${firstName}` : ''}!
             </h1>
           </div>
           <div className="flex w-full flex-col items-center">

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -23,14 +23,18 @@ export function PromptView() {
   const navigate = useNavigate();
   const { toast } = useToast();
   const { user, totalTokens, isLoading } = useAuth();
-  const { data: profile } = useProfile();
+  const { data: profile, isLoading: isProfileLoading } = useProfile();
   const { isSidebarOpen } = useOutletContext<{ isSidebarOpen: boolean }>();
   const queryClient = useQueryClient();
 
   const firstName = useMemo(() => {
+    // Wait until the profile query resolves for signed-in users so the
+    // greeting doesn't flash the email local-part before snapping to the
+    // real first name.
+    if (user && isProfileLoading) return '';
     const source = profile?.full_name || user?.email?.split('@')[0] || '';
-    return source.trim().split(/\s+/)[0] ?? '';
-  }, [profile?.full_name, user?.email]);
+    return source.trim().split(/\s+/)[0] || '';
+  }, [profile?.full_name, user, isProfileLoading]);
 
   const [type, setType] = useState<'parametric' | 'creative'>('parametric');
 


### PR DESCRIPTION
## Summary
- The time-based header on the home page (`PromptView`) now reads `Good morning, {firstName}!` (or afternoon/evening) when a signed-in user has a profile name set.
- Falls back to the email local-part if `profile.full_name` isn't populated, and drops the comma entirely when signed out so unauthenticated visitors still see a clean `Good morning!`.
- Pulls the name via the existing `useProfile()` hook — same source used by `Sidebar` and `UserAvatar` — so no new data plumbing.

## Implementation notes
- `firstName` is derived by taking the first whitespace-separated token of `profile.full_name` (with the email-prefix fallback), memoized on `profile?.full_name` and `user?.email`.
- Greeting JSX conditionally appends `, {firstName}` only when a name is resolvable, preserving the existing signed-out UX.

## Test plan
- [ ] Signed out: header reads `Good morning!` (no trailing comma).
- [ ] Signed in with `full_name` set: header reads `Good morning, {firstName}!`.
- [ ] Signed in without `full_name`: header falls back to the email local-part.
- [ ] Afternoon/evening time ranges still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Personalizes the home page greeting with the user’s first name and removes a brief email-prefix flash.

- **New Features**
  - On `PromptView`, shows “Good morning, {firstName}!” (or afternoon/evening). Falls back to the email local-part; shows “Good morning!” when signed out.
  - First name is taken from the first token of `profile.full_name` via `useProfile()`.

- **Bug Fixes**
  - Waits for the profile query to finish before resolving the name to avoid “johndoe” → “John” flicker on cold cache.
  - Simplified fallback with `|| ''` so all-whitespace names resolve to empty and the comma is dropped.

<sup>Written for commit 775fdf1f5e9e68864b8f4cde139f30c68f70d69e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

