### PR TITLE
feat(home): add Onshape extension banner under prompt box

### DIFF
--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -278,11 +278,16 @@ export function PromptView() {
                     href="https://cad.onshape.com/appstore/apps/Design%20&%20Documentation/690a8dc864e816c112aa66a0"
                     target="_blank"
                     rel="noopener noreferrer"
-                    onClick={() =>
-                      posthog.capture('onshape_banner_click', {
-                        location: 'prompt_view',
-                      })
-                    }
+                    onClick={() => {
+                      try {
+                        posthog.capture('onshape_banner_click', {
+                          location: 'prompt_view',
+                        });
+                      } catch {
+                        // Analytics failures (e.g. blocked by ad-blocker)
+                        // must never block the link's navigation.
+                      }
+                    }}
                     className="group inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm text-adam-text-secondary transition-colors hover:border-adam-blue/40 hover:bg-adam-blue/10 hover:text-adam-text-primary"
                   >
                     <span>

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, Link, useOutletContext } from 'react-router-dom';
-import { LogIn } from 'lucide-react';
+import { ArrowUpRight, LogIn } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
@@ -272,6 +272,29 @@ export function PromptView() {
                   </div>
                 )}
               </div>
+              {user && (
+                <div className="flex justify-center">
+                  <a
+                    href="https://cad.onshape.com/appstore/apps/Design%20&%20Documentation/690a8dc864e816c112aa66a0"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() =>
+                      posthog.capture('onshape_banner_click', {
+                        location: 'prompt_view',
+                      })
+                    }
+                    className="group inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm text-adam-text-secondary transition-colors hover:border-adam-blue/40 hover:bg-adam-blue/10 hover:text-adam-text-primary"
+                  >
+                    <span>
+                      Try our{' '}
+                      <span className="font-medium text-adam-blue">
+                        Onshape extension
+                      </span>
+                    </span>
+                    <ArrowUpRight className="h-3.5 w-3.5 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+                  </a>
+                </div>
+              )}
               {!user && (
                 <p className="text-center text-sm text-gray-500">
                   <Link

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -272,7 +272,7 @@ export function PromptView() {
                   </div>
                 )}
               </div>
-              {user && !limitReached && !lowPrompts && (
+              {!isLoading && user && !limitReached && !lowPrompts && (
                 <div className="flex justify-center">
                   <a
                     href="https://cad.onshape.com/appstore/apps/Design%20&%20Documentation/690a8dc864e816c112aa66a0"

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -272,7 +272,7 @@ export function PromptView() {
                   </div>
                 )}
               </div>
-              {user && (
+              {user && !limitReached && !lowPrompts && (
                 <div className="flex justify-center">
                   <a
                     href="https://cad.onshape.com/appstore/apps/Design%20&%20Documentation/690a8dc864e816c112aa66a0"


### PR DESCRIPTION
Shows a subtle pill-style link to the Onshape App Store listing for signed-in users on the home page, with a PostHog click event for tracking conversion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a subtle, pill-style Onshape extension banner below the prompt box for signed-in users. It shows only after auth has settled (`!isLoading`), hides when credits warnings (limit reached or low prompts) are shown, and opens the Onshape App Store in a new tab while logging `onshape_banner_click` via `posthog` wrapped in try/catch so ad-blockers never block navigation.

<sup>Written for commit b52a622b5a42535c749148d1b689ac55d8983ed9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

