### PR TITLE
fix(tokens): stop showing 0 balance in the free-tier reset window

### DIFF
--- a/supabase/migrations/20260419120000_fix_free_tier_token_reset.sql
+++ b/supabase/migrations/20260419120000_fix_free_tier_token_reset.sql
@@ -30,7 +30,7 @@ BEGIN
     -- legitimate caller's outer flow (user_extradata, deduct_tokens) continues
     -- on its own fallback path rather than erroring to the client.
     v_caller := auth.uid();
-    IF auth.role() <> 'service_role' AND v_caller IS DISTINCT FROM p_user_id THEN
+    IF auth.role() IS DISTINCT FROM 'service_role' AND v_caller IS DISTINCT FROM p_user_id THEN
         RETURN;
     END IF;
 

--- a/supabase/migrations/20260419120000_fix_free_tier_token_reset.sql
+++ b/supabase/migrations/20260419120000_fix_free_tier_token_reset.sql
@@ -1,0 +1,228 @@
+-- Fix free-tier daily token reset.
+--
+-- Bug 1: reset_free_tier_tokens() set expires_at = now() + 1 day. Because pg_cron
+--        fires with small execution jitter, each day's stored expires_at crept
+--        slightly ahead of the next cron's now(), and the gate
+--        "expires_at < now()" made the cron skip its own prior resets.
+--
+-- Bug 2: user_extradata() and deduct_tokens() zero the displayed balance the
+--        instant expires_at < now(). So any window between expiry and the next
+--        (possibly skipped) cron caused users to see "You've used all your tokens"
+--        with their real balance still sitting unchanged in the DB.
+--
+-- Fix: add a just-in-time reset on every read/deduct. The cron stays as a
+-- backstop and is rewritten to pin expires_at to the next UTC day boundary so
+-- it no longer drifts or skips.
+
+CREATE OR REPLACE FUNCTION "public"."ensure_free_tier_fresh"("p_user_id" uuid)
+RETURNS void
+LANGUAGE "plpgsql"
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_is_free boolean;
+    v_caller uuid;
+BEGIN
+    -- Allow service role (no auth context) or the user acting on themselves.
+    -- Prevents an authenticated client from poking other users' balances via rpc.
+    v_caller := auth.uid();
+    IF v_caller IS NOT NULL AND v_caller <> p_user_id THEN
+        RETURN;
+    END IF;
+
+    SELECT NOT EXISTS (
+        SELECT 1 FROM public.subscriptions
+        WHERE user_id = p_user_id
+        AND status IN ('active', 'trialing')
+    ) INTO v_is_free;
+
+    IF NOT v_is_free THEN
+        RETURN;
+    END IF;
+
+    INSERT INTO public.token_balances (user_id, source, balance, expires_at, updated_at)
+    VALUES (
+        p_user_id,
+        'subscription',
+        50,
+        date_trunc('day', now()) + interval '1 day',
+        now()
+    )
+    ON CONFLICT (user_id, source) DO UPDATE
+    SET balance = 50,
+        expires_at = date_trunc('day', now()) + interval '1 day',
+        updated_at = now()
+    WHERE token_balances.expires_at IS NULL
+       OR token_balances.expires_at <= now();
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."deduct_tokens"(
+    "p_user_id" uuid,
+    "p_operation" "public"."token_operation_type",
+    "p_reference_id" text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE "plpgsql"
+AS $$
+DECLARE
+    v_cost integer;
+    v_sub_balance integer;
+    v_pur_balance integer;
+    v_sub_expires timestamptz;
+    v_remaining integer;
+    v_sub_deduct integer;
+    v_pur_deduct integer;
+BEGIN
+    SELECT cost INTO v_cost FROM public.token_costs WHERE operation = p_operation;
+    IF v_cost IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'error', 'unknown_operation');
+    END IF;
+
+    PERFORM public.ensure_free_tier_fresh(p_user_id);
+
+    SELECT balance, expires_at INTO v_sub_balance, v_sub_expires
+    FROM public.token_balances
+    WHERE user_id = p_user_id AND source = 'subscription'
+    FOR UPDATE;
+
+    IF v_sub_expires IS NOT NULL AND v_sub_expires < now() THEN
+        v_sub_balance := 0;
+    END IF;
+
+    SELECT balance INTO v_pur_balance
+    FROM public.token_balances
+    WHERE user_id = p_user_id AND source = 'purchased'
+    FOR UPDATE;
+
+    v_sub_balance := COALESCE(v_sub_balance, 0);
+    v_pur_balance := COALESCE(v_pur_balance, 0);
+
+    IF (v_sub_balance + v_pur_balance) < v_cost THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'insufficient_tokens',
+            'tokensRequired', v_cost,
+            'tokensAvailable', v_sub_balance + v_pur_balance
+        );
+    END IF;
+
+    v_sub_deduct := LEAST(v_cost, v_sub_balance);
+    v_pur_deduct := v_cost - v_sub_deduct;
+
+    IF v_sub_deduct > 0 THEN
+        UPDATE public.token_balances
+        SET balance = balance - v_sub_deduct, updated_at = now()
+        WHERE user_id = p_user_id AND source = 'subscription';
+    END IF;
+
+    IF v_pur_deduct > 0 THEN
+        UPDATE public.token_balances
+        SET balance = balance - v_pur_deduct, updated_at = now()
+        WHERE user_id = p_user_id AND source = 'purchased';
+    END IF;
+
+    INSERT INTO public.token_transactions (
+        user_id, operation, amount, source, reference_id,
+        subscription_balance_after, purchased_balance_after
+    ) VALUES (
+        p_user_id, p_operation, -v_cost,
+        CASE WHEN v_sub_deduct > 0 THEN 'subscription'::public.token_source_type ELSE 'purchased'::public.token_source_type END,
+        p_reference_id,
+        v_sub_balance - v_sub_deduct,
+        v_pur_balance - v_pur_deduct
+    );
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'tokensDeducted', v_cost,
+        'subscriptionBalance', v_sub_balance - v_sub_deduct,
+        'purchasedBalance', v_pur_balance - v_pur_deduct,
+        'totalBalance', (v_sub_balance - v_sub_deduct) + (v_pur_balance - v_pur_deduct)
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."reset_free_tier_tokens"()
+RETURNS void
+LANGUAGE "plpgsql"
+AS $$
+BEGIN
+    UPDATE public.token_balances tb
+    SET balance = 50,
+        expires_at = date_trunc('day', now()) + interval '1 day',
+        updated_at = now()
+    WHERE tb.source = 'subscription'
+    AND NOT EXISTS (
+        SELECT 1 FROM public.subscriptions s
+        WHERE s.user_id = tb.user_id
+        AND s.status IN ('active', 'trialing')
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION "public"."user_extradata"("user_id_input" "uuid")
+RETURNS "public"."user_data"
+LANGUAGE "plpgsql"
+AS $$
+DECLARE
+    hasTrialed boolean;
+    userlevel public.subscriptions.level%TYPE;
+    userstatus public.subscriptions.status%TYPE;
+    v_sub_balance integer;
+    v_pur_balance integer;
+    v_sub_expires timestamptz;
+    v_sub_limit integer;
+    ret user_data;
+BEGIN
+    PERFORM public.ensure_free_tier_fresh(user_id_input);
+
+    SELECT (
+        (SELECT count(*) FROM public.trial_users WHERE user_id = user_id_input) > 0
+    ) INTO hasTrialed;
+
+    SELECT STATUS, LEVEL INTO userstatus, userlevel
+    FROM public.subscriptions
+    WHERE user_id = user_id_input;
+
+    SELECT balance, expires_at INTO v_sub_balance, v_sub_expires
+    FROM public.token_balances
+    WHERE user_id = user_id_input AND source = 'subscription';
+
+    SELECT balance INTO v_pur_balance
+    FROM public.token_balances
+    WHERE user_id = user_id_input AND source = 'purchased';
+
+    v_sub_balance := COALESCE(v_sub_balance, 0);
+    v_pur_balance := COALESCE(v_pur_balance, 0);
+
+    IF v_sub_expires IS NOT NULL AND v_sub_expires < now() THEN
+        v_sub_balance := 0;
+    END IF;
+
+    ret."hasTrialed" = hasTrialed;
+
+    IF (userstatus = 'active') THEN
+        ret."sublevel" = userlevel;
+    ELSIF (userstatus = 'trialing') THEN
+        ret."sublevel" = 'pro';
+    ELSE
+        ret."sublevel" = 'free';
+    END IF;
+
+    v_sub_limit := public.get_subscription_token_limit(user_id_input);
+
+    ret."subscriptionTokens" = v_sub_balance;
+    ret."purchasedTokens" = v_pur_balance;
+    ret."totalTokens" = v_sub_balance + v_pur_balance;
+    ret."subscriptionTokenLimit" = v_sub_limit;
+    ret."subscriptionExpiresAt" = v_sub_expires;
+
+    RETURN ret;
+
+EXCEPTION
+    WHEN others THEN
+        RAISE EXCEPTION 'An error occurred in function user_extradata(): %', SQLERRM;
+END;
+$$;

--- a/supabase/migrations/20260419120000_fix_free_tier_token_reset.sql
+++ b/supabase/migrations/20260419120000_fix_free_tier_token_reset.sql
@@ -24,10 +24,13 @@ DECLARE
     v_is_free boolean;
     v_caller uuid;
 BEGIN
-    -- Allow service role (no auth context) or the user acting on themselves.
-    -- Prevents an authenticated client from poking other users' balances via rpc.
+    -- Only allow service role (server-side edge functions) or the user acting
+    -- on themselves. auth.role() = 'anon' with uid = NULL would otherwise slip
+    -- past a uid-only check. Silent return, not an exception, so that a
+    -- legitimate caller's outer flow (user_extradata, deduct_tokens) continues
+    -- on its own fallback path rather than erroring to the client.
     v_caller := auth.uid();
-    IF v_caller IS NOT NULL AND v_caller <> p_user_id THEN
+    IF auth.role() <> 'service_role' AND v_caller IS DISTINCT FROM p_user_id THEN
         RETURN;
     END IF;
 
@@ -87,6 +90,11 @@ BEGIN
     WHERE user_id = p_user_id AND source = 'subscription'
     FOR UPDATE;
 
+    -- Expired subscription tokens count as 0. For free-tier users this is
+    -- unreachable after ensure_free_tier_fresh (expires_at is always future).
+    -- It is load-bearing for paid users whose billing-cycle sub has lapsed,
+    -- and for the edge case where ensure_free_tier_fresh silently bailed
+    -- (auth-mismatch). Don't remove without preserving both cases.
     IF v_sub_expires IS NOT NULL AND v_sub_expires < now() THEN
         v_sub_balance := 0;
     END IF;
@@ -158,7 +166,11 @@ BEGIN
         SELECT 1 FROM public.subscriptions s
         WHERE s.user_id = tb.user_id
         AND s.status IN ('active', 'trialing')
-    );
+    )
+    -- Idempotency guard: don't re-credit users whose period is still live.
+    -- With expires_at pinned to the day boundary, the scheduled midnight run
+    -- satisfies `<=` exactly; manual or retried mid-day runs are safely no-ops.
+    AND (tb.expires_at IS NULL OR tb.expires_at <= now());
 END;
 $$;
 
@@ -197,6 +209,9 @@ BEGIN
     v_sub_balance := COALESCE(v_sub_balance, 0);
     v_pur_balance := COALESCE(v_pur_balance, 0);
 
+    -- See matching comment in deduct_tokens: this branch is load-bearing for
+    -- paid users whose billing-cycle sub has lapsed and as a fallback if
+    -- ensure_free_tier_fresh silently bailed. Do not remove.
     IF v_sub_expires IS NOT NULL AND v_sub_expires < now() THEN
         v_sub_balance := 0;
     END IF;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -23,6 +23,52 @@ BEGIN
     RETURN 50;
 END;
 $$;
+-- Just-in-time daily reset for free-tier users.
+-- Safe to call on every read/deduct: only touches the row when it's expired or missing.
+-- Decouples correctness from the cron firing on time — the cron is now a backstop.
+CREATE OR REPLACE FUNCTION "public"."ensure_free_tier_fresh"("p_user_id" uuid)
+RETURNS void
+LANGUAGE "plpgsql"
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_is_free boolean;
+    v_caller uuid;
+BEGIN
+    -- Allow service role (no auth context) or the user acting on themselves.
+    -- Prevents an authenticated client from poking other users' balances via rpc.
+    v_caller := auth.uid();
+    IF v_caller IS NOT NULL AND v_caller <> p_user_id THEN
+        RETURN;
+    END IF;
+
+    SELECT NOT EXISTS (
+        SELECT 1 FROM public.subscriptions
+        WHERE user_id = p_user_id
+        AND status IN ('active', 'trialing')
+    ) INTO v_is_free;
+
+    IF NOT v_is_free THEN
+        RETURN;
+    END IF;
+
+    INSERT INTO public.token_balances (user_id, source, balance, expires_at, updated_at)
+    VALUES (
+        p_user_id,
+        'subscription',
+        50,
+        date_trunc('day', now()) + interval '1 day',
+        now()
+    )
+    ON CONFLICT (user_id, source) DO UPDATE
+    SET balance = 50,
+        expires_at = date_trunc('day', now()) + interval '1 day',
+        updated_at = now()
+    WHERE token_balances.expires_at IS NULL
+       OR token_balances.expires_at <= now();
+END;
+$$;
 
 -- Atomic token deduction
 CREATE OR REPLACE FUNCTION "public"."deduct_tokens"(
@@ -47,6 +93,8 @@ BEGIN
     IF v_cost IS NULL THEN
         RETURN jsonb_build_object('success', false, 'error', 'unknown_operation');
     END IF;
+
+    PERFORM public.ensure_free_tier_fresh(p_user_id);
 
     -- Lock and read subscription balance
     SELECT balance, expires_at INTO v_sub_balance, v_sub_expires
@@ -279,7 +327,11 @@ BEGIN
 END;
 $$;
 
--- Daily cron function to reset free-tier users
+-- Daily cron backstop for free-tier users.
+-- The JIT reset in ensure_free_tier_fresh is the primary mechanism; this cron
+-- keeps rows fresh for users who don't check in on a given day. We pin
+-- expires_at to the next UTC day boundary to avoid the drift that used to
+-- cause the cron to skip its own prior resets.
 CREATE OR REPLACE FUNCTION "public"."reset_free_tier_tokens"()
 RETURNS void
 LANGUAGE "plpgsql"
@@ -287,22 +339,21 @@ AS $$
 BEGIN
     UPDATE public.token_balances tb
     SET balance = 50,
-        expires_at = now() + interval '1 day',
+        expires_at = date_trunc('day', now()) + interval '1 day',
         updated_at = now()
     WHERE tb.source = 'subscription'
     AND NOT EXISTS (
         SELECT 1 FROM public.subscriptions s
         WHERE s.user_id = tb.user_id
         AND s.status IN ('active', 'trialing')
-    )
-    AND (tb.expires_at IS NULL OR tb.expires_at < now());
+    );
 END;
 $$;
 
 -- User extra data function (returns token balances)
 CREATE OR REPLACE FUNCTION "public"."user_extradata"("user_id_input" "uuid")
 RETURNS "public"."user_data"
-LANGUAGE "plpgsql" STABLE
+LANGUAGE "plpgsql"
 AS $$
 DECLARE
     hasTrialed boolean;
@@ -314,6 +365,8 @@ DECLARE
     v_sub_limit integer;
     ret user_data;
 BEGIN
+    PERFORM public.ensure_free_tier_fresh(user_id_input);
+
     -- Get trial status
     SELECT (
         (SELECT count(*) FROM public.trial_users WHERE user_id = user_id_input) > 0

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -42,7 +42,7 @@ BEGIN
     -- legitimate caller's outer flow (user_extradata, deduct_tokens) continues
     -- on its own fallback path rather than erroring to the client.
     v_caller := auth.uid();
-    IF auth.role() <> 'service_role' AND v_caller IS DISTINCT FROM p_user_id THEN
+    IF auth.role() IS DISTINCT FROM 'service_role' AND v_caller IS DISTINCT FROM p_user_id THEN
         RETURN;
     END IF;
 

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -36,10 +36,13 @@ DECLARE
     v_is_free boolean;
     v_caller uuid;
 BEGIN
-    -- Allow service role (no auth context) or the user acting on themselves.
-    -- Prevents an authenticated client from poking other users' balances via rpc.
+    -- Only allow service role (server-side edge functions) or the user acting
+    -- on themselves. auth.role() = 'anon' with uid = NULL would otherwise slip
+    -- past a uid-only check. Silent return, not an exception, so that a
+    -- legitimate caller's outer flow (user_extradata, deduct_tokens) continues
+    -- on its own fallback path rather than erroring to the client.
     v_caller := auth.uid();
-    IF v_caller IS NOT NULL AND v_caller <> p_user_id THEN
+    IF auth.role() <> 'service_role' AND v_caller IS DISTINCT FROM p_user_id THEN
         RETURN;
     END IF;
 
@@ -102,7 +105,11 @@ BEGIN
     WHERE user_id = p_user_id AND source = 'subscription'
     FOR UPDATE;
 
-    -- If subscription tokens have expired, treat as 0
+    -- Expired subscription tokens count as 0. For free-tier users this is
+    -- unreachable after ensure_free_tier_fresh (expires_at is always future).
+    -- It is load-bearing for paid users whose billing-cycle sub has lapsed,
+    -- and for the edge case where ensure_free_tier_fresh silently bailed
+    -- (auth-mismatch). Don't remove without preserving both cases.
     IF v_sub_expires IS NOT NULL AND v_sub_expires < now() THEN
         v_sub_balance := 0;
     END IF;
@@ -346,7 +353,11 @@ BEGIN
         SELECT 1 FROM public.subscriptions s
         WHERE s.user_id = tb.user_id
         AND s.status IN ('active', 'trialing')
-    );
+    )
+    -- Idempotency guard: don't re-credit users whose period is still live.
+    -- With expires_at pinned to the day boundary, the scheduled midnight run
+    -- satisfies `<=` exactly; manual or retried mid-day runs are safely no-ops.
+    AND (tb.expires_at IS NULL OR tb.expires_at <= now());
 END;
 $$;
 
@@ -389,7 +400,9 @@ BEGIN
     v_sub_balance := COALESCE(v_sub_balance, 0);
     v_pur_balance := COALESCE(v_pur_balance, 0);
 
-    -- If subscription tokens have expired, treat as 0
+    -- See matching comment in deduct_tokens: this branch is load-bearing for
+    -- paid users whose billing-cycle sub has lapsed and as a fallback if
+    -- ensure_free_tier_fresh silently bailed. Do not remove.
     IF v_sub_expires IS NOT NULL AND v_sub_expires < now() THEN
         v_sub_balance := 0;
     END IF;


### PR DESCRIPTION
## Summary

A user reported seeing "You've used all your tokens. Start a trial..." when they had ~40 free-tier tokens the day before. Not a dark pattern — two compounding bugs in the daily reset logic:

1. **Reset cron drifted forward every day.** `reset_free_tier_tokens` set `expires_at = now() + 1 day`, which crept ahead of the next cron's fire time. The gate `expires_at < now()` then skipped its own prior resets.
2. **`user_extradata` and `deduct_tokens` zeroed the displayed balance the moment `expires_at < now()`.** Any window between expiry and the (possibly skipped) cron reset showed 0 — even though the row still had 40 tokens.

## Fix

- New `ensure_free_tier_fresh(user_id)` helper — `SECURITY DEFINER`, idempotent. Upserts the free-tier subscription row to 50 tokens with a next-UTC-midnight expiry, but only when the row is missing or expired. Includes an `auth.uid()` guard so clients can't `rpc` a reset on arbitrary user IDs.
- `user_extradata` and `deduct_tokens` call the helper first, so correctness no longer depends on the cron firing on time. Dropped `STABLE` from `user_extradata` since it now writes through the helper.
- `reset_free_tier_tokens` cron: pinned `expires_at` to `date_trunc('day', now()) + 1 day` (no more drift) and dropped the `expires_at < now()` gate (it's now a backstop behind the JIT reset).

## Test plan

- [ ] Apply the migration against a staging branch of the DB
- [ ] Manually reproduce: set a free user's `token_balances.expires_at` to 1 minute ago with `balance=40`. Call `user_extradata` → expect `subscriptionTokens = 50`, not 0
- [ ] Verify paid user (`status='active'`, `balance=5000`) is untouched by the helper
- [ ] Verify the cron still runs clean on next UTC midnight
- [ ] Known not-fixed: UTC-only day boundary. A user in UTC-8 still sees the day flip at 4pm local. Needs a `users.timezone` column to fix properly — flagged for follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops showing 0 tokens for free‑tier users during the daily reset window by adding a just‑in‑time reset and fixing cron drift. Also restores cron idempotency and tightens the auth guard.

- **Bug Fixes**
  - Added `ensure_free_tier_fresh(user_id)` (`SECURITY DEFINER`, idempotent) to upsert free‑tier rows to 50 tokens with a next‑UTC‑midnight expiry; uses a null‑safe `auth.role()` check (`IS DISTINCT FROM`) and allows only `service_role` or matching `auth.uid()` (otherwise no‑op).
  - `user_extradata` and `deduct_tokens` now call the helper before reads/deductions (removed `STABLE` from `user_extradata`); kept the expired‑subscription zeroing branch for lapsed paid users and auth‑mismatch fallback.
  - Updated `reset_free_tier_tokens` to pin `expires_at` to next UTC midnight and restored the `expires_at <= now()` guard so retries are safe; it now acts as a backstop. Paid users are untouched.

<sup>Written for commit bdc8a86df41500013daf7a1e47d86ab119987b52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

