### PR TITLE
feat(settings): redesign settings page with card-based layout

### DIFF
--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -162,10 +162,10 @@ export default function SettingsView() {
         : 'bg-gradient-to-r from-adam-blue/20 to-fuchsia-500/20 text-adam-neutral-50';
 
   return (
-    <div className="flex min-h-full w-full items-center justify-center bg-adam-background-1 px-6 py-6 sm:px-8 sm:py-8">
-      <div className="w-full max-w-3xl">
-        <header className="mb-6 flex flex-col gap-1">
-          <h1 className="text-2xl font-semibold tracking-tight text-adam-neutral-50">
+    <div className="flex min-h-full w-full items-center justify-center bg-adam-background-1 px-6 py-10 sm:px-10 sm:py-12">
+      <div className="w-full max-w-5xl">
+        <header className="mb-10 flex flex-col gap-1">
+          <h1 className="text-3xl font-semibold tracking-tight text-adam-neutral-50">
             Settings
           </h1>
           <p className="text-sm text-adam-neutral-200">
@@ -173,376 +173,385 @@ export default function SettingsView() {
           </p>
         </header>
 
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-5">
           {/* Account */}
-          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-5">
-            <div className="mb-4 flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-adam-neutral-800">
-                <User className="h-4 w-4 text-adam-neutral-50" />
+          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
+            <div className="grid gap-6 md:grid-cols-[220px_1fr] md:gap-12">
+              <div className="flex items-start gap-3 md:flex-col md:gap-4">
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-adam-neutral-800">
+                  <User className="h-4 w-4 text-adam-neutral-50" />
+                </div>
+                <div>
+                  <h2 className="text-base font-medium text-adam-neutral-50">
+                    Account
+                  </h2>
+                  <p className="mt-1 text-xs leading-relaxed text-adam-neutral-200">
+                    Your profile and login details
+                  </p>
+                </div>
               </div>
-              <div>
-                <h2 className="text-base font-medium text-adam-neutral-50">
-                  Account
-                </h2>
-                <p className="text-xs text-adam-neutral-200">
-                  Your profile and login details
-                </p>
-              </div>
-            </div>
 
-            <div className="divide-y divide-adam-neutral-800">
-              <div className="flex items-center justify-between gap-4 py-3 first:pt-0">
-                <div className="flex min-w-0 flex-1 items-center gap-4">
-                  <AvatarUpdateDialog />
-                  <div className="min-w-0 flex-1">
-                    <div className="mb-1 text-xs uppercase tracking-wide text-adam-neutral-300">
-                      Name
-                    </div>
-                    {editingName ? (
-                      <Input
-                        ref={nameInputRef}
-                        value={newName}
-                        className="h-9 w-full max-w-xs"
-                        onChange={(e) => setNewName(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' && !e.shiftKey) {
-                            e.preventDefault();
-                            handleUpdateName();
-                          }
-                        }}
-                      />
-                    ) : (
-                      <div className="truncate text-sm font-medium text-adam-neutral-50">
-                        {profile?.full_name || user?.email}
+              <div className="divide-y divide-adam-neutral-800">
+                <div className="flex items-center justify-between gap-4 pb-5 first:pt-0">
+                  <div className="flex min-w-0 flex-1 items-center gap-4">
+                    <AvatarUpdateDialog />
+                    <div className="min-w-0 flex-1">
+                      <div className="mb-1 text-xs uppercase tracking-wide text-adam-neutral-300">
+                        Name
                       </div>
-                    )}
+                      {editingName ? (
+                        <Input
+                          ref={nameInputRef}
+                          value={newName}
+                          className="h-9 w-full max-w-xs"
+                          onChange={(e) => setNewName(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' && !e.shiftKey) {
+                              e.preventDefault();
+                              handleUpdateName();
+                            }
+                          }}
+                        />
+                      ) : (
+                        <div className="truncate text-sm font-medium text-adam-neutral-50">
+                          {profile?.full_name || user?.email}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                  {editingName ? (
+                    <div className="flex flex-shrink-0 items-center gap-2">
+                      <Button
+                        onClick={() => handleUpdateName()}
+                        variant="light"
+                        disabled={isUpdateLoading}
+                        className="rounded-full font-light"
+                      >
+                        {isUpdateLoading ? (
+                          <div className="flex items-center gap-2">
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            Saving...
+                          </div>
+                        ) : (
+                          'Save'
+                        )}
+                      </Button>
+                      <Button
+                        onClick={() => {
+                          setEditingName(false);
+                          setNewName(profile?.full_name || '');
+                        }}
+                        variant="dark"
+                        className="rounded-full font-light"
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button
+                      onClick={() => setEditingName(true)}
+                      variant="dark"
+                      className="flex-shrink-0 rounded-full font-light"
+                    >
+                      Edit
+                    </Button>
+                  )}
+                </div>
+
+                <div className="flex items-center justify-between gap-4 py-5">
+                  <div className="min-w-0">
+                    <div className="mb-1 text-xs uppercase tracking-wide text-adam-neutral-300">
+                      Email
+                    </div>
+                    <div className="truncate text-sm font-medium text-adam-neutral-50">
+                      {user?.email}
+                    </div>
                   </div>
                 </div>
-                {editingName ? (
-                  <div className="flex flex-shrink-0 items-center gap-2">
-                    <Button
-                      onClick={() => handleUpdateName()}
-                      variant="light"
-                      disabled={isUpdateLoading}
-                      className="rounded-full font-light"
-                    >
-                      {isUpdateLoading ? (
-                        <div className="flex items-center gap-2">
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                          Saving...
-                        </div>
-                      ) : (
-                        'Save'
-                      )}
-                    </Button>
-                    <Button
-                      onClick={() => {
-                        setEditingName(false);
-                        setNewName(profile?.full_name || '');
-                      }}
-                      variant="dark"
-                      className="rounded-full font-light"
-                    >
-                      Cancel
-                    </Button>
+
+                <div className="flex items-center justify-between gap-4 pt-5 last:pb-0">
+                  <div>
+                    <div className="text-sm font-medium text-adam-neutral-50">
+                      Password
+                    </div>
+                    <div className="mt-1 text-xs text-adam-neutral-200">
+                      Send a reset link to your email
+                    </div>
                   </div>
-                ) : (
                   <Button
-                    onClick={() => setEditingName(true)}
+                    onClick={() => handleResetPassword()}
+                    disabled={isResetLoading}
                     variant="dark"
                     className="flex-shrink-0 rounded-full font-light"
                   >
-                    Edit
+                    {isResetLoading ? (
+                      <div className="flex items-center gap-2">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Loading...
+                      </div>
+                    ) : (
+                      'Reset Password'
+                    )}
                   </Button>
-                )}
-              </div>
-
-              <div className="flex items-center justify-between gap-4 py-3">
-                <div className="min-w-0">
-                  <div className="mb-1 text-xs uppercase tracking-wide text-adam-neutral-300">
-                    Email
-                  </div>
-                  <div className="truncate text-sm font-medium text-adam-neutral-50">
-                    {user?.email}
-                  </div>
                 </div>
-              </div>
-
-              <div className="flex items-center justify-between gap-4 py-3 last:pb-0">
-                <div>
-                  <div className="text-sm font-medium text-adam-neutral-50">
-                    Password
-                  </div>
-                  <div className="mt-1 text-xs text-adam-neutral-200">
-                    Send a reset link to your email
-                  </div>
-                </div>
-                <Button
-                  onClick={() => handleResetPassword()}
-                  disabled={isResetLoading}
-                  variant="dark"
-                  className="flex-shrink-0 rounded-full font-light"
-                >
-                  {isResetLoading ? (
-                    <div className="flex items-center gap-2">
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                      Loading...
-                    </div>
-                  ) : (
-                    'Reset Password'
-                  )}
-                </Button>
               </div>
             </div>
           </section>
 
           {/* Notifications */}
-          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-5">
-            <div className="mb-4 flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-adam-neutral-800">
-                <Bell className="h-4 w-4 text-adam-neutral-50" />
+          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
+            <div className="grid gap-6 md:grid-cols-[220px_1fr] md:gap-12">
+              <div className="flex items-start gap-3 md:flex-col md:gap-4">
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-adam-neutral-800">
+                  <Bell className="h-4 w-4 text-adam-neutral-50" />
+                </div>
+                <div>
+                  <h2 className="text-base font-medium text-adam-neutral-50">
+                    Notifications
+                  </h2>
+                  <p className="mt-1 text-xs leading-relaxed text-adam-neutral-200">
+                    Choose what Adam can ping you about
+                  </p>
+                </div>
               </div>
-              <div>
-                <h2 className="text-base font-medium text-adam-neutral-50">
-                  Notifications
-                </h2>
-                <p className="text-xs text-adam-neutral-200">
-                  Choose what Adam can ping you about
-                </p>
-              </div>
-            </div>
 
-            <div className="flex items-center justify-between gap-4">
-              <div className="flex-1">
-                <div className="text-sm font-medium text-adam-neutral-50">
-                  Responses
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex-1">
+                  <div className="text-sm font-medium text-adam-neutral-50">
+                    Responses
+                  </div>
+                  <div className="mt-1 text-xs text-adam-neutral-200">
+                    Get notified when Adam finishes a long-running request, like
+                    a highest quality mesh generation.
+                  </div>
                 </div>
-                <div className="mt-1 text-xs text-adam-neutral-200">
-                  Get notified when Adam finishes a long-running request, like a
-                  highest quality mesh generation.
-                </div>
+                <Switch
+                  checked={profile?.notifications_enabled ?? false}
+                  onCheckedChange={handleUpdateNotifications}
+                />
               </div>
-              <Switch
-                checked={profile?.notifications_enabled ?? false}
-                onCheckedChange={handleUpdateNotifications}
-              />
             </div>
           </section>
 
           {/* Billing */}
-          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-5">
-            <div className="mb-4 flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-adam-neutral-800">
-                <CreditCard className="h-4 w-4 text-adam-neutral-50" />
-              </div>
-              <div>
-                <h2 className="text-base font-medium text-adam-neutral-50">
-                  Billing
-                </h2>
-                <p className="text-xs text-adam-neutral-200">
-                  Your plan and token usage
-                </p>
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-4">
-              {/* Plan card */}
-              <div className="rounded-xl border border-adam-neutral-800 bg-adam-background-1 p-4">
-                <div className="mb-4 flex items-start justify-between gap-4">
-                  <div className="flex items-center gap-2">
-                    <span
-                      className={cn(
-                        'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium',
-                        tierAccent,
-                      )}
-                    >
-                      {subscription === 'pro' && (
-                        <Sparkles className="h-3 w-3" />
-                      )}
-                      {tierLabel}
-                    </span>
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <Info className="h-4 w-4 text-adam-neutral-300 transition-colors hover:text-adam-neutral-50" />
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>{subscriptionTokenLimit} tokens per period</p>
-                        {tokenCosts.map((tc) => (
-                          <p key={tc.operation}>
-                            {tc.operation}: {tc.cost} tokens
-                          </p>
-                        ))}
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-
-                  {subscription !== 'free' ? (
-                    <Button
-                      onClick={() => handleManageSubscription()}
-                      className="flex-shrink-0 rounded-full font-light"
-                      variant="dark"
-                      disabled={isManageLoading}
-                    >
-                      {isManageLoading ? (
-                        <div className="flex items-center gap-2">
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                          Loading...
-                        </div>
-                      ) : (
-                        'Manage'
-                      )}
-                    </Button>
-                  ) : (
-                    <Link to="/subscription" className="flex-shrink-0">
-                      <Button
-                        className="rounded-full font-light"
-                        variant="light"
-                      >
-                        Upgrade
-                      </Button>
-                    </Link>
-                  )}
+          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
+            <div className="grid gap-6 md:grid-cols-[220px_1fr] md:gap-12">
+              <div className="flex items-start gap-3 md:flex-col md:gap-4">
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-adam-neutral-800">
+                  <CreditCard className="h-4 w-4 text-adam-neutral-50" />
                 </div>
+                <div>
+                  <h2 className="text-base font-medium text-adam-neutral-50">
+                    Billing
+                  </h2>
+                  <p className="mt-1 text-xs leading-relaxed text-adam-neutral-200">
+                    Your plan and token usage
+                  </p>
+                </div>
+              </div>
 
-                <div className="flex flex-col gap-3">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-adam-neutral-200">
-                      Subscription tokens
-                    </span>
-                    <span className="text-xs font-medium tabular-nums text-adam-neutral-50">
-                      {subscriptionTokens.toLocaleString()} /{' '}
-                      {subscriptionTokenLimit.toLocaleString()}
-                    </span>
+              <div className="flex flex-col gap-5">
+                {/* Plan card */}
+                <div className="rounded-xl border border-adam-neutral-800 bg-adam-background-1 p-5">
+                  <div className="mb-4 flex items-start justify-between gap-4">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={cn(
+                          'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium',
+                          tierAccent,
+                        )}
+                      >
+                        {subscription === 'pro' && (
+                          <Sparkles className="h-3 w-3" />
+                        )}
+                        {tierLabel}
+                      </span>
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <Info className="h-4 w-4 text-adam-neutral-300 transition-colors hover:text-adam-neutral-50" />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>{subscriptionTokenLimit} tokens per period</p>
+                          {tokenCosts.map((tc) => (
+                            <p key={tc.operation}>
+                              {tc.operation}: {tc.cost} tokens
+                            </p>
+                          ))}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+
+                    {subscription !== 'free' ? (
+                      <Button
+                        onClick={() => handleManageSubscription()}
+                        className="flex-shrink-0 rounded-full font-light"
+                        variant="dark"
+                        disabled={isManageLoading}
+                      >
+                        {isManageLoading ? (
+                          <div className="flex items-center gap-2">
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            Loading...
+                          </div>
+                        ) : (
+                          'Manage'
+                        )}
+                      </Button>
+                    ) : (
+                      <Link to="/subscription" className="flex-shrink-0">
+                        <Button
+                          className="rounded-full font-light"
+                          variant="light"
+                        >
+                          Upgrade
+                        </Button>
+                      </Link>
+                    )}
                   </div>
-                  <Progress
-                    indicatorClassName={cn(
-                      usagePercent < 70
-                        ? 'bg-lime-500'
-                        : usagePercent < 90
-                          ? 'bg-amber-500'
-                          : 'bg-[#FB2C2C]',
-                    )}
-                    className={cn(
-                      'h-2',
-                      usagePercent < 70
-                        ? 'bg-lime-950'
-                        : usagePercent < 90
-                          ? 'bg-amber-950'
-                          : 'bg-[#3a1818]',
-                    )}
-                    max={subscriptionTokenLimit}
-                    value={subscriptionUsed}
-                  />
 
-                  {purchasedTokens > 0 && (
-                    <div className="flex items-center justify-between pt-1">
+                  <div className="flex flex-col gap-3">
+                    <div className="flex items-center justify-between">
                       <span className="text-xs text-adam-neutral-200">
-                        Purchased tokens
+                        Subscription tokens
                       </span>
                       <span className="text-xs font-medium tabular-nums text-adam-neutral-50">
-                        {purchasedTokens.toLocaleString()}
+                        {subscriptionTokens.toLocaleString()} /{' '}
+                        {subscriptionTokenLimit.toLocaleString()}
                       </span>
                     </div>
-                  )}
+                    <Progress
+                      indicatorClassName={cn(
+                        usagePercent < 70
+                          ? 'bg-lime-500'
+                          : usagePercent < 90
+                            ? 'bg-amber-500'
+                            : 'bg-[#FB2C2C]',
+                      )}
+                      className={cn(
+                        'h-2',
+                        usagePercent < 70
+                          ? 'bg-lime-950'
+                          : usagePercent < 90
+                            ? 'bg-amber-950'
+                            : 'bg-[#3a1818]',
+                      )}
+                      max={subscriptionTokenLimit}
+                      value={subscriptionUsed}
+                    />
 
-                  <div className="flex items-center justify-between border-t border-adam-neutral-800 pt-3">
-                    <span className="text-sm font-medium text-adam-neutral-50">
-                      Total available
-                    </span>
-                    <span className="text-sm font-semibold tabular-nums text-adam-neutral-50">
-                      {totalTokens.toLocaleString()}
-                    </span>
+                    {purchasedTokens > 0 && (
+                      <div className="flex items-center justify-between pt-1">
+                        <span className="text-xs text-adam-neutral-200">
+                          Purchased tokens
+                        </span>
+                        <span className="text-xs font-medium tabular-nums text-adam-neutral-50">
+                          {purchasedTokens.toLocaleString()}
+                        </span>
+                      </div>
+                    )}
+
+                    <div className="flex items-center justify-between border-t border-adam-neutral-800 pt-3">
+                      <span className="text-sm font-medium text-adam-neutral-50">
+                        Total available
+                      </span>
+                      <span className="text-sm font-semibold tabular-nums text-adam-neutral-50">
+                        {totalTokens.toLocaleString()}
+                      </span>
+                    </div>
                   </div>
                 </div>
+
+                {/* Buy Tokens */}
+                {tokenPacks.length > 0 && (
+                  <div className="flex flex-col gap-3">
+                    <div className="flex items-baseline justify-between">
+                      <div className="text-sm font-medium text-adam-neutral-50">
+                        Buy Tokens
+                      </div>
+                      <div className="text-xs text-adam-neutral-200">
+                        Never expire
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                      {tokenPacks.map((pack) => {
+                        const isThisPending =
+                          isPurchaseLoading &&
+                          purchaseVariables?.lookupKey ===
+                            pack.stripe_lookup_key;
+                        return (
+                          <button
+                            key={pack.id}
+                            type="button"
+                            disabled={isPurchaseLoading}
+                            onClick={() =>
+                              purchaseTokenPack({
+                                lookupKey: pack.stripe_lookup_key,
+                              })
+                            }
+                            className={cn(
+                              'group relative flex flex-col items-start gap-1 rounded-xl border border-adam-neutral-800 bg-adam-background-1 p-4 text-left transition-all',
+                              'hover:border-adam-blue/50 hover:bg-adam-neutral-800/50',
+                              'disabled:cursor-not-allowed disabled:opacity-50',
+                            )}
+                          >
+                            {isThisPending && (
+                              <Loader2 className="absolute right-3 top-3 h-4 w-4 animate-spin text-adam-neutral-200" />
+                            )}
+                            <div className="text-base font-semibold tabular-nums text-adam-neutral-50">
+                              {pack.token_amount.toLocaleString()}
+                            </div>
+                            <div className="text-xs text-adam-neutral-200">
+                              tokens
+                            </div>
+                            <div className="mt-2 text-sm font-medium tabular-nums text-adam-blue">
+                              ${(pack.price_cents / 100).toFixed(2)}
+                            </div>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
               </div>
-
-              {/* Buy Tokens */}
-              {tokenPacks.length > 0 && (
-                <div className="flex flex-col gap-3">
-                  <div className="flex items-baseline justify-between">
-                    <div className="text-sm font-medium text-adam-neutral-50">
-                      Buy Tokens
-                    </div>
-                    <div className="text-xs text-adam-neutral-200">
-                      Never expire
-                    </div>
-                  </div>
-                  <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-                    {tokenPacks.map((pack) => {
-                      const isThisPending =
-                        isPurchaseLoading &&
-                        purchaseVariables?.lookupKey === pack.stripe_lookup_key;
-                      return (
-                        <button
-                          key={pack.id}
-                          type="button"
-                          disabled={isPurchaseLoading}
-                          onClick={() =>
-                            purchaseTokenPack({
-                              lookupKey: pack.stripe_lookup_key,
-                            })
-                          }
-                          className={cn(
-                            'group relative flex flex-col items-start gap-1 rounded-xl border border-adam-neutral-800 bg-adam-background-1 p-4 text-left transition-all',
-                            'hover:border-adam-blue/50 hover:bg-adam-neutral-800/50',
-                            'disabled:cursor-not-allowed disabled:opacity-50',
-                          )}
-                        >
-                          {isThisPending && (
-                            <Loader2 className="absolute right-3 top-3 h-4 w-4 animate-spin text-adam-neutral-200" />
-                          )}
-                          <div className="text-base font-semibold tabular-nums text-adam-neutral-50">
-                            {pack.token_amount.toLocaleString()}
-                          </div>
-                          <div className="text-xs text-adam-neutral-200">
-                            tokens
-                          </div>
-                          <div className="mt-2 text-sm font-medium tabular-nums text-adam-blue">
-                            ${(pack.price_cents / 100).toFixed(2)}
-                          </div>
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
             </div>
           </section>
 
           {/* Data & Privacy */}
-          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-5">
-            <div className="mb-4 flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-adam-neutral-800">
-                <ShieldAlert className="h-4 w-4 text-adam-neutral-50" />
+          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
+            <div className="grid gap-6 md:grid-cols-[220px_1fr] md:gap-12">
+              <div className="flex items-start gap-3 md:flex-col md:gap-4">
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-adam-neutral-800">
+                  <ShieldAlert className="h-4 w-4 text-adam-neutral-50" />
+                </div>
+                <div>
+                  <h2 className="text-base font-medium text-adam-neutral-50">
+                    Data and Privacy
+                  </h2>
+                  <p className="mt-1 text-xs leading-relaxed text-adam-neutral-200">
+                    Control your data on Adam
+                  </p>
+                </div>
               </div>
-              <div>
-                <h2 className="text-base font-medium text-adam-neutral-50">
-                  Data and Privacy
-                </h2>
-                <p className="text-xs text-adam-neutral-200">
-                  Control your data on Adam
-                </p>
-              </div>
-            </div>
 
-            <div className="flex items-center justify-between gap-4 rounded-xl border border-red-900/30 bg-red-950/10 p-4">
-              <div className="flex-1">
-                <div className="text-sm font-medium text-adam-neutral-50">
-                  Delete Account
+              <div className="flex items-center justify-between gap-4 rounded-xl border border-red-900/30 bg-red-950/10 p-4">
+                <div className="flex-1">
+                  <div className="text-sm font-medium text-adam-neutral-50">
+                    Delete Account
+                  </div>
+                  <div className="mt-1 text-xs text-adam-neutral-200">
+                    Permanently delete your account and all associated data from
+                    Adam.
+                  </div>
                 </div>
-                <div className="mt-1 text-xs text-adam-neutral-200">
-                  Permanently delete your account and all associated data from
-                  Adam.
-                </div>
+                <DeleteAccountDialog>
+                  <Button
+                    className="flex-shrink-0 rounded-full font-light"
+                    variant="destructive"
+                  >
+                    Delete
+                  </Button>
+                </DeleteAccountDialog>
               </div>
-              <DeleteAccountDialog>
-                <Button
-                  className="flex-shrink-0 rounded-full font-light"
-                  variant="destructive"
-                >
-                  Delete
-                </Button>
-              </DeleteAccountDialog>
             </div>
           </section>
 

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -162,10 +162,10 @@ export default function SettingsView() {
         : 'bg-gradient-to-r from-adam-blue/20 to-fuchsia-500/20 text-adam-neutral-50';
 
   return (
-    <div className="flex h-full w-full flex-col overflow-y-auto bg-adam-background-1">
-      <div className="mx-auto w-full max-w-3xl px-6 py-12 sm:px-8 sm:py-16">
-        <header className="mb-10 flex flex-col gap-2">
-          <h1 className="text-3xl font-semibold tracking-tight text-adam-neutral-50">
+    <div className="min-h-full w-full bg-adam-background-1 px-6 py-6 sm:px-8 sm:py-8">
+      <div className="mx-auto w-full max-w-3xl">
+        <header className="mb-6 flex flex-col gap-1">
+          <h1 className="text-2xl font-semibold tracking-tight text-adam-neutral-50">
             Settings
           </h1>
           <p className="text-sm text-adam-neutral-200">
@@ -173,10 +173,10 @@ export default function SettingsView() {
           </p>
         </header>
 
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4">
           {/* Account */}
-          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
-            <div className="mb-6 flex items-center gap-3">
+          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-5">
+            <div className="mb-4 flex items-center gap-3">
               <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-adam-neutral-800">
                 <User className="h-4 w-4 text-adam-neutral-50" />
               </div>
@@ -191,7 +191,7 @@ export default function SettingsView() {
             </div>
 
             <div className="divide-y divide-adam-neutral-800">
-              <div className="flex items-center justify-between gap-4 py-5 first:pt-0">
+              <div className="flex items-center justify-between gap-4 py-3 first:pt-0">
                 <div className="flex min-w-0 flex-1 items-center gap-4">
                   <AvatarUpdateDialog />
                   <div className="min-w-0 flex-1">
@@ -257,7 +257,7 @@ export default function SettingsView() {
                 )}
               </div>
 
-              <div className="flex items-center justify-between gap-4 py-5">
+              <div className="flex items-center justify-between gap-4 py-3">
                 <div className="min-w-0">
                   <div className="mb-1 text-xs uppercase tracking-wide text-adam-neutral-300">
                     Email
@@ -268,7 +268,7 @@ export default function SettingsView() {
                 </div>
               </div>
 
-              <div className="flex items-center justify-between gap-4 py-5 last:pb-0">
+              <div className="flex items-center justify-between gap-4 py-3 last:pb-0">
                 <div>
                   <div className="text-sm font-medium text-adam-neutral-50">
                     Password
@@ -297,8 +297,8 @@ export default function SettingsView() {
           </section>
 
           {/* Notifications */}
-          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
-            <div className="mb-6 flex items-center gap-3">
+          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-5">
+            <div className="mb-4 flex items-center gap-3">
               <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-adam-neutral-800">
                 <Bell className="h-4 w-4 text-adam-neutral-50" />
               </div>
@@ -330,8 +330,8 @@ export default function SettingsView() {
           </section>
 
           {/* Billing */}
-          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
-            <div className="mb-6 flex items-center gap-3">
+          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-5">
+            <div className="mb-4 flex items-center gap-3">
               <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-adam-neutral-800">
                 <CreditCard className="h-4 w-4 text-adam-neutral-50" />
               </div>
@@ -345,9 +345,9 @@ export default function SettingsView() {
               </div>
             </div>
 
-            <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-4">
               {/* Plan card */}
-              <div className="rounded-xl border border-adam-neutral-800 bg-adam-background-1 p-5">
+              <div className="rounded-xl border border-adam-neutral-800 bg-adam-background-1 p-4">
                 <div className="mb-4 flex items-start justify-between gap-4">
                   <div className="flex items-center gap-2">
                     <span
@@ -510,8 +510,8 @@ export default function SettingsView() {
           </section>
 
           {/* Data & Privacy */}
-          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
-            <div className="mb-6 flex items-center gap-3">
+          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-5">
+            <div className="mb-4 flex items-center gap-3">
               <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-adam-neutral-800">
                 <ShieldAlert className="h-4 w-4 text-adam-neutral-50" />
               </div>

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -1,6 +1,14 @@
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';
-import { Loader2, Info } from 'lucide-react';
+import {
+  Loader2,
+  Info,
+  User,
+  Bell,
+  CreditCard,
+  ShieldAlert,
+  Sparkles,
+} from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useManageSubscription } from '@/services/subscriptionService';
 import { useTokenPackPurchase } from '@/services/subscriptionService';
@@ -137,48 +145,84 @@ export default function SettingsView() {
       },
     });
 
-  return (
-    <div className="flex h-full w-full flex-col overflow-y-auto bg-adam-background-1 p-8">
-      <div className="mx-auto flex max-w-4xl flex-col gap-12">
-        <h1 className="text-2xl font-medium text-adam-neutral-50">Settings</h1>
+  const tierLabel =
+    subscription === 'free'
+      ? 'Adam Free'
+      : subscription === 'standard'
+        ? 'Adam Standard'
+        : 'Adam Pro';
 
-        <div className="flex flex-col gap-24">
-          <div className="grid grid-cols-3 items-center gap-4 sm:grid-cols-4">
-            <div className="h-full w-full">
-              <h2 className="text-lg font-medium text-adam-neutral-50">
-                Account
-              </h2>
+  const tierAccent =
+    subscription === 'free'
+      ? 'bg-adam-neutral-700 text-adam-neutral-50'
+      : subscription === 'standard'
+        ? 'bg-adam-blue/15 text-adam-blue'
+        : 'bg-gradient-to-r from-adam-blue/20 to-fuchsia-500/20 text-adam-neutral-10';
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-y-auto bg-adam-background-1">
+      <div className="mx-auto w-full max-w-3xl px-6 py-12 sm:px-8 sm:py-16">
+        <header className="mb-10 flex flex-col gap-2">
+          <h1 className="text-3xl font-semibold tracking-tight text-adam-neutral-50">
+            Settings
+          </h1>
+          <p className="text-sm text-adam-neutral-200">
+            Manage your account, billing, and preferences.
+          </p>
+        </header>
+
+        <div className="flex flex-col gap-6">
+          {/* Account */}
+          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
+            <div className="mb-6 flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-adam-neutral-800">
+                <User className="h-4 w-4 text-adam-neutral-50" />
+              </div>
+              <div>
+                <h2 className="text-base font-medium text-adam-neutral-50">
+                  Account
+                </h2>
+                <p className="text-xs text-adam-neutral-200">
+                  Your profile and login details
+                </p>
+              </div>
             </div>
-            <div className="col-span-3 flex w-full flex-col gap-8 text-adam-neutral-50">
-              <div className="col-span-3 grid grid-cols-3 items-center gap-4">
-                <div className="col-span-2 flex items-center gap-4 text-adam-neutral-50">
+
+            <div className="divide-y divide-adam-neutral-800">
+              <div className="flex items-center justify-between gap-4 py-5 first:pt-0">
+                <div className="flex min-w-0 flex-1 items-center gap-4">
                   <AvatarUpdateDialog />
-                  {editingName ? (
-                    <Input
-                      ref={nameInputRef}
-                      value={newName}
-                      className="h-9 w-full"
-                      onChange={(e) => setNewName(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && !e.shiftKey) {
-                          e.preventDefault();
-                          handleUpdateName();
-                        }
-                      }}
-                    />
-                  ) : (
-                    <div className="text-sm font-medium">
-                      {profile?.full_name || user?.email}
+                  <div className="min-w-0 flex-1">
+                    <div className="mb-1 text-xs uppercase tracking-wide text-adam-neutral-300">
+                      Name
                     </div>
-                  )}
+                    {editingName ? (
+                      <Input
+                        ref={nameInputRef}
+                        value={newName}
+                        className="h-9 w-full max-w-xs"
+                        onChange={(e) => setNewName(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && !e.shiftKey) {
+                            e.preventDefault();
+                            handleUpdateName();
+                          }
+                        }}
+                      />
+                    ) : (
+                      <div className="truncate text-sm font-medium text-adam-neutral-50">
+                        {profile?.full_name || user?.email}
+                      </div>
+                    )}
+                  </div>
                 </div>
                 {editingName ? (
-                  <div className="flex items-center justify-end gap-2">
+                  <div className="flex flex-shrink-0 items-center gap-2">
                     <Button
                       onClick={() => handleUpdateName()}
                       variant="light"
                       disabled={isUpdateLoading}
-                      className="justify-self-end rounded-full font-light"
+                      className="rounded-full font-light"
                     >
                       {isUpdateLoading ? (
                         <div className="flex items-center gap-2">
@@ -195,7 +239,7 @@ export default function SettingsView() {
                         setNewName(profile?.full_name || '');
                       }}
                       variant="dark"
-                      className="justify-self-end rounded-full font-light"
+                      className="rounded-full font-light"
                     >
                       Cancel
                     </Button>
@@ -204,30 +248,38 @@ export default function SettingsView() {
                   <Button
                     onClick={() => setEditingName(true)}
                     variant="dark"
-                    className="justify-self-end rounded-full font-light"
+                    className="flex-shrink-0 rounded-full font-light"
                   >
                     Edit
                   </Button>
                 )}
               </div>
-              <div className="col-span-2 flex flex-col gap-2">
-                <div className="text-sm font-medium">Email</div>
-                <div className="text-xs text-adam-neutral-200">
-                  {user?.email}
+
+              <div className="flex items-center justify-between gap-4 py-5">
+                <div className="min-w-0">
+                  <div className="mb-1 text-xs uppercase tracking-wide text-adam-neutral-300">
+                    Email
+                  </div>
+                  <div className="truncate text-sm font-medium text-adam-neutral-50">
+                    {user?.email}
+                  </div>
                 </div>
               </div>
-              <div className="col-span-3 grid grid-cols-3 items-center gap-2">
-                <div className="col-span-2 flex flex-col gap-2">
-                  <div className="text-sm font-medium">Password</div>
-                  <div className="text-xs text-adam-neutral-200">
-                    Reset your password
+
+              <div className="flex items-center justify-between gap-4 py-5 last:pb-0">
+                <div>
+                  <div className="text-sm font-medium text-adam-neutral-50">
+                    Password
+                  </div>
+                  <div className="mt-1 text-xs text-adam-neutral-200">
+                    Send a reset link to your email
                   </div>
                 </div>
                 <Button
                   onClick={() => handleResetPassword()}
                   disabled={isResetLoading}
                   variant="dark"
-                  className="justify-self-end rounded-full font-light"
+                  className="flex-shrink-0 rounded-full font-light"
                 >
                   {isResetLoading ? (
                     <div className="flex items-center gap-2">
@@ -240,51 +292,76 @@ export default function SettingsView() {
                 </Button>
               </div>
             </div>
-          </div>
+          </section>
 
-          <div className="grid grid-cols-3 items-center gap-4 sm:grid-cols-4">
-            <div className="h-full w-full">
-              <h2 className="text-lg font-medium text-adam-neutral-50">
-                Notifications
-              </h2>
+          {/* Notifications */}
+          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
+            <div className="mb-6 flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-adam-neutral-800">
+                <Bell className="h-4 w-4 text-adam-neutral-50" />
+              </div>
+              <div>
+                <h2 className="text-base font-medium text-adam-neutral-50">
+                  Notifications
+                </h2>
+                <p className="text-xs text-adam-neutral-200">
+                  Choose what Adam can ping you about
+                </p>
+              </div>
             </div>
-            <div className="col-span-3 grid grid-cols-3 items-center gap-4">
-              <div className="col-span-2 flex w-full flex-col gap-2 text-adam-neutral-50">
-                <div className="text-sm font-medium">Responses</div>
-                <div className="text-xs text-adam-neutral-200">
+
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex-1">
+                <div className="text-sm font-medium text-adam-neutral-50">
+                  Responses
+                </div>
+                <div className="mt-1 text-xs text-adam-neutral-200">
                   Get notified when Adam finishes a long-running request, like a
                   highest quality mesh generation.
                 </div>
               </div>
               <Switch
-                className="justify-self-end"
                 checked={profile?.notifications_enabled}
                 onCheckedChange={handleUpdateNotifications}
               />
             </div>
-          </div>
+          </section>
 
-          <div className="grid grid-cols-3 items-center gap-4 sm:grid-cols-4">
-            <div className="h-full w-full">
-              <h2 className="text-lg font-medium text-adam-neutral-50">
-                Billing
-              </h2>
+          {/* Billing */}
+          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
+            <div className="mb-6 flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-adam-neutral-800">
+                <CreditCard className="h-4 w-4 text-adam-neutral-50" />
+              </div>
+              <div>
+                <h2 className="text-base font-medium text-adam-neutral-50">
+                  Billing
+                </h2>
+                <p className="text-xs text-adam-neutral-200">
+                  Your plan and token usage
+                </p>
+              </div>
             </div>
-            <div className="col-span-3 flex w-full flex-col gap-6">
-              {/* Subscription info */}
-              <div className="grid grid-cols-3 items-center gap-4">
-                <div className="col-span-2 flex w-full flex-col gap-2">
-                  <div className="flex items-center gap-2 text-adam-neutral-50">
-                    <p className="text-sm font-medium">
-                      {subscription === 'free'
-                        ? 'Adam Free'
-                        : subscription === 'standard'
-                          ? 'Adam Standard'
-                          : 'Adam Pro'}
-                    </p>
+
+            <div className="flex flex-col gap-6">
+              {/* Plan card */}
+              <div className="rounded-xl border border-adam-neutral-800 bg-adam-background-1 p-5">
+                <div className="mb-4 flex items-start justify-between gap-4">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium',
+                        tierAccent,
+                      )}
+                    >
+                      {subscription === 'pro' && (
+                        <Sparkles className="h-3 w-3" />
+                      )}
+                      {tierLabel}
+                    </span>
                     <Tooltip>
                       <TooltipTrigger>
-                        <Info className="h-4 w-4" />
+                        <Info className="h-4 w-4 text-adam-neutral-300 transition-colors hover:text-adam-neutral-50" />
                       </TooltipTrigger>
                       <TooltipContent>
                         <p>{subscriptionTokenLimit} tokens per period</p>
@@ -297,167 +374,193 @@ export default function SettingsView() {
                     </Tooltip>
                   </div>
 
-                  {/* Token usage bar */}
-                  <div className="flex w-full flex-col gap-2">
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs text-adam-neutral-200">
-                        Subscription tokens
-                      </span>
-                      <span className="text-xs text-adam-neutral-200">
-                        {subscriptionTokens} / {subscriptionTokenLimit}
-                      </span>
-                    </div>
-                    <Progress
-                      indicatorClassName={cn(
-                        usagePercent < 70
-                          ? 'bg-lime-500'
-                          : usagePercent < 90
-                            ? 'bg-amber-500'
-                            : 'bg-[#FB2C2C]',
+                  {subscription !== 'free' ? (
+                    <Button
+                      onClick={() => handleManageSubscription()}
+                      className="flex-shrink-0 rounded-full font-light"
+                      variant="dark"
+                      disabled={isManageLoading}
+                    >
+                      {isManageLoading ? (
+                        <div className="flex items-center gap-2">
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          Loading...
+                        </div>
+                      ) : (
+                        'Manage'
                       )}
-                      className={cn(
-                        usagePercent < 70
-                          ? 'bg-lime-800'
-                          : usagePercent < 90
-                            ? 'bg-amber-800'
-                            : 'bg-[#843535]',
-                      )}
-                      max={subscriptionTokenLimit}
-                      value={subscriptionUsed}
-                    />
-
-                    {purchasedTokens > 0 && (
-                      <div className="flex items-center justify-between">
-                        <span className="text-xs text-adam-neutral-200">
-                          Purchased tokens
-                        </span>
-                        <span className="text-xs text-adam-neutral-200">
-                          {purchasedTokens}
-                        </span>
-                      </div>
-                    )}
-
-                    <div className="flex items-center justify-between border-t border-adam-neutral-700 pt-1">
-                      <span className="text-xs font-medium text-adam-neutral-50">
-                        Total available
-                      </span>
-                      <span className="text-xs font-medium text-adam-neutral-50">
-                        {totalTokens}
-                      </span>
-                    </div>
-                  </div>
+                    </Button>
+                  ) : (
+                    <Link to="/subscription" className="flex-shrink-0">
+                      <Button
+                        className="rounded-full font-light"
+                        variant="light"
+                      >
+                        Upgrade
+                      </Button>
+                    </Link>
+                  )}
                 </div>
 
-                {subscription !== 'free' ? (
-                  <Button
-                    onClick={() => handleManageSubscription()}
-                    className="justify-self-end rounded-full font-light"
-                    variant="dark"
-                    disabled={isManageLoading}
-                  >
-                    {isManageLoading ? (
-                      <div className="flex items-center gap-2">
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        Loading...
-                      </div>
-                    ) : (
-                      'Manage'
+                <div className="flex flex-col gap-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-adam-neutral-200">
+                      Subscription tokens
+                    </span>
+                    <span className="text-xs font-medium tabular-nums text-adam-neutral-50">
+                      {subscriptionTokens.toLocaleString()} /{' '}
+                      {subscriptionTokenLimit.toLocaleString()}
+                    </span>
+                  </div>
+                  <Progress
+                    indicatorClassName={cn(
+                      usagePercent < 70
+                        ? 'bg-lime-500'
+                        : usagePercent < 90
+                          ? 'bg-amber-500'
+                          : 'bg-[#FB2C2C]',
                     )}
-                  </Button>
-                ) : (
-                  <Link to="/subscription" className="justify-self-end">
-                    <Button
-                      className="justify-self-end rounded-full font-light"
-                      variant="dark"
-                    >
-                      Upgrade
-                    </Button>
-                  </Link>
-                )}
+                    className={cn(
+                      'h-2',
+                      usagePercent < 70
+                        ? 'bg-lime-950'
+                        : usagePercent < 90
+                          ? 'bg-amber-950'
+                          : 'bg-[#3a1818]',
+                    )}
+                    max={subscriptionTokenLimit}
+                    value={subscriptionUsed}
+                  />
+
+                  {purchasedTokens > 0 && (
+                    <div className="flex items-center justify-between pt-1">
+                      <span className="text-xs text-adam-neutral-200">
+                        Purchased tokens
+                      </span>
+                      <span className="text-xs font-medium tabular-nums text-adam-neutral-50">
+                        {purchasedTokens.toLocaleString()}
+                      </span>
+                    </div>
+                  )}
+
+                  <div className="flex items-center justify-between border-t border-adam-neutral-800 pt-3">
+                    <span className="text-sm font-medium text-adam-neutral-50">
+                      Total available
+                    </span>
+                    <span className="text-sm font-semibold tabular-nums text-adam-neutral-50">
+                      {totalTokens.toLocaleString()}
+                    </span>
+                  </div>
+                </div>
               </div>
 
-              {/* Buy Tokens section */}
+              {/* Buy Tokens */}
               {tokenPacks.length > 0 && (
                 <div className="flex flex-col gap-3">
-                  <div className="text-sm font-medium text-adam-neutral-50">
-                    Buy Tokens
+                  <div className="flex items-baseline justify-between">
+                    <div className="text-sm font-medium text-adam-neutral-50">
+                      Buy Tokens
+                    </div>
+                    <div className="text-xs text-adam-neutral-200">
+                      Never expire
+                    </div>
                   </div>
-                  <div className="text-xs text-adam-neutral-200">
-                    Purchased tokens never expire.
-                  </div>
-                  <div className="flex flex-wrap gap-3">
+                  <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
                     {tokenPacks.map((pack) => {
                       const isThisPending =
                         isPurchaseLoading &&
                         purchaseVariables?.lookupKey === pack.stripe_lookup_key;
                       return (
-                        <Button
+                        <button
                           key={pack.id}
-                          variant="dark"
-                          className="rounded-full font-light"
+                          type="button"
                           disabled={isPurchaseLoading}
                           onClick={() =>
                             purchaseTokenPack({
                               lookupKey: pack.stripe_lookup_key,
                             })
                           }
+                          className={cn(
+                            'group relative flex flex-col items-start gap-1 rounded-xl border border-adam-neutral-800 bg-adam-background-1 p-4 text-left transition-all',
+                            'hover:border-adam-blue/50 hover:bg-adam-neutral-800/50',
+                            'disabled:cursor-not-allowed disabled:opacity-50',
+                          )}
                         >
                           {isThisPending && (
-                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            <Loader2 className="absolute right-3 top-3 h-4 w-4 animate-spin text-adam-neutral-200" />
                           )}
-                          {`${pack.token_amount} tokens - $${(pack.price_cents / 100).toFixed(2)}`}
-                        </Button>
+                          <div className="text-base font-semibold tabular-nums text-adam-neutral-50">
+                            {pack.token_amount.toLocaleString()}
+                          </div>
+                          <div className="text-xs text-adam-neutral-200">
+                            tokens
+                          </div>
+                          <div className="mt-2 text-sm font-medium tabular-nums text-adam-blue">
+                            ${(pack.price_cents / 100).toFixed(2)}
+                          </div>
+                        </button>
                       );
                     })}
                   </div>
                 </div>
               )}
             </div>
-          </div>
+          </section>
 
-          <div className="flex flex-col gap-8">
-            <div className="grid grid-cols-3 items-center gap-4 sm:grid-cols-4">
-              <div className="h-full w-full">
-                <h2 className="text-lg font-medium text-adam-neutral-50">
+          {/* Data & Privacy */}
+          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
+            <div className="mb-6 flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-adam-neutral-800">
+                <ShieldAlert className="h-4 w-4 text-adam-neutral-50" />
+              </div>
+              <div>
+                <h2 className="text-base font-medium text-adam-neutral-50">
                   Data and Privacy
                 </h2>
+                <p className="text-xs text-adam-neutral-200">
+                  Control your data on Adam
+                </p>
               </div>
-              <div className="col-span-3 grid grid-cols-3 items-center gap-4">
-                <div className="col-span-2 flex w-full flex-col gap-2 text-adam-neutral-50">
-                  <div className="text-sm font-medium">Delete Account</div>
-                  <div className="text-xs text-adam-neutral-200">
-                    Permanently delete your account and all associated data from
-                    Adam
-                  </div>
+            </div>
+
+            <div className="flex items-center justify-between gap-4 rounded-xl border border-red-900/30 bg-red-950/10 p-4">
+              <div className="flex-1">
+                <div className="text-sm font-medium text-adam-neutral-50">
+                  Delete Account
                 </div>
-                <DeleteAccountDialog>
-                  <Button
-                    className="justify-self-end rounded-full font-light"
-                    variant="destructive"
-                  >
-                    Delete
-                  </Button>
-                </DeleteAccountDialog>
+                <div className="mt-1 text-xs text-adam-neutral-200">
+                  Permanently delete your account and all associated data from
+                  Adam.
+                </div>
               </div>
-            </div>
-            <div className="grid grid-cols-4 items-center gap-4">
-              <div className="col-span-4 flex w-full items-center justify-center gap-2 sm:col-span-2 sm:col-start-2 sm:justify-normal">
+              <DeleteAccountDialog>
                 <Button
-                  className="rounded-full font-light"
-                  variant="dark"
-                  asChild
+                  className="flex-shrink-0 rounded-full font-light"
+                  variant="destructive"
                 >
-                  <Link to="/terms-of-service">Terms of Service</Link>
+                  Delete
                 </Button>
-                <Button
-                  className="rounded-full font-light"
-                  variant="dark"
-                  asChild
-                >
-                  <Link to="/privacy-policy">Privacy Policy</Link>
-                </Button>
-              </div>
+              </DeleteAccountDialog>
             </div>
+          </section>
+
+          {/* Legal footer */}
+          <div className="mt-2 flex items-center justify-center gap-4 text-xs text-adam-neutral-300">
+            <Link
+              to="/terms-of-service"
+              className="transition-colors hover:text-adam-neutral-50"
+            >
+              Terms of Service
+            </Link>
+            <span aria-hidden className="text-adam-neutral-700">
+              •
+            </span>
+            <Link
+              to="/privacy-policy"
+              className="transition-colors hover:text-adam-neutral-50"
+            >
+              Privacy Policy
+            </Link>
           </div>
         </div>
       </div>

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -1,14 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';
-import {
-  Loader2,
-  Info,
-  User,
-  Bell,
-  CreditCard,
-  ShieldAlert,
-  Sparkles,
-} from 'lucide-react';
+import { Loader2, Info, Sparkles } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import {
   useManageSubscription,
@@ -162,401 +154,314 @@ export default function SettingsView() {
         : 'bg-gradient-to-r from-adam-blue/20 to-fuchsia-500/20 text-adam-neutral-50';
 
   return (
-    <div className="flex min-h-full w-full items-center justify-center bg-adam-background-1 px-6 py-10 sm:px-10 sm:py-12">
-      <div className="w-full max-w-5xl">
-        <header className="mb-10 flex flex-col gap-1">
-          <h1 className="text-3xl font-semibold tracking-tight text-adam-neutral-50">
+    <div className="flex min-h-full w-full items-center justify-center bg-adam-background-1 px-6 py-10">
+      <div className="w-full max-w-xl">
+        <header className="mb-8">
+          <h1 className="text-2xl font-medium tracking-tight text-adam-neutral-50">
             Settings
           </h1>
-          <p className="text-sm text-adam-neutral-200">
+          <p className="mt-1 text-sm text-adam-neutral-200">
             Manage your account, billing, and preferences.
           </p>
         </header>
 
-        <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-4">
           {/* Account */}
-          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
-            <div className="grid gap-6 md:grid-cols-[220px_1fr] md:gap-12">
-              <div className="flex items-start gap-3 md:flex-col md:gap-4">
-                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-adam-neutral-800">
-                  <User className="h-4 w-4 text-adam-neutral-50" />
-                </div>
-                <div>
-                  <h2 className="text-base font-medium text-adam-neutral-50">
-                    Account
-                  </h2>
-                  <p className="mt-1 text-xs leading-relaxed text-adam-neutral-200">
-                    Your profile and login details
-                  </p>
-                </div>
-              </div>
+          <section className="rounded-xl border border-adam-neutral-800 bg-adam-background-2 p-6">
+            <h2 className="mb-5 text-sm font-medium text-adam-neutral-50">
+              Account
+            </h2>
 
-              <div className="divide-y divide-adam-neutral-800">
-                <div className="flex items-center justify-between gap-4 pb-5 first:pt-0">
-                  <div className="flex min-w-0 flex-1 items-center gap-4">
-                    <AvatarUpdateDialog />
-                    <div className="min-w-0 flex-1">
-                      <div className="mb-1 text-xs uppercase tracking-wide text-adam-neutral-300">
-                        Name
-                      </div>
-                      {editingName ? (
-                        <Input
-                          ref={nameInputRef}
-                          value={newName}
-                          className="h-9 w-full max-w-xs"
-                          onChange={(e) => setNewName(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter' && !e.shiftKey) {
-                              e.preventDefault();
-                              handleUpdateName();
-                            }
-                          }}
-                        />
-                      ) : (
-                        <div className="truncate text-sm font-medium text-adam-neutral-50">
-                          {profile?.full_name || user?.email}
-                        </div>
-                      )}
-                    </div>
-                  </div>
+            <div className="divide-y divide-adam-neutral-800">
+              <div className="flex items-center justify-between gap-4 pb-5">
+                <div className="flex min-w-0 flex-1 items-center gap-3">
+                  <AvatarUpdateDialog />
                   {editingName ? (
-                    <div className="flex flex-shrink-0 items-center gap-2">
-                      <Button
-                        onClick={() => handleUpdateName()}
-                        variant="light"
-                        disabled={isUpdateLoading}
-                        className="rounded-full font-light"
-                      >
-                        {isUpdateLoading ? (
-                          <div className="flex items-center gap-2">
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            Saving...
-                          </div>
-                        ) : (
-                          'Save'
-                        )}
-                      </Button>
-                      <Button
-                        onClick={() => {
-                          setEditingName(false);
-                          setNewName(profile?.full_name || '');
-                        }}
-                        variant="dark"
-                        className="rounded-full font-light"
-                      >
-                        Cancel
-                      </Button>
-                    </div>
+                    <Input
+                      ref={nameInputRef}
+                      value={newName}
+                      className="h-9 w-full max-w-xs"
+                      onChange={(e) => setNewName(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                          e.preventDefault();
+                          handleUpdateName();
+                        }
+                      }}
+                    />
                   ) : (
-                    <Button
-                      onClick={() => setEditingName(true)}
-                      variant="dark"
-                      className="flex-shrink-0 rounded-full font-light"
-                    >
-                      Edit
-                    </Button>
+                    <div className="min-w-0 truncate text-sm text-adam-neutral-50">
+                      {profile?.full_name || user?.email}
+                    </div>
                   )}
                 </div>
-
-                <div className="flex items-center justify-between gap-4 py-5">
-                  <div className="min-w-0">
-                    <div className="mb-1 text-xs uppercase tracking-wide text-adam-neutral-300">
-                      Email
-                    </div>
-                    <div className="truncate text-sm font-medium text-adam-neutral-50">
-                      {user?.email}
-                    </div>
+                {editingName ? (
+                  <div className="flex flex-shrink-0 items-center gap-2">
+                    <Button
+                      onClick={() => handleUpdateName()}
+                      variant="light"
+                      disabled={isUpdateLoading}
+                      className="rounded-full font-light"
+                    >
+                      {isUpdateLoading ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        'Save'
+                      )}
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        setEditingName(false);
+                        setNewName(profile?.full_name || '');
+                      }}
+                      variant="dark"
+                      className="rounded-full font-light"
+                    >
+                      Cancel
+                    </Button>
                   </div>
-                </div>
-
-                <div className="flex items-center justify-between gap-4 pt-5 last:pb-0">
-                  <div>
-                    <div className="text-sm font-medium text-adam-neutral-50">
-                      Password
-                    </div>
-                    <div className="mt-1 text-xs text-adam-neutral-200">
-                      Send a reset link to your email
-                    </div>
-                  </div>
+                ) : (
                   <Button
-                    onClick={() => handleResetPassword()}
-                    disabled={isResetLoading}
+                    onClick={() => setEditingName(true)}
                     variant="dark"
                     className="flex-shrink-0 rounded-full font-light"
                   >
-                    {isResetLoading ? (
-                      <div className="flex items-center gap-2">
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        Loading...
-                      </div>
-                    ) : (
-                      'Reset Password'
-                    )}
+                    Edit
                   </Button>
+                )}
+              </div>
+
+              <div className="py-5">
+                <div className="text-sm text-adam-neutral-50">Email</div>
+                <div className="mt-0.5 truncate text-xs text-adam-neutral-200">
+                  {user?.email}
                 </div>
+              </div>
+
+              <div className="flex items-center justify-between gap-4 pt-5">
+                <div className="min-w-0">
+                  <div className="text-sm text-adam-neutral-50">Password</div>
+                  <div className="mt-0.5 text-xs text-adam-neutral-200">
+                    Send a reset link to your email
+                  </div>
+                </div>
+                <Button
+                  onClick={() => handleResetPassword()}
+                  disabled={isResetLoading}
+                  variant="dark"
+                  className="flex-shrink-0 rounded-full font-light"
+                >
+                  {isResetLoading ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    'Reset Password'
+                  )}
+                </Button>
               </div>
             </div>
           </section>
 
           {/* Notifications */}
-          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
-            <div className="grid gap-6 md:grid-cols-[220px_1fr] md:gap-12">
-              <div className="flex items-start gap-3 md:flex-col md:gap-4">
-                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-adam-neutral-800">
-                  <Bell className="h-4 w-4 text-adam-neutral-50" />
-                </div>
-                <div>
-                  <h2 className="text-base font-medium text-adam-neutral-50">
-                    Notifications
-                  </h2>
-                  <p className="mt-1 text-xs leading-relaxed text-adam-neutral-200">
-                    Choose what Adam can ping you about
-                  </p>
-                </div>
-              </div>
+          <section className="rounded-xl border border-adam-neutral-800 bg-adam-background-2 p-6">
+            <h2 className="mb-5 text-sm font-medium text-adam-neutral-50">
+              Notifications
+            </h2>
 
-              <div className="flex items-center justify-between gap-4">
-                <div className="flex-1">
-                  <div className="text-sm font-medium text-adam-neutral-50">
-                    Responses
-                  </div>
-                  <div className="mt-1 text-xs text-adam-neutral-200">
-                    Get notified when Adam finishes a long-running request, like
-                    a highest quality mesh generation.
-                  </div>
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0 flex-1">
+                <div className="text-sm text-adam-neutral-50">Responses</div>
+                <div className="mt-0.5 text-xs leading-relaxed text-adam-neutral-200">
+                  Get notified when Adam finishes a long-running request.
                 </div>
-                <Switch
-                  checked={profile?.notifications_enabled ?? false}
-                  onCheckedChange={handleUpdateNotifications}
-                />
               </div>
+              <Switch
+                className="mt-0.5"
+                checked={profile?.notifications_enabled ?? false}
+                onCheckedChange={handleUpdateNotifications}
+              />
             </div>
           </section>
 
           {/* Billing */}
-          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
-            <div className="grid gap-6 md:grid-cols-[220px_1fr] md:gap-12">
-              <div className="flex items-start gap-3 md:flex-col md:gap-4">
-                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-adam-neutral-800">
-                  <CreditCard className="h-4 w-4 text-adam-neutral-50" />
-                </div>
-                <div>
-                  <h2 className="text-base font-medium text-adam-neutral-50">
-                    Billing
-                  </h2>
-                  <p className="mt-1 text-xs leading-relaxed text-adam-neutral-200">
-                    Your plan and token usage
-                  </p>
-                </div>
-              </div>
+          <section className="rounded-xl border border-adam-neutral-800 bg-adam-background-2 p-6">
+            <h2 className="mb-5 text-sm font-medium text-adam-neutral-50">
+              Billing
+            </h2>
 
-              <div className="flex flex-col gap-5">
-                {/* Plan card */}
-                <div className="rounded-xl border border-adam-neutral-800 bg-adam-background-1 p-5">
-                  <div className="mb-4 flex items-start justify-between gap-4">
-                    <div className="flex items-center gap-2">
-                      <span
-                        className={cn(
-                          'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium',
-                          tierAccent,
-                        )}
-                      >
-                        {subscription === 'pro' && (
-                          <Sparkles className="h-3 w-3" />
-                        )}
-                        {tierLabel}
-                      </span>
-                      <Tooltip>
-                        <TooltipTrigger>
-                          <Info className="h-4 w-4 text-adam-neutral-300 transition-colors hover:text-adam-neutral-50" />
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>{subscriptionTokenLimit} tokens per period</p>
-                          {tokenCosts.map((tc) => (
-                            <p key={tc.operation}>
-                              {tc.operation}: {tc.cost} tokens
-                            </p>
-                          ))}
-                        </TooltipContent>
-                      </Tooltip>
-                    </div>
+            <div className="flex flex-col gap-5">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium',
+                      tierAccent,
+                    )}
+                  >
+                    {subscription === 'pro' && <Sparkles className="h-3 w-3" />}
+                    {tierLabel}
+                  </span>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <Info className="h-4 w-4 text-adam-neutral-300 transition-colors hover:text-adam-neutral-50" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>{subscriptionTokenLimit} tokens per period</p>
+                      {tokenCosts.map((tc) => (
+                        <p key={tc.operation}>
+                          {tc.operation}: {tc.cost} tokens
+                        </p>
+                      ))}
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
 
-                    {subscription !== 'free' ? (
-                      <Button
-                        onClick={() => handleManageSubscription()}
-                        className="flex-shrink-0 rounded-full font-light"
-                        variant="dark"
-                        disabled={isManageLoading}
-                      >
-                        {isManageLoading ? (
-                          <div className="flex items-center gap-2">
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                            Loading...
-                          </div>
-                        ) : (
-                          'Manage'
-                        )}
-                      </Button>
+                {subscription !== 'free' ? (
+                  <Button
+                    onClick={() => handleManageSubscription()}
+                    className="flex-shrink-0 rounded-full font-light"
+                    variant="dark"
+                    disabled={isManageLoading}
+                  >
+                    {isManageLoading ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
                     ) : (
-                      <Link to="/subscription" className="flex-shrink-0">
-                        <Button
-                          className="rounded-full font-light"
-                          variant="light"
-                        >
-                          Upgrade
-                        </Button>
-                      </Link>
+                      'Manage'
                     )}
-                  </div>
-
-                  <div className="flex flex-col gap-3">
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs text-adam-neutral-200">
-                        Subscription tokens
-                      </span>
-                      <span className="text-xs font-medium tabular-nums text-adam-neutral-50">
-                        {subscriptionTokens.toLocaleString()} /{' '}
-                        {subscriptionTokenLimit.toLocaleString()}
-                      </span>
-                    </div>
-                    <Progress
-                      indicatorClassName={cn(
-                        usagePercent < 70
-                          ? 'bg-lime-500'
-                          : usagePercent < 90
-                            ? 'bg-amber-500'
-                            : 'bg-[#FB2C2C]',
-                      )}
-                      className={cn(
-                        'h-2',
-                        usagePercent < 70
-                          ? 'bg-lime-950'
-                          : usagePercent < 90
-                            ? 'bg-amber-950'
-                            : 'bg-[#3a1818]',
-                      )}
-                      max={subscriptionTokenLimit}
-                      value={subscriptionUsed}
-                    />
-
-                    {purchasedTokens > 0 && (
-                      <div className="flex items-center justify-between pt-1">
-                        <span className="text-xs text-adam-neutral-200">
-                          Purchased tokens
-                        </span>
-                        <span className="text-xs font-medium tabular-nums text-adam-neutral-50">
-                          {purchasedTokens.toLocaleString()}
-                        </span>
-                      </div>
-                    )}
-
-                    <div className="flex items-center justify-between border-t border-adam-neutral-800 pt-3">
-                      <span className="text-sm font-medium text-adam-neutral-50">
-                        Total available
-                      </span>
-                      <span className="text-sm font-semibold tabular-nums text-adam-neutral-50">
-                        {totalTokens.toLocaleString()}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Buy Tokens */}
-                {tokenPacks.length > 0 && (
-                  <div className="flex flex-col gap-3">
-                    <div className="flex items-baseline justify-between">
-                      <div className="text-sm font-medium text-adam-neutral-50">
-                        Buy Tokens
-                      </div>
-                      <div className="text-xs text-adam-neutral-200">
-                        Never expire
-                      </div>
-                    </div>
-                    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-                      {tokenPacks.map((pack) => {
-                        const isThisPending =
-                          isPurchaseLoading &&
-                          purchaseVariables?.lookupKey ===
-                            pack.stripe_lookup_key;
-                        return (
-                          <button
-                            key={pack.id}
-                            type="button"
-                            disabled={isPurchaseLoading}
-                            onClick={() =>
-                              purchaseTokenPack({
-                                lookupKey: pack.stripe_lookup_key,
-                              })
-                            }
-                            className={cn(
-                              'group relative flex flex-col items-start gap-1 rounded-xl border border-adam-neutral-800 bg-adam-background-1 p-4 text-left transition-all',
-                              'hover:border-adam-blue/50 hover:bg-adam-neutral-800/50',
-                              'disabled:cursor-not-allowed disabled:opacity-50',
-                            )}
-                          >
-                            {isThisPending && (
-                              <Loader2 className="absolute right-3 top-3 h-4 w-4 animate-spin text-adam-neutral-200" />
-                            )}
-                            <div className="text-base font-semibold tabular-nums text-adam-neutral-50">
-                              {pack.token_amount.toLocaleString()}
-                            </div>
-                            <div className="text-xs text-adam-neutral-200">
-                              tokens
-                            </div>
-                            <div className="mt-2 text-sm font-medium tabular-nums text-adam-blue">
-                              ${(pack.price_cents / 100).toFixed(2)}
-                            </div>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
+                  </Button>
+                ) : (
+                  <Link to="/subscription" className="flex-shrink-0">
+                    <Button className="rounded-full font-light" variant="light">
+                      Upgrade
+                    </Button>
+                  </Link>
                 )}
               </div>
+
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-adam-neutral-200">
+                    Subscription tokens
+                  </span>
+                  <span className="text-xs tabular-nums text-adam-neutral-50">
+                    {subscriptionTokens.toLocaleString()} /{' '}
+                    {subscriptionTokenLimit.toLocaleString()}
+                  </span>
+                </div>
+                <Progress
+                  indicatorClassName={cn(
+                    usagePercent < 70
+                      ? 'bg-lime-500'
+                      : usagePercent < 90
+                        ? 'bg-amber-500'
+                        : 'bg-[#FB2C2C]',
+                  )}
+                  className={cn(
+                    'h-1.5',
+                    usagePercent < 70
+                      ? 'bg-lime-950'
+                      : usagePercent < 90
+                        ? 'bg-amber-950'
+                        : 'bg-[#3a1818]',
+                  )}
+                  max={subscriptionTokenLimit}
+                  value={subscriptionUsed}
+                />
+                {purchasedTokens > 0 && (
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-adam-neutral-200">
+                      Purchased tokens
+                    </span>
+                    <span className="text-xs tabular-nums text-adam-neutral-50">
+                      {purchasedTokens.toLocaleString()}
+                    </span>
+                  </div>
+                )}
+                <div className="mt-1 flex items-center justify-between border-t border-adam-neutral-800 pt-3">
+                  <span className="text-sm text-adam-neutral-50">
+                    Total available
+                  </span>
+                  <span className="text-sm font-medium tabular-nums text-adam-neutral-50">
+                    {totalTokens.toLocaleString()}
+                  </span>
+                </div>
+              </div>
+
+              {tokenPacks.length > 0 && (
+                <div className="flex flex-col gap-2 border-t border-adam-neutral-800 pt-5">
+                  <div className="flex items-baseline justify-between">
+                    <div className="text-sm text-adam-neutral-50">
+                      Buy more tokens
+                    </div>
+                    <div className="text-xs text-adam-neutral-200">
+                      Never expire
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-3 gap-2">
+                    {tokenPacks.map((pack) => {
+                      const isThisPending =
+                        isPurchaseLoading &&
+                        purchaseVariables?.lookupKey === pack.stripe_lookup_key;
+                      return (
+                        <button
+                          key={pack.id}
+                          type="button"
+                          disabled={isPurchaseLoading}
+                          onClick={() =>
+                            purchaseTokenPack({
+                              lookupKey: pack.stripe_lookup_key,
+                            })
+                          }
+                          className={cn(
+                            'relative flex flex-col items-start rounded-lg border border-adam-neutral-800 bg-adam-background-1 px-3 py-2.5 text-left transition-colors',
+                            'hover:border-adam-blue/40 hover:bg-adam-neutral-800/40',
+                            'disabled:cursor-not-allowed disabled:opacity-50',
+                          )}
+                        >
+                          {isThisPending && (
+                            <Loader2 className="absolute right-2 top-2 h-3.5 w-3.5 animate-spin text-adam-neutral-200" />
+                          )}
+                          <div className="text-sm font-medium tabular-nums text-adam-neutral-50">
+                            {pack.token_amount.toLocaleString()}
+                          </div>
+                          <div className="mt-0.5 text-xs tabular-nums text-adam-neutral-200">
+                            ${(pack.price_cents / 100).toFixed(2)}
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
             </div>
           </section>
 
           {/* Data & Privacy */}
-          <section className="rounded-2xl border border-adam-neutral-800 bg-adam-background-2 p-6 sm:p-8">
-            <div className="grid gap-6 md:grid-cols-[220px_1fr] md:gap-12">
-              <div className="flex items-start gap-3 md:flex-col md:gap-4">
-                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-adam-neutral-800">
-                  <ShieldAlert className="h-4 w-4 text-adam-neutral-50" />
-                </div>
-                <div>
-                  <h2 className="text-base font-medium text-adam-neutral-50">
-                    Data and Privacy
-                  </h2>
-                  <p className="mt-1 text-xs leading-relaxed text-adam-neutral-200">
-                    Control your data on Adam
-                  </p>
-                </div>
-              </div>
+          <section className="rounded-xl border border-adam-neutral-800 bg-adam-background-2 p-6">
+            <h2 className="mb-5 text-sm font-medium text-adam-neutral-50">
+              Data and privacy
+            </h2>
 
-              <div className="flex items-center justify-between gap-4 rounded-xl border border-red-900/30 bg-red-950/10 p-4">
-                <div className="flex-1">
-                  <div className="text-sm font-medium text-adam-neutral-50">
-                    Delete Account
-                  </div>
-                  <div className="mt-1 text-xs text-adam-neutral-200">
-                    Permanently delete your account and all associated data from
-                    Adam.
-                  </div>
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0 flex-1">
+                <div className="text-sm text-adam-neutral-50">
+                  Delete account
                 </div>
-                <DeleteAccountDialog>
-                  <Button
-                    className="flex-shrink-0 rounded-full font-light"
-                    variant="destructive"
-                  >
-                    Delete
-                  </Button>
-                </DeleteAccountDialog>
+                <div className="mt-0.5 text-xs leading-relaxed text-adam-neutral-200">
+                  Permanently delete your account and all associated data.
+                </div>
               </div>
+              <DeleteAccountDialog>
+                <Button
+                  className="flex-shrink-0 rounded-full font-light"
+                  variant="destructive"
+                >
+                  Delete
+                </Button>
+              </DeleteAccountDialog>
             </div>
           </section>
 
-          {/* Legal footer */}
-          <div className="mt-2 flex items-center justify-center gap-4 text-xs text-adam-neutral-300">
+          <div className="mt-2 flex items-center justify-center gap-3 text-xs text-adam-neutral-300">
             <Link
               to="/terms-of-service"
               className="transition-colors hover:text-adam-neutral-50"

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -396,7 +396,7 @@ export default function SettingsView() {
                       Never expire
                     </div>
                   </div>
-                  <div className="grid grid-cols-3 gap-2">
+                  <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
                     {tokenPacks.map((pack) => {
                       const isThisPending =
                         isPurchaseLoading &&

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -10,8 +10,10 @@ import {
   Sparkles,
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { useManageSubscription } from '@/services/subscriptionService';
-import { useTokenPackPurchase } from '@/services/subscriptionService';
+import {
+  useManageSubscription,
+  useTokenPackPurchase,
+} from '@/services/subscriptionService';
 import {
   Tooltip,
   TooltipContent,
@@ -321,7 +323,7 @@ export default function SettingsView() {
                 </div>
               </div>
               <Switch
-                checked={profile?.notifications_enabled}
+                checked={profile?.notifications_enabled ?? false}
                 onCheckedChange={handleUpdateNotifications}
               />
             </div>

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -159,7 +159,7 @@ export default function SettingsView() {
       ? 'bg-adam-neutral-700 text-adam-neutral-50'
       : subscription === 'standard'
         ? 'bg-adam-blue/15 text-adam-blue'
-        : 'bg-gradient-to-r from-adam-blue/20 to-fuchsia-500/20 text-adam-neutral-10';
+        : 'bg-gradient-to-r from-adam-blue/20 to-fuchsia-500/20 text-adam-neutral-50';
 
   return (
     <div className="flex h-full w-full flex-col overflow-y-auto bg-adam-background-1">

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -162,8 +162,8 @@ export default function SettingsView() {
         : 'bg-gradient-to-r from-adam-blue/20 to-fuchsia-500/20 text-adam-neutral-50';
 
   return (
-    <div className="min-h-full w-full bg-adam-background-1 px-6 py-6 sm:px-8 sm:py-8">
-      <div className="mx-auto w-full max-w-3xl">
+    <div className="flex min-h-full w-full items-center justify-center bg-adam-background-1 px-6 py-6 sm:px-8 sm:py-8">
+      <div className="w-full max-w-3xl">
         <header className="mb-6 flex flex-col gap-1">
           <h1 className="text-2xl font-semibold tracking-tight text-adam-neutral-50">
             Settings


### PR DESCRIPTION
## Summary

- Replaces the flat 3-col grid with iconified card sections for **Account**, **Notifications**, **Billing**, and **Data & Privacy**.
- Page gains a subtitle, colored tier badge (with `Sparkles` for Pro), a cleaner token usage block, and tile-style token pack selectors that hover to `adam-blue`.
- Delete Account sits in a tinted danger-zone row; legal links move to a centered footer.

## Scope

Presentation-only — all hooks, state, handlers, and Supabase/Stripe flows are unchanged. `tsc --noEmit` passes clean.

## Test plan

- [ ] Load `/settings` as a Free user — verify the tier badge is gray and the "Upgrade" CTA links to `/subscription`
- [ ] As a Standard/Pro user — verify the badge color (and Sparkles on Pro), and that **Manage** opens the Stripe billing portal
- [ ] Edit name → Save / Cancel / Enter-to-submit all work
- [ ] Toggle response notifications → toast appears, value persists on reload
- [ ] Reset password → email toast appears
- [ ] Buy a token pack → Stripe checkout opens; purchased tokens row appears when `purchasedTokens > 0`
- [ ] Usage bar turns amber ≥70% and red ≥90%
- [ ] Delete Account dialog opens from the danger-zone button
- [ ] Terms of Service and Privacy Policy footer links navigate correctly
- [ ] Mobile width (<640px) — cards reflow and token pack grid drops to 2 columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Settings page to a narrow, centered card layout with simpler typography for better readability. UI-only; all handlers and subscription flows are unchanged.

- **New Features**
  - Centered layout at `max-w-xl` with a `text-2xl` H1 and quiet `text-sm` section headers.
  - Card sections for Account, Notifications, Billing, and Data & privacy; cleaner row layout; legal links in a centered footer.
  - Colored tier badge with `Sparkles` on Pro and a tooltip for limits/costs; redesigned usage bar with amber/red thresholds and a total; compact token pack tiles with inline spinners, responsive to 2 columns on mobile (3 from `sm:` up).

- **Refactors**
  - Merged `subscriptionService` imports and defaulted the notifications `Switch` to `false` while the profile loads.
  - Removed nested scroll, tightened spacing, and vertically centered the content; aligned Pro badge text to `text-adam-neutral-50`.

<sup>Written for commit 430afbcb55986a79374406f3c3b93b8ff28d8b01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

