### PR TITLE
feat(credits): home-page credits pill with hover breakdown + upgrade modal

### DIFF
--- a/src/components/CreditsButton.tsx
+++ b/src/components/CreditsButton.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useRef, useState } from 'react';
+import { Zap } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import { Button } from '@/components/ui/button';
+import { UpgradeModal } from '@/components/UpgradeModal';
+import { useAuth } from '@/contexts/AuthContext';
+import { cn } from '@/lib/utils';
+
+function formatCompact(n: number): string {
+  if (n >= 1_000_000) {
+    const v = n / 1_000_000;
+    return `${v >= 10 ? v.toFixed(0) : v.toFixed(1)}M`;
+  }
+  if (n >= 1_000) {
+    const v = n / 1_000;
+    return `${v >= 100 ? v.toFixed(0) : v.toFixed(1)}K`;
+  }
+  return n.toLocaleString();
+}
+
+function formatFull(n: number): string {
+  return n.toLocaleString();
+}
+
+export function CreditsButton() {
+  const {
+    user,
+    subscription,
+    totalTokens,
+    purchasedTokens,
+    subscriptionTokens,
+    subscriptionTokenLimit,
+  } = useAuth();
+
+  const [open, setOpen] = useState(false);
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
+  const openTimer = useRef<number | null>(null);
+  const closeTimer = useRef<number | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Close when clicking outside while open (pinned-by-click behavior)
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [open]);
+
+  if (!user) return null;
+
+  const isFree = subscription === 'free';
+  const periodLabel = isFree ? '/ day' : '/ mo';
+  const limitLabel = `${formatFull(subscriptionTokenLimit)} credits ${periodLabel}`;
+
+  const handleEnter = () => {
+    if (closeTimer.current) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    if (open) return;
+    // slight hover-intent delay so brushing past the pill doesn't pop the card
+    if (openTimer.current) window.clearTimeout(openTimer.current);
+    openTimer.current = window.setTimeout(() => setOpen(true), 300);
+  };
+
+  const handleLeave = () => {
+    if (openTimer.current) {
+      window.clearTimeout(openTimer.current);
+      openTimer.current = null;
+    }
+    // small delay so moving between pill and card doesn't flicker the card closed
+    closeTimer.current = window.setTimeout(() => setOpen(false), 120);
+  };
+
+  return (
+    <>
+      <UpgradeModal open={upgradeOpen} onOpenChange={setUpgradeOpen} />
+      <div
+        ref={wrapperRef}
+        className="relative"
+        onMouseEnter={handleEnter}
+        onMouseLeave={handleLeave}
+      >
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          aria-label="View credits"
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-full',
+            'bg-adam-neutral-950 px-3 py-1.5 text-sm font-medium',
+            'text-adam-neutral-10 shadow-sm',
+            'border border-white/5',
+            'transition-colors',
+            '[@media(hover:hover)]:hover:bg-adam-neutral-900',
+          )}
+        >
+          <Zap className="h-3.5 w-3.5" fill="currentColor" />
+          <span>{formatCompact(totalTokens)}</span>
+        </button>
+
+        {open && (
+          <div
+            className={cn(
+              'absolute right-0 top-full z-50 mt-2 w-[320px]',
+              'rounded-md border border-adam-neutral-800 bg-adam-bg-secondary-dark text-adam-neutral-10 shadow-lg',
+              'animate-in fade-in-0 zoom-in-95',
+            )}
+            onMouseEnter={handleEnter}
+            onMouseLeave={handleLeave}
+          >
+            {/* Header */}
+            <div className="flex items-start justify-between gap-3 px-4 pb-3 pt-4">
+              <div className="text-base font-semibold leading-tight">
+                {limitLabel}
+              </div>
+              <Button
+                size="sm"
+                onClick={() => {
+                  setOpen(false);
+                  setUpgradeOpen(true);
+                }}
+                className="h-8 rounded-full bg-adam-neutral-10 px-4 text-xs font-medium text-adam-bg-dark [@media(hover:hover)]:hover:bg-white [@media(hover:hover)]:hover:text-adam-bg-dark"
+              >
+                Upgrade
+              </Button>
+            </div>
+
+            <div className="h-px bg-adam-neutral-800" />
+
+            {/* Credits breakdown */}
+            <div className="px-4 py-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Zap
+                    className="h-4 w-4 text-adam-neutral-10"
+                    fill="currentColor"
+                  />
+                  <span className="text-sm font-medium">Credits</span>
+                </div>
+                <span className="text-sm font-semibold tabular-nums">
+                  {formatFull(totalTokens)}
+                </span>
+              </div>
+
+              <div className="mt-2 space-y-1 pl-6 text-xs text-adam-neutral-400">
+                <div className="flex items-center justify-between">
+                  <span>Add-on credits</span>
+                  <span className="tabular-nums">
+                    {formatFull(purchasedTokens)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>{isFree ? 'Daily credits' : 'Monthly credits'}</span>
+                  <span className="tabular-nums">
+                    {formatFull(subscriptionTokens)}
+                    {' / '}
+                    {formatFull(subscriptionTokenLimit)}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Daily refresh — free tier only */}
+            {isFree && (
+              <>
+                <div className="h-px bg-adam-neutral-800" />
+                <div className="px-4 py-3">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="h-4 w-4"
+                        aria-hidden
+                      >
+                        <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+                        <path d="M21 3v5h-5" />
+                        <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+                        <path d="M3 21v-5h5" />
+                      </svg>
+                      <span className="text-sm font-medium">
+                        Daily refresh credits
+                      </span>
+                    </div>
+                    <span className="text-sm font-semibold tabular-nums">
+                      {formatFull(subscriptionTokenLimit)}
+                    </span>
+                  </div>
+                  <div className="mt-1 pl-6 text-xs text-adam-neutral-400">
+                    Refreshes to {formatFull(subscriptionTokenLimit)} every day
+                  </div>
+                </div>
+              </>
+            )}
+
+            <div className="h-px bg-adam-neutral-800" />
+
+            {/* Footer link */}
+            <Link
+              to="/subscription"
+              className="flex w-full items-center justify-between px-4 py-3 text-sm text-adam-neutral-10 [@media(hover:hover)]:hover:bg-adam-neutral-900"
+            >
+              <span>View plans</span>
+              <span aria-hidden>→</span>
+            </Link>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/CreditsButton.tsx
+++ b/src/components/CreditsButton.tsx
@@ -34,22 +34,36 @@ export function CreditsButton() {
   } = useAuth();
 
   const [open, setOpen] = useState(false);
+  // Card opened by click stays pinned — mouse-leave alone won't dismiss it.
+  // Only outside-click (or an explicit close action) clears this.
+  const [pinnedByClick, setPinnedByClick] = useState(false);
   const [upgradeOpen, setUpgradeOpen] = useState(false);
   const openTimer = useRef<number | null>(null);
   const closeTimer = useRef<number | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  // Close when clicking outside while open (pinned-by-click behavior)
+  // Close when clicking outside while open (dismisses both hover + click open states)
   useEffect(() => {
     if (!open) return;
     const onDocClick = (e: MouseEvent) => {
-      if (!wrapperRef.current?.contains(e.target as Node)) {
-        setOpen(false);
+      if (e.target instanceof Node && wrapperRef.current?.contains(e.target)) {
+        return;
       }
+      setOpen(false);
+      setPinnedByClick(false);
     };
     document.addEventListener('mousedown', onDocClick);
     return () => document.removeEventListener('mousedown', onDocClick);
   }, [open]);
+
+  // Clear any in-flight hover timers when the component unmounts (e.g. the
+  // user navigates away from `/` while a 300ms open-delay is still pending).
+  useEffect(() => {
+    return () => {
+      if (openTimer.current) window.clearTimeout(openTimer.current);
+      if (closeTimer.current) window.clearTimeout(closeTimer.current);
+    };
+  }, []);
 
   if (!user) return null;
 
@@ -73,8 +87,24 @@ export function CreditsButton() {
       window.clearTimeout(openTimer.current);
       openTimer.current = null;
     }
+    // If the user explicitly clicked to pin the card, don't auto-close on
+    // mouse-leave — they'll dismiss it themselves via outside-click.
+    if (pinnedByClick) return;
     // small delay so moving between pill and card doesn't flicker the card closed
     closeTimer.current = window.setTimeout(() => setOpen(false), 120);
+  };
+
+  const handlePillClick = () => {
+    setOpen(true);
+    setPinnedByClick(true);
+    if (openTimer.current) {
+      window.clearTimeout(openTimer.current);
+      openTimer.current = null;
+    }
+    if (closeTimer.current) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
   };
 
   return (
@@ -88,7 +118,7 @@ export function CreditsButton() {
       >
         <button
           type="button"
-          onClick={() => setOpen(true)}
+          onClick={handlePillClick}
           aria-haspopup="dialog"
           aria-expanded={open}
           aria-label="View credits"
@@ -124,6 +154,7 @@ export function CreditsButton() {
                 size="sm"
                 onClick={() => {
                   setOpen(false);
+                  setPinnedByClick(false);
                   setUpgradeOpen(true);
                 }}
                 className="h-8 rounded-full bg-adam-neutral-10 px-4 text-xs font-medium text-adam-bg-dark [@media(hover:hover)]:hover:bg-white [@media(hover:hover)]:hover:text-adam-bg-dark"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation } from 'react-router-dom';
 import { PanelLeft } from 'lucide-react';
 
 import { Sidebar } from './Sidebar';
+import { CreditsButton } from './CreditsButton';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { useIsMobile } from '@/hooks/useIsMobile';
@@ -48,6 +49,20 @@ export function Layout() {
           setIsSidebarOpen={setIsSidebarOpen}
         />
         <div className="relative flex-1 overflow-auto bg-adam-bg-dark">
+          {/* Credits button — home page only. Mirrors the sidebar-toggle's
+              movement: eases inward when the sidebar opens (so it lands
+              inside the rounded panel) and back to the edge when it closes. */}
+          {user && location.pathname === '/' && (
+            <div
+              className={`absolute z-20 transition-all duration-300 ease-in-out ${
+                isSidebarOpen && !isMobile
+                  ? 'right-[2.25rem] top-[2.25rem]'
+                  : 'right-3.5 top-3.5'
+              }`}
+            >
+              <CreditsButton />
+            </div>
+          )}
           {/* Toggle Sidebar Button - Positioned on main content area */}
           {!isMobile && user && (
             <Button

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -51,8 +51,9 @@ export function Layout() {
         <div className="relative flex-1 overflow-auto bg-adam-bg-dark">
           {/* Credits button — home page only. Mirrors the sidebar-toggle's
               movement: eases inward when the sidebar opens (so it lands
-              inside the rounded panel) and back to the edge when it closes. */}
-          {user && location.pathname === '/' && (
+              inside the rounded panel) and back to the edge when it closes.
+              The `!user` branch above returns early, so no `user` guard here. */}
+          {location.pathname === '/' && (
             <div
               className={`absolute z-20 transition-all duration-300 ease-in-out ${
                 isSidebarOpen && !isMobile

--- a/src/components/Subscriptions.tsx
+++ b/src/components/Subscriptions.tsx
@@ -16,6 +16,12 @@ import {
   useTokenPackPurchase,
 } from '@/services/subscriptionService';
 import { useTokenPacks } from '@/hooks/useTokenPacks';
+import {
+  Cadence,
+  PRICING_PLANS,
+  PlanName,
+  creditsFeatureLine,
+} from '@/config/pricing';
 
 interface PricingTier {
   name: string;
@@ -28,71 +34,37 @@ interface PricingTier {
   lookupKey: string;
 }
 
-const freePlan: PricingTier = {
-  name: 'Free',
-  description: 'Get started with Adam',
-  price: '0',
-  features: ['50 tokens per day', 'All AI features', 'Community support'],
-  buttonText: 'Current Plan',
-  lookupKey: 'free',
-};
+// Build the tier list for a given cadence from the shared pricing config.
+// Display order (Free → Pro → Standard) is preserved from the original
+// layout so the "Popular" Pro card sits in the middle of the row.
+const DISPLAY_ORDER: PlanName[] = ['Free', 'Pro', 'Standard'];
 
-const standardFeatures = [
-  '1,000 tokens per month',
-  'All AI features',
-  'Buy additional token packs',
-];
+function buildTiers(cadence: Cadence): PricingTier[] {
+  return DISPLAY_ORDER.map((planName): PricingTier => {
+    const plan = PRICING_PLANS[planName];
+    const isFree = plan.name === 'Free';
+    const features = [creditsFeatureLine(plan), ...plan.extraFeatures];
 
-const proFeatures = [
-  '5,000 tokens per month',
-  'Phone number of founders',
-  'Exclusive access to new features',
-  'Good vibes',
-];
+    const base: PricingTier = {
+      name: plan.name,
+      description: plan.description,
+      price: cadence === 'yearly' ? plan.yearlyPrice : plan.monthlyPrice,
+      features,
+      buttonText: isFree ? 'Current Plan' : `Get ${plan.name}`,
+      popular: plan.popular,
+      lookupKey:
+        cadence === 'yearly' ? plan.yearlyLookupKey : plan.monthlyLookupKey,
+    };
+    // Yearly view shows the crossed-out monthly price above the discount price.
+    if (cadence === 'yearly' && !isFree) {
+      return { ...base, oldPrice: plan.monthlyPrice };
+    }
+    return base;
+  });
+}
 
-const yearlyPricingTiers: PricingTier[] = [
-  freePlan,
-  {
-    name: 'Pro',
-    description: 'For power users',
-    oldPrice: '29.99',
-    price: '17.99',
-    features: proFeatures,
-    buttonText: 'Get Pro',
-    popular: true,
-    lookupKey: 'pro_yearly',
-  },
-  {
-    name: 'Standard',
-    description: 'For regular use',
-    oldPrice: '9.99',
-    price: '5.99',
-    features: standardFeatures,
-    buttonText: 'Get Standard',
-    lookupKey: 'standard_yearly',
-  },
-];
-
-const monthlyPricingTiers: PricingTier[] = [
-  freePlan,
-  {
-    name: 'Pro',
-    description: 'For power users',
-    price: '29.99',
-    features: proFeatures,
-    buttonText: 'Get Pro',
-    popular: true,
-    lookupKey: 'pro_monthly',
-  },
-  {
-    name: 'Standard',
-    description: 'For regular use',
-    price: '9.99',
-    features: standardFeatures,
-    buttonText: 'Get Standard',
-    lookupKey: 'standard_monthly',
-  },
-];
+const yearlyPricingTiers: PricingTier[] = buildTiers('yearly');
+const monthlyPricingTiers: PricingTier[] = buildTiers('monthly');
 
 export function Subscriptions() {
   const navigate = useNavigate();

--- a/src/components/UpgradeModal.tsx
+++ b/src/components/UpgradeModal.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Check, Loader2, Zap } from 'lucide-react';
 
 import {
@@ -14,52 +15,7 @@ import {
   useSubscriptionService,
 } from '@/services/subscriptionService';
 import { cn } from '@/lib/utils';
-
-interface Tier {
-  name: string;
-  price: string;
-  period: string;
-  credits: string;
-  blurb: string;
-  features: string[];
-  lookupKey: string; // '' for free
-  popular?: boolean;
-}
-
-const TIERS: Tier[] = [
-  {
-    name: 'Free',
-    price: '$0',
-    period: '/mo',
-    credits: '50 credits / day',
-    blurb: 'Get started with Adam',
-    features: ['All AI features', 'Community support'],
-    lookupKey: '',
-  },
-  {
-    name: 'Standard',
-    price: '$9.99',
-    period: '/mo',
-    credits: '1,000 credits / mo',
-    blurb: 'For regular use',
-    features: ['All AI features', 'Buy add-on credit packs'],
-    lookupKey: 'standard_monthly',
-  },
-  {
-    name: 'Pro',
-    price: '$29.99',
-    period: '/mo',
-    credits: '5,000 credits / mo',
-    blurb: 'For power users',
-    features: [
-      'All AI features',
-      'Phone number of founders',
-      'Exclusive new features',
-    ],
-    lookupKey: 'pro_monthly',
-    popular: true,
-  },
-];
+import { PLAN_ORDER, PRICING_PLANS, creditsBadgeLabel } from '@/config/pricing';
 
 interface UpgradeModalProps {
   open: boolean;
@@ -72,7 +28,10 @@ export function UpgradeModal({ open, onOpenChange }: UpgradeModalProps) {
     useSubscriptionService();
   const { mutate: manage, isPending: isManaging } = useManageSubscription();
 
-  const isBusy = isSubscribing || isManaging;
+  // Track which tier's button was clicked so only that one shows a spinner
+  // (rather than spinning every button the moment any mutation is in flight).
+  const [activeLookupKey, setActiveLookupKey] = useState<string | null>(null);
+
   const currentTierName =
     subscription === 'pro'
       ? 'Pro'
@@ -80,13 +39,19 @@ export function UpgradeModal({ open, onOpenChange }: UpgradeModalProps) {
         ? 'Standard'
         : 'Free';
 
-  const handleClick = (tier: Tier) => {
-    if (tier.name === currentTierName) return;
-    if (subscription === 'free' && tier.lookupKey) {
-      subscribe({ lookupKey: tier.lookupKey, source: 'upgrade_modal' });
+  const isAnyBusy = isSubscribing || isManaging;
+
+  const handleClick = (lookupKey: string, planName: string) => {
+    if (planName === currentTierName) return;
+    setActiveLookupKey(lookupKey);
+    if (subscription === 'free' && lookupKey) {
+      subscribe(
+        { lookupKey, source: 'upgrade_modal' },
+        { onSettled: () => setActiveLookupKey(null) },
+      );
     } else if (subscription !== 'free') {
       // Paid user changing plans — route through Stripe portal
-      manage();
+      manage(undefined, { onSettled: () => setActiveLookupKey(null) });
     }
   };
 
@@ -103,73 +68,77 @@ export function UpgradeModal({ open, onOpenChange }: UpgradeModalProps) {
         </DialogHeader>
 
         <div className="mt-2 grid grid-cols-1 gap-3 md:grid-cols-3">
-          {TIERS.map((tier) => {
-            const isCurrent = tier.name === currentTierName;
+          {PLAN_ORDER.map((planName) => {
+            const plan = PRICING_PLANS[planName];
+            const isCurrent = plan.name === currentTierName;
+            const lookupKey = plan.monthlyLookupKey;
+            const isThisBusy = activeLookupKey === lookupKey && isAnyBusy;
+
             return (
               <div
-                key={tier.name}
+                key={plan.name}
                 className={cn(
                   'relative flex flex-col rounded-lg border p-5',
-                  tier.popular
+                  plan.popular
                     ? 'border-adam-blue/60 bg-adam-neutral-950'
                     : 'border-adam-neutral-800 bg-adam-neutral-950/60',
                 )}
               >
-                {tier.popular && (
+                {plan.popular && (
                   <span className="absolute right-3 top-3 rounded-full bg-adam-blue/20 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-adam-blue">
                     Popular
                   </span>
                 )}
 
                 <div className="text-sm font-medium text-adam-neutral-10">
-                  {tier.name}
+                  {plan.name}
                 </div>
                 <div className="text-xs text-adam-neutral-400">
-                  {tier.blurb}
+                  {plan.description}
                 </div>
 
                 <div className="mt-3 flex items-baseline gap-1">
-                  <span className="text-2xl font-semibold">{tier.price}</span>
-                  <span className="text-xs text-adam-neutral-400">
-                    {tier.period}
+                  <span className="text-2xl font-semibold">
+                    ${plan.monthlyPrice}
                   </span>
+                  <span className="text-xs text-adam-neutral-400">/mo</span>
                 </div>
 
                 <div className="mt-3 flex items-center gap-1.5 rounded-md bg-adam-neutral-900 px-2 py-1.5 text-xs font-medium">
                   <Zap className="h-3 w-3" fill="currentColor" />
-                  <span>{tier.credits}</span>
+                  <span>{creditsBadgeLabel(plan)}</span>
                 </div>
 
                 <ul className="mt-3 space-y-1.5 text-xs text-adam-neutral-300">
-                  {tier.features.map((f) => (
-                    <li key={f} className="flex items-start gap-1.5">
+                  {plan.extraFeatures.map((feature) => (
+                    <li key={feature} className="flex items-start gap-1.5">
                       <Check className="mt-0.5 h-3 w-3 shrink-0 text-adam-neutral-400" />
-                      <span>{f}</span>
+                      <span>{feature}</span>
                     </li>
                   ))}
                 </ul>
 
                 <div className="mt-auto pt-4">
                   <Button
-                    disabled={isCurrent || isBusy}
-                    onClick={() => handleClick(tier)}
+                    disabled={isCurrent || isAnyBusy}
+                    onClick={() => handleClick(lookupKey, plan.name)}
                     className={cn(
                       'h-9 w-full rounded-full text-xs font-medium',
                       isCurrent
                         ? 'bg-adam-neutral-900 text-adam-neutral-400 [@media(hover:hover)]:hover:bg-adam-neutral-900 [@media(hover:hover)]:hover:text-adam-neutral-400'
-                        : tier.popular
+                        : plan.popular
                           ? 'bg-adam-neutral-10 text-adam-bg-dark [@media(hover:hover)]:hover:bg-white [@media(hover:hover)]:hover:text-adam-bg-dark'
                           : 'bg-adam-neutral-800 text-adam-neutral-10 [@media(hover:hover)]:hover:bg-adam-neutral-700 [@media(hover:hover)]:hover:text-adam-neutral-10',
                     )}
                   >
-                    {isBusy ? (
+                    {isThisBusy ? (
                       <Loader2 className="h-4 w-4 animate-spin" />
                     ) : isCurrent ? (
                       'Current plan'
-                    ) : tier.lookupKey ? (
-                      `Get ${tier.name}`
-                    ) : (
+                    ) : plan.name === 'Free' ? (
                       'Downgrade'
+                    ) : (
+                      `Get ${plan.name}`
                     )}
                   </Button>
                 </div>

--- a/src/components/UpgradeModal.tsx
+++ b/src/components/UpgradeModal.tsx
@@ -1,0 +1,183 @@
+import { Check, Loader2, Zap } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  useManageSubscription,
+  useSubscriptionService,
+} from '@/services/subscriptionService';
+import { cn } from '@/lib/utils';
+
+interface Tier {
+  name: string;
+  price: string;
+  period: string;
+  credits: string;
+  blurb: string;
+  features: string[];
+  lookupKey: string; // '' for free
+  popular?: boolean;
+}
+
+const TIERS: Tier[] = [
+  {
+    name: 'Free',
+    price: '$0',
+    period: '/mo',
+    credits: '50 credits / day',
+    blurb: 'Get started with Adam',
+    features: ['All AI features', 'Community support'],
+    lookupKey: '',
+  },
+  {
+    name: 'Standard',
+    price: '$9.99',
+    period: '/mo',
+    credits: '1,000 credits / mo',
+    blurb: 'For regular use',
+    features: ['All AI features', 'Buy add-on credit packs'],
+    lookupKey: 'standard_monthly',
+  },
+  {
+    name: 'Pro',
+    price: '$29.99',
+    period: '/mo',
+    credits: '5,000 credits / mo',
+    blurb: 'For power users',
+    features: [
+      'All AI features',
+      'Phone number of founders',
+      'Exclusive new features',
+    ],
+    lookupKey: 'pro_monthly',
+    popular: true,
+  },
+];
+
+interface UpgradeModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function UpgradeModal({ open, onOpenChange }: UpgradeModalProps) {
+  const { subscription } = useAuth();
+  const { mutate: subscribe, isPending: isSubscribing } =
+    useSubscriptionService();
+  const { mutate: manage, isPending: isManaging } = useManageSubscription();
+
+  const isBusy = isSubscribing || isManaging;
+  const currentTierName =
+    subscription === 'pro'
+      ? 'Pro'
+      : subscription === 'standard'
+        ? 'Standard'
+        : 'Free';
+
+  const handleClick = (tier: Tier) => {
+    if (tier.name === currentTierName) return;
+    if (subscription === 'free' && tier.lookupKey) {
+      subscribe({ lookupKey: tier.lookupKey, source: 'upgrade_modal' });
+    } else if (subscription !== 'free') {
+      // Paid user changing plans — route through Stripe portal
+      manage();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] w-[95vw] max-w-6xl overflow-y-auto border-adam-neutral-800 bg-adam-bg-secondary-dark p-10 text-adam-neutral-10 sm:rounded-xl">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-semibold">
+            Upgrade your plan
+          </DialogTitle>
+          <DialogDescription className="text-sm text-adam-neutral-400">
+            All plans include every AI feature. Upgrade for more credits.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="mt-2 grid grid-cols-1 gap-3 md:grid-cols-3">
+          {TIERS.map((tier) => {
+            const isCurrent = tier.name === currentTierName;
+            return (
+              <div
+                key={tier.name}
+                className={cn(
+                  'relative flex flex-col rounded-lg border p-5',
+                  tier.popular
+                    ? 'border-adam-blue/60 bg-adam-neutral-950'
+                    : 'border-adam-neutral-800 bg-adam-neutral-950/60',
+                )}
+              >
+                {tier.popular && (
+                  <span className="absolute right-3 top-3 rounded-full bg-adam-blue/20 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-adam-blue">
+                    Popular
+                  </span>
+                )}
+
+                <div className="text-sm font-medium text-adam-neutral-10">
+                  {tier.name}
+                </div>
+                <div className="text-xs text-adam-neutral-400">
+                  {tier.blurb}
+                </div>
+
+                <div className="mt-3 flex items-baseline gap-1">
+                  <span className="text-2xl font-semibold">{tier.price}</span>
+                  <span className="text-xs text-adam-neutral-400">
+                    {tier.period}
+                  </span>
+                </div>
+
+                <div className="mt-3 flex items-center gap-1.5 rounded-md bg-adam-neutral-900 px-2 py-1.5 text-xs font-medium">
+                  <Zap className="h-3 w-3" fill="currentColor" />
+                  <span>{tier.credits}</span>
+                </div>
+
+                <ul className="mt-3 space-y-1.5 text-xs text-adam-neutral-300">
+                  {tier.features.map((f) => (
+                    <li key={f} className="flex items-start gap-1.5">
+                      <Check className="mt-0.5 h-3 w-3 shrink-0 text-adam-neutral-400" />
+                      <span>{f}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <div className="mt-auto pt-4">
+                  <Button
+                    disabled={isCurrent || isBusy}
+                    onClick={() => handleClick(tier)}
+                    className={cn(
+                      'h-9 w-full rounded-full text-xs font-medium',
+                      isCurrent
+                        ? 'bg-adam-neutral-900 text-adam-neutral-400 [@media(hover:hover)]:hover:bg-adam-neutral-900 [@media(hover:hover)]:hover:text-adam-neutral-400'
+                        : tier.popular
+                          ? 'bg-adam-neutral-10 text-adam-bg-dark [@media(hover:hover)]:hover:bg-white [@media(hover:hover)]:hover:text-adam-bg-dark'
+                          : 'bg-adam-neutral-800 text-adam-neutral-10 [@media(hover:hover)]:hover:bg-adam-neutral-700 [@media(hover:hover)]:hover:text-adam-neutral-10',
+                    )}
+                  >
+                    {isBusy ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : isCurrent ? (
+                      'Current plan'
+                    ) : tier.lookupKey ? (
+                      `Get ${tier.name}`
+                    ) : (
+                      'Downgrade'
+                    )}
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/config/pricing.ts
+++ b/src/config/pricing.ts
@@ -1,0 +1,103 @@
+/**
+ * Single source of truth for subscription pricing.
+ *
+ * Consumed by `Subscriptions` (the full /subscription page) and
+ * `UpgradeModal` (the compact in-app upgrade dialog). Neither file should
+ * redeclare plan names, prices, lookup keys, or credit amounts — derive
+ * the view-specific shapes from the plans below.
+ */
+
+export type PlanName = 'Free' | 'Standard' | 'Pro';
+
+export type Cadence = 'monthly' | 'yearly';
+
+export interface PricingPlan {
+  name: PlanName;
+  description: string;
+  /** Price in USD per month on the monthly plan. `'0'` for Free. */
+  monthlyPrice: string;
+  /** Price in USD per month on the yearly plan (already divided by 12). */
+  yearlyPrice: string;
+  /** Number of credits granted by the plan each period. */
+  creditsAmount: number;
+  /** Refresh cadence for the credits allowance. */
+  creditsPeriod: 'day' | 'mo';
+  /** Extra feature bullets, NOT including the credits line. */
+  extraFeatures: string[];
+  /** Stripe price lookup key for the monthly cadence. */
+  monthlyLookupKey: string;
+  /** Stripe price lookup key for the yearly cadence. */
+  yearlyLookupKey: string;
+  /** Whether to highlight the plan visually. */
+  popular?: boolean;
+}
+
+export const PRICING_PLANS: Record<PlanName, PricingPlan> = {
+  Free: {
+    name: 'Free',
+    description: 'Get started with Adam',
+    monthlyPrice: '0',
+    yearlyPrice: '0',
+    creditsAmount: 50,
+    creditsPeriod: 'day',
+    extraFeatures: ['All AI features', 'Community support'],
+    monthlyLookupKey: 'free',
+    yearlyLookupKey: 'free',
+  },
+  Standard: {
+    name: 'Standard',
+    description: 'For regular use',
+    monthlyPrice: '9.99',
+    yearlyPrice: '5.99',
+    creditsAmount: 1000,
+    creditsPeriod: 'mo',
+    extraFeatures: ['All AI features', 'Buy additional token packs'],
+    monthlyLookupKey: 'standard_monthly',
+    yearlyLookupKey: 'standard_yearly',
+  },
+  Pro: {
+    name: 'Pro',
+    description: 'For power users',
+    monthlyPrice: '29.99',
+    yearlyPrice: '17.99',
+    creditsAmount: 5000,
+    creditsPeriod: 'mo',
+    extraFeatures: [
+      'Phone number of founders',
+      'Exclusive access to new features',
+      'Good vibes',
+    ],
+    monthlyLookupKey: 'pro_monthly',
+    yearlyLookupKey: 'pro_yearly',
+    popular: true,
+  },
+};
+
+/** Display order used across both the pricing page and the upgrade modal. */
+export const PLAN_ORDER: PlanName[] = ['Free', 'Standard', 'Pro'];
+
+/**
+ * Feature-list-friendly credits line, e.g. "50 tokens per day" or
+ * "1,000 tokens per month". Used in the full Subscriptions page where
+ * credits live inline with the other feature bullets.
+ */
+export function creditsFeatureLine(plan: PricingPlan): string {
+  const periodWord = plan.creditsPeriod === 'day' ? 'day' : 'month';
+  return `${plan.creditsAmount.toLocaleString()} tokens per ${periodWord}`;
+}
+
+/**
+ * Compact credits label, e.g. "50 credits / day" or "1,000 credits / mo".
+ * Used in the upgrade modal where credits appear as a dedicated badge.
+ */
+export function creditsBadgeLabel(plan: PricingPlan): string {
+  return `${plan.creditsAmount.toLocaleString()} credits / ${plan.creditsPeriod}`;
+}
+
+export function lookupKey(plan: PricingPlan, cadence: Cadence): string {
+  return cadence === 'yearly' ? plan.yearlyLookupKey : plan.monthlyLookupKey;
+}
+
+export function priceFor(plan: PricingPlan, cadence: Cadence): string {
+  return cadence === 'yearly' ? plan.yearlyPrice : plan.monthlyPrice;
+}


### PR DESCRIPTION
## Summary

Adds a credits indicator to the top-right of the home page so users can see their token balance at a glance and jump straight to an upgrade flow without leaving the page.

- **`CreditsButton`** — pill showing compact token total (e.g. `808.4K`) wired to `useAuth()` (`totalTokens`, `purchasedTokens`, `subscriptionTokens`, `subscriptionTokenLimit`). Opens a hover card after a 300ms hover-intent delay (also on click). Card breaks down add-on vs subscription credits, shows daily-refresh for free users, and has a "View plans →" footer link to `/subscription`.
- **`UpgradeModal`** — large (`max-w-6xl`) dialog opened from the card's **Upgrade** button. Shows Free / Standard / Pro side-by-side with explicit credit amounts (50/day, 1k/mo, 5k/mo) and feature lists. Free users → Stripe checkout via `useSubscriptionService`; paid users → Stripe portal via `useManageSubscription`. Current tier shows a disabled "Current plan" button.
- **Layout integration** — pill is rendered only on `/`. It eases inward to `right-[2.25rem] top-[2.25rem]` when the sidebar is open (so it lands inside `PromptView`'s rounded panel) and back to `right-3.5 top-3.5` when closed, mirroring the sidebar-toggle's motion with a 300ms transition.

## Why

The existing upgrade path required navigating to `/subscription`. This gives users a persistent, glanceable credits readout on home plus a one-click upgrade surface — the hover card answers "how many credits do I have and where did they come from?" and the modal answers "what would I get if I paid?" without leaving the page.

## Implementation notes

- Hover card uses a hand-rolled hover state (not Radix `HoverCard`). Radix's `HoverCardTrigger asChild` Slot was swallowing `<Link>`/button clicks during testing; manual state with `onMouseEnter`/`onMouseLeave` timers gives us reliable click behavior, a tunable open delay, and a 120ms close grace period so moving between pill and card doesn't flicker.
- Clicking the pill pins the card open; outside-click (`mousedown`) dismisses it.
- Positioning is tied only to sidebar state, not route, so toggling the sidebar is the only thing that moves the pill — no flashing on navigation.
- Tier data in `UpgradeModal` is duplicated from `Subscriptions.tsx` intentionally to keep the modal compact. If we add more tiers this should be extracted to a shared module.

## Test plan

- [ ] On `/` as a free user, pill shows the correct daily balance; hover card breaks down add-on vs daily credits and shows "Daily refresh credits" section
- [ ] On `/` as a paid user, hover card shows `Monthly credits X / Y`; daily-refresh section is hidden
- [ ] Hover on pill → 300ms delay before card opens; moving cursor away before delay cancels the open
- [ ] Click pill → card opens immediately; click outside → card closes
- [ ] Click "Upgrade" in card → card closes, `UpgradeModal` opens
- [ ] Click "Get Standard" / "Get Pro" in modal → Stripe checkout redirects (free users) or Stripe portal (paid users)
- [ ] "Current plan" tier button is disabled with correct label
- [ ] Toggle sidebar → pill eases in/out with 300ms transition; no flashing
- [ ] Navigate to `/subscription`, `/editor/:id`, `/settings`, `/history` → pill is hidden (home-only)
- [ ] Signed-out users see no pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a credits pill to the home page with a hover breakdown and an upgrade modal, so users can see their balance and upgrade without leaving the page. Also fixes hover-card pinning and loading states, and centralizes plan data to keep pricing consistent.

- **New Features**
  - `CreditsButton` shows compact total from `useAuth`; hover (300ms) or click opens a card with add-on vs subscription credits, free daily refresh, and a "View plans" link.
  - `UpgradeModal` lists Free/Standard/Pro with credit amounts; free users go to Stripe checkout via `useSubscriptionService`, paid users to Stripe portal via `useManageSubscription`; current plan is disabled.
  - Home-only integration at top-right; eases with the sidebar and hides when signed out.

- **Bug Fixes**
  - Hover card now stays open when clicked (click-pin); outside-click closes it, and hover timers are cleared on unmount to prevent stray opens.
  - `UpgradeModal` shows a spinner only on the clicked plan button; minor event handling tightened with `instanceof Node`.
  - Centralized plans in `src/config/pricing.ts`; `Subscriptions` and `UpgradeModal` derive tiers from one source to avoid drift.

<sup>Written for commit a5f36a274304875b39a5a6c4018e408eed14a8f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

