### PR TITLE
feat(viewer): default parametric preview to orthographic

### DIFF
--- a/src/components/viewer/OrthographicPerspectiveToggle.tsx
+++ b/src/components/viewer/OrthographicPerspectiveToggle.tsx
@@ -23,24 +23,6 @@ export function OrthographicPerspectiveToggle({
         <Tooltip>
           <TooltipTrigger asChild>
             <div className="cursor-help">
-              <PerspectiveCube className="h-4 w-4 text-adam-text-primary" />
-            </div>
-          </TooltipTrigger>
-          <TooltipContent
-            side="top"
-            className="border-adam-neutral-700 bg-adam-background-2 text-adam-text-primary"
-          >
-            <p>Perspective View</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-
-      <Switch checked={isOrthographic} onCheckedChange={onToggle} />
-
-      <TooltipProvider delayDuration={300}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="cursor-help">
               <OrthographicCube className="h-4 w-4 text-adam-text-primary" />
             </div>
           </TooltipTrigger>
@@ -49,6 +31,27 @@ export function OrthographicPerspectiveToggle({
             className="border-adam-neutral-700 bg-adam-background-2 text-adam-text-primary"
           >
             <p>Orthographic View</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+
+      <Switch
+        checked={!isOrthographic}
+        onCheckedChange={(checked) => onToggle(!checked)}
+      />
+
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="cursor-help">
+              <PerspectiveCube className="h-4 w-4 text-adam-text-primary" />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent
+            side="top"
+            className="border-adam-neutral-700 bg-adam-background-2 text-adam-text-primary"
+          >
+            <p>Perspective View</p>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>

--- a/src/components/viewer/ThreeScene.tsx
+++ b/src/components/viewer/ThreeScene.tsx
@@ -26,7 +26,7 @@ export function ThreeScene({
   isMobile = false,
   backgroundColor = '#3B3B3B',
 }: ThreeSceneProps) {
-  const [isOrthographic, setIsOrthographic] = useState(false);
+  const [isOrthographic, setIsOrthographic] = useState(true);
 
   // Store the initial isMobile value to prevent position changes during resize
   const [initialIsMobile] = useState(isMobile);


### PR DESCRIPTION
Parametric CAD work reads more naturally in orthographic projection, so start there and reorder the toggle so the default sits on the "off" side.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the 3D viewer to open in orthographic projection by default for clearer parametric CAD previews. Inverted the view toggle so the default sits on the off side, swapped the cube icons, and updated tooltips to match.

<sup>Written for commit dbb084e5d607b0fa318034c33b0baadf18757aa2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

