### PR TITLE
fix(ui): dark overscroll background on html/body

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -67,8 +67,11 @@
   * {
     @apply border-border;
   }
+  html {
+    @apply bg-adam-bg-dark;
+  }
   body {
-    @apply m-0 min-h-dvh w-full bg-background text-foreground;
+    @apply m-0 min-h-dvh w-full bg-adam-bg-dark text-foreground;
     font-family: 'Inter', sans-serif;
   }
 }


### PR DESCRIPTION
## Summary
- Html and body still used the default white `bg-background` while the whole app renders on `#191A1A`, so rubber-band overscroll at the top/bottom of the page flashed a white strip.
- Set both `<html>` and `<body>` to `bg-adam-bg-dark` in [src/index.css](src/index.css) so the overscroll area matches the UI.

## Test plan
- [ ] On macOS/iOS, drag past the top and bottom of the page — the exposed area should be dark (`#191A1A`), not white.
- [ ] Confirm no regression on any view; all top-level views already render on `bg-adam-bg-dark` / `bg-adam-bg-secondary-dark`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `html` and `body` to `bg-adam-bg-dark` in `src/index.css` to stop white flashes during rubber-band overscroll and match the app’s dark background.

<sup>Written for commit 9962f582e7b24f8b6859bb6da2f068bf4eb4f225. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

