### PR TITLE
feat(chat): stream OpenSCAD code into the assistant message

### DIFF
--- a/src/components/chat/AssistantMessage.tsx
+++ b/src/components/chat/AssistantMessage.tsx
@@ -207,7 +207,6 @@ export function AssistantMessage({
           ) : (
             <>
               {conversation.type === 'parametric' &&
-                isLoading &&
                 isLastMessage &&
                 !message.content.text &&
                 (!message.content.toolCalls ||

--- a/src/components/chat/AssistantMessage.tsx
+++ b/src/components/chat/AssistantMessage.tsx
@@ -14,7 +14,6 @@ import {
 } from 'lucide-react';
 import { Streamdown } from 'streamdown';
 import { StreamingCodeBlock } from '@/components/chat/StreamingCodeBlock';
-import { generateDownloadFilename } from '@/utils/downloadUtils';
 import { Button } from '@/components/ui/button';
 import { RefreshCw } from 'lucide-react';
 import { Avatar, AvatarImage } from '@/components/ui/avatar';
@@ -251,10 +250,6 @@ export function AssistantMessage({
                             key={toolCall.id ?? `${toolCall.name}`}
                             code={streamingCode}
                             isStreaming={true}
-                            filename={generateDownloadFilename({
-                              currentMessage: message,
-                              extension: 'scad',
-                            })}
                           />
                         );
                       }

--- a/src/components/chat/AssistantMessage.tsx
+++ b/src/components/chat/AssistantMessage.tsx
@@ -207,11 +207,13 @@ export function AssistantMessage({
           ) : (
             <>
               {conversation.type === 'parametric' &&
-                isLastMessage &&
                 !message.content.text &&
                 (!message.content.toolCalls ||
                   message.content.toolCalls.length === 0) &&
-                !message.content.artifact && (
+                !message.content.artifact &&
+                !message.content.mesh &&
+                (!message.content.images ||
+                  message.content.images.length === 0) && (
                   <div className="flex h-10 w-full items-center justify-between overflow-hidden rounded-md bg-adam-neutral-950 px-3">
                     <div className="flex h-full items-center justify-center gap-2">
                       <Box className="h-4 w-4 text-white" />

--- a/src/components/chat/AssistantMessage.tsx
+++ b/src/components/chat/AssistantMessage.tsx
@@ -326,14 +326,19 @@ export function AssistantMessage({
                   <MeshImagePreview meshId={message.content.mesh.id} />
                 </div>
               )}
-              {message.content.artifact && (
-                <ObjectButton
-                  message={message}
-                  currentMessage={currentMessage}
-                  setCurrentMessage={setCurrentMessage}
-                  currentVersion={currentVersion}
-                />
-              )}
+              {message.content.artifact &&
+                !message.content.toolCalls?.some(
+                  (c) =>
+                    c.name === 'build_parametric_model' &&
+                    c.status === 'pending',
+                ) && (
+                  <ObjectButton
+                    message={message}
+                    currentMessage={currentMessage}
+                    setCurrentMessage={setCurrentMessage}
+                    currentVersion={currentVersion}
+                  />
+                )}
             </>
           )}
 

--- a/src/components/chat/AssistantMessage.tsx
+++ b/src/components/chat/AssistantMessage.tsx
@@ -13,6 +13,7 @@ import {
   Sparkles,
 } from 'lucide-react';
 import { Streamdown } from 'streamdown';
+import { StreamingCodeBlock } from '@/components/chat/StreamingCodeBlock';
 import { Button } from '@/components/ui/button';
 import { RefreshCw } from 'lucide-react';
 import { Avatar, AvatarImage } from '@/components/ui/avatar';
@@ -205,6 +206,21 @@ export function AssistantMessage({
             </>
           ) : (
             <>
+              {conversation.type === 'parametric' &&
+                isLoading &&
+                isLastMessage &&
+                !message.content.text &&
+                (!message.content.toolCalls ||
+                  message.content.toolCalls.length === 0) &&
+                !message.content.artifact && (
+                  <div className="flex h-10 w-full items-center justify-between overflow-hidden rounded-md bg-adam-neutral-950 px-3">
+                    <div className="flex h-full items-center justify-center gap-2">
+                      <Box className="h-4 w-4 text-white" />
+                      <span>Building CAD...</span>
+                    </div>
+                    <Loader2 className="h-4 w-4 animate-spin text-white" />
+                  </div>
+                )}
               {message.content.text ? (
                 <Streamdown
                   className="px-1 [&_:not(pre)>code]:rounded [&_:not(pre)>code]:bg-adam-neutral-950 [&_:not(pre)>code]:px-1 [&_:not(pre)>code]:py-0.5 [&_a]:text-adam-blue [&_a]:underline hover:[&_a]:opacity-80 [&_h1]:mt-2 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:mt-2 [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:mt-1 [&_h3]:font-semibold [&_ol]:list-decimal [&_ol]:pl-5 [&_p:not(:last-child)]:mb-2 [&_p]:leading-relaxed [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:bg-adam-neutral-950 [&_pre]:p-3 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:list-disc [&_ul]:pl-5"
@@ -216,56 +232,78 @@ export function AssistantMessage({
               {message.content.toolCalls &&
                 message.content.toolCalls.length > 0 && (
                   <div className="flex w-full flex-col gap-2">
-                    {message.content.toolCalls.map((toolCall) => (
-                      <div
-                        key={toolCall.id ?? `${toolCall.name}`}
-                        className="flex h-10 w-full items-center justify-between overflow-hidden rounded-md bg-adam-neutral-950 px-3 hover:bg-adam-neutral-900"
-                      >
-                        <div className="flex h-full items-center justify-center gap-2">
-                          {toolCall.name === 'create_image' && (
-                            <ImageIcon className="h-4 w-4 text-white" />
-                          )}
-                          {toolCall.name === 'create_mesh' && (
-                            <Box className="h-4 w-4 text-white" />
-                          )}
-                          {(toolCall.name === 'build_parametric_model' ||
-                            toolCall.name === 'apply_parameter_changes') && (
-                            <Box className="h-4 w-4 text-white" />
-                          )}
+                    {message.content.toolCalls.map((toolCall) => {
+                      // For a pending parametric build, once code starts
+                      // streaming swap the generic status row for the live
+                      // code. Before the first chunk we keep the original
+                      // "Building CAD..." row so the thinking state is clear.
+                      const streamingCode =
+                        message.content.artifact?.code ?? '';
+                      if (
+                        toolCall.name === 'build_parametric_model' &&
+                        toolCall.status === 'pending' &&
+                        streamingCode.length > 0
+                      ) {
+                        return (
+                          <StreamingCodeBlock
+                            key={toolCall.id ?? `${toolCall.name}`}
+                            code={streamingCode}
+                            isStreaming={true}
+                          />
+                        );
+                      }
+
+                      return (
+                        <div
+                          key={toolCall.id ?? `${toolCall.name}`}
+                          className="flex h-10 w-full items-center justify-between overflow-hidden rounded-md bg-adam-neutral-950 px-3 hover:bg-adam-neutral-900"
+                        >
+                          <div className="flex h-full items-center justify-center gap-2">
+                            {toolCall.name === 'create_image' && (
+                              <ImageIcon className="h-4 w-4 text-white" />
+                            )}
+                            {toolCall.name === 'create_mesh' && (
+                              <Box className="h-4 w-4 text-white" />
+                            )}
+                            {(toolCall.name === 'build_parametric_model' ||
+                              toolCall.name === 'apply_parameter_changes') && (
+                              <Box className="h-4 w-4 text-white" />
+                            )}
+                            {toolCall.status === 'pending' && (
+                              <span>
+                                {toolCall.name === 'create_image'
+                                  ? 'Queuing image...'
+                                  : toolCall.name === 'create_mesh'
+                                    ? 'Queuing mesh...'
+                                    : toolCall.name ===
+                                          'build_parametric_model' ||
+                                        toolCall.name ===
+                                          'apply_parameter_changes'
+                                      ? 'Building CAD...'
+                                      : `${toolCall.name}...`}
+                              </span>
+                            )}
+                            {toolCall.status === 'error' && (
+                              <span>
+                                {toolCall.name === 'create_image'
+                                  ? 'Failed to start image generation'
+                                  : toolCall.name === 'create_mesh'
+                                    ? 'Failed to start mesh generation'
+                                    : toolCall.name ===
+                                          'build_parametric_model' ||
+                                        toolCall.name ===
+                                          'apply_parameter_changes'
+                                      ? 'Failed to generate CAD'
+                                      : `${toolCall.name}...`}
+                              </span>
+                            )}
+                          </div>
                           {toolCall.status === 'pending' && (
-                            <span>
-                              {toolCall.name === 'create_image'
-                                ? 'Queuing image...'
-                                : toolCall.name === 'create_mesh'
-                                  ? 'Queuing mesh...'
-                                  : toolCall.name ===
-                                        'build_parametric_model' ||
-                                      toolCall.name ===
-                                        'apply_parameter_changes'
-                                    ? 'Building CAD...'
-                                    : `${toolCall.name}...`}
-                            </span>
-                          )}
-                          {toolCall.status === 'error' && (
-                            <span>
-                              {toolCall.name === 'create_image'
-                                ? 'Failed to start image generation'
-                                : toolCall.name === 'create_mesh'
-                                  ? 'Failed to start mesh generation'
-                                  : toolCall.name ===
-                                        'build_parametric_model' ||
-                                      toolCall.name ===
-                                        'apply_parameter_changes'
-                                    ? 'Failed to generate CAD'
-                                    : `${toolCall.name}...`}
-                            </span>
+                            <Loader2 className="h-4 w-4 animate-spin text-white" />
                           )}
                         </div>
-                        {toolCall.status === 'pending' && (
-                          <Loader2 className="h-4 w-4 animate-spin text-white" />
-                        )}
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
               <AssistantMessageImagesViewer message={message} />

--- a/src/components/chat/AssistantMessage.tsx
+++ b/src/components/chat/AssistantMessage.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { Streamdown } from 'streamdown';
 import { StreamingCodeBlock } from '@/components/chat/StreamingCodeBlock';
+import { generateDownloadFilename } from '@/utils/downloadUtils';
 import { Button } from '@/components/ui/button';
 import { RefreshCw } from 'lucide-react';
 import { Avatar, AvatarImage } from '@/components/ui/avatar';
@@ -250,6 +251,10 @@ export function AssistantMessage({
                             key={toolCall.id ?? `${toolCall.name}`}
                             code={streamingCode}
                             isStreaming={true}
+                            filename={generateDownloadFilename({
+                              currentMessage: message,
+                              extension: 'scad',
+                            })}
                           />
                         );
                       }

--- a/src/components/chat/StreamingCodeBlock.tsx
+++ b/src/components/chat/StreamingCodeBlock.tsx
@@ -47,10 +47,6 @@ export function StreamingCodeBlock({
     el.scrollTop = el.scrollHeight;
   }, [visibleCode]);
 
-  useEffect(() => {
-    if (!isStreaming) stickToBottomRef.current = true;
-  }, [isStreaming]);
-
   const handleScroll = () => {
     const el = scrollRef.current;
     if (!el) return;
@@ -63,13 +59,13 @@ export function StreamingCodeBlock({
 
   return (
     <div className="w-full overflow-hidden rounded-lg border border-white/[0.06] bg-adam-neutral-950/90 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-      <div className="flex h-7 items-center justify-between border-b border-white/[0.06] px-3">
-        <div className="flex items-center gap-1.5 text-[10.5px] font-medium uppercase tracking-[0.08em] text-adam-neutral-400">
+      <div className="flex h-7 items-center justify-between gap-3 border-b border-white/[0.06] px-3">
+        <div className="flex min-w-0 flex-1 items-center gap-1.5 text-[10.5px] font-medium uppercase tracking-[0.08em] text-adam-neutral-400">
           <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-adam-blue/80" />
           <span className="truncate">{filename}</span>
         </div>
         {showCaret && (
-          <div className="flex items-center gap-1.5 text-[10.5px] text-adam-neutral-500">
+          <div className="flex shrink-0 items-center gap-1.5 text-[10.5px] text-adam-neutral-500">
             <span className="relative flex h-1.5 w-1.5">
               <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-adam-blue/70" />
               <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-adam-blue" />

--- a/src/components/chat/StreamingCodeBlock.tsx
+++ b/src/components/chat/StreamingCodeBlock.tsx
@@ -20,11 +20,13 @@ export function StreamingCodeBlock({
   const stickToBottomRef = useRef(true);
   const [visibleCount, setVisibleCount] = useState(0);
 
-  // Catch up to the incoming stream at a readable pace.
+  // Catch up to the incoming stream at a readable pace. Scale with backlog
+  // so very long responses finish in ~1.5s rather than tens of seconds.
   useEffect(() => {
     if (visibleCount >= code.length) return;
+    const backlog = code.length - visibleCount;
     const step = isStreaming
-      ? REVEAL_CHARS_PER_TICK
+      ? Math.max(REVEAL_CHARS_PER_TICK, Math.ceil(backlog / 60))
       : Math.max(REVEAL_CHARS_PER_TICK, Math.ceil(code.length / 40));
     const id = window.setTimeout(() => {
       setVisibleCount((prev) => Math.min(prev + step, code.length));

--- a/src/components/chat/StreamingCodeBlock.tsx
+++ b/src/components/chat/StreamingCodeBlock.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+interface StreamingCodeBlockProps {
+  code: string;
+  isStreaming: boolean;
+}
+
+// Keep it compact — stays inside the chat bubble without swallowing the view.
+const MAX_HEIGHT = 180;
+
+// Typewriter reveal: ~300 chars/sec feels live without being frantic.
+const REVEAL_CHARS_PER_TICK = 8;
+const REVEAL_TICK_MS = 28;
+
+export function StreamingCodeBlock({
+  code,
+  isStreaming,
+}: StreamingCodeBlockProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const stickToBottomRef = useRef(true);
+  const [visibleCount, setVisibleCount] = useState(0);
+
+  // Catch up to the incoming stream at a readable pace.
+  useEffect(() => {
+    if (visibleCount >= code.length) return;
+    const step = isStreaming
+      ? REVEAL_CHARS_PER_TICK
+      : Math.max(REVEAL_CHARS_PER_TICK, Math.ceil(code.length / 40));
+    const id = window.setTimeout(() => {
+      setVisibleCount((prev) => Math.min(prev + step, code.length));
+    }, REVEAL_TICK_MS);
+    return () => window.clearTimeout(id);
+  }, [code, visibleCount, isStreaming]);
+
+  const visibleCode = useMemo(
+    () => code.slice(0, visibleCount),
+    [code, visibleCount],
+  );
+
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !stickToBottomRef.current) return;
+    el.scrollTop = el.scrollHeight;
+  }, [visibleCode]);
+
+  useEffect(() => {
+    if (!isStreaming) stickToBottomRef.current = true;
+  }, [isStreaming]);
+
+  const handleScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    stickToBottomRef.current = distanceFromBottom < 16;
+  };
+
+  const revealing = visibleCount < code.length;
+  const showCaret = isStreaming || revealing;
+
+  return (
+    <div className="w-full overflow-hidden rounded-lg border border-white/[0.06] bg-adam-neutral-950/90 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+      <div className="flex h-7 items-center justify-between border-b border-white/[0.06] px-3">
+        <div className="flex items-center gap-1.5 text-[10.5px] font-medium uppercase tracking-[0.08em] text-adam-neutral-400">
+          <span className="h-1.5 w-1.5 rounded-full bg-adam-blue/80" />
+          model.scad
+        </div>
+        {showCaret && (
+          <div className="flex items-center gap-1.5 text-[10.5px] text-adam-neutral-500">
+            <span className="relative flex h-1.5 w-1.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-adam-blue/70" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-adam-blue" />
+            </span>
+            streaming
+          </div>
+        )}
+      </div>
+
+      <div className="relative">
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          className="overflow-auto px-3 py-2.5 font-mono text-[11.5px] leading-[1.55] text-adam-text-primary/95"
+          style={{ maxHeight: MAX_HEIGHT }}
+        >
+          <pre className="m-0 whitespace-pre-wrap break-words">
+            <code>{visibleCode}</code>
+            {showCaret && (
+              <span
+                aria-hidden
+                className="ml-[1px] inline-block h-[0.95em] w-[0.5ch] translate-y-[2px] animate-pulse rounded-[1px] bg-adam-blue/90 align-middle"
+              />
+            )}
+          </pre>
+        </div>
+
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-adam-neutral-950 to-transparent"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/StreamingCodeBlock.tsx
+++ b/src/components/chat/StreamingCodeBlock.tsx
@@ -3,6 +3,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 interface StreamingCodeBlockProps {
   code: string;
   isStreaming: boolean;
+  filename?: string;
 }
 
 // Keep it compact — stays inside the chat bubble without swallowing the view.
@@ -15,6 +16,7 @@ const REVEAL_TICK_MS = 28;
 export function StreamingCodeBlock({
   code,
   isStreaming,
+  filename = 'model.scad',
 }: StreamingCodeBlockProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const stickToBottomRef = useRef(true);
@@ -63,8 +65,8 @@ export function StreamingCodeBlock({
     <div className="w-full overflow-hidden rounded-lg border border-white/[0.06] bg-adam-neutral-950/90 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
       <div className="flex h-7 items-center justify-between border-b border-white/[0.06] px-3">
         <div className="flex items-center gap-1.5 text-[10.5px] font-medium uppercase tracking-[0.08em] text-adam-neutral-400">
-          <span className="h-1.5 w-1.5 rounded-full bg-adam-blue/80" />
-          model.scad
+          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-adam-blue/80" />
+          <span className="truncate">{filename}</span>
         </div>
         {showCaret && (
           <div className="flex items-center gap-1.5 text-[10.5px] text-adam-neutral-500">

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -905,7 +905,7 @@ Deno.serve(async (req) => {
               ...finalUserMessage,
             ];
 
-            // Code generation request logic
+            // Code generation request logic (SSE streaming)
             const codeRequestBody: OpenRouterRequest = {
               model,
               messages: [
@@ -913,6 +913,7 @@ Deno.serve(async (req) => {
                 ...codeMessages,
               ],
               max_tokens: 16000,
+              stream: true,
             };
 
             // Also apply thinking to code generation if enabled
@@ -923,8 +924,21 @@ Deno.serve(async (req) => {
               codeRequestBody.max_tokens = 20000;
             }
 
-            const [codeResult, titleResult] = await Promise.allSettled([
-              fetch(OPENROUTER_API_URL, {
+            // Kick off title generation alongside the streamed code.
+            const titlePromise = generateTitleFromMessages(messagesToSend);
+
+            let rawCode = '';
+            let codeGenFailed = false;
+
+            const stripCodeFences = (s: string): string => {
+              let out = s;
+              out = out.replace(/^```(?:openscad)?\s*\n?/, '');
+              out = out.replace(/\n?```\s*$/, '');
+              return out;
+            };
+
+            try {
+              const codeResponse = await fetch(OPENROUTER_API_URL, {
                 method: 'POST',
                 headers: {
                   'Content-Type': 'application/json',
@@ -933,31 +947,76 @@ Deno.serve(async (req) => {
                   'X-Title': 'Adam CAD',
                 },
                 body: JSON.stringify(codeRequestBody),
-              }).then(async (r) => {
-                if (!r.ok) {
-                  const t = await r.text();
-                  throw new Error(`Code gen error: ${r.status} - ${t}`);
+              });
+
+              if (!codeResponse.ok) {
+                const t = await codeResponse.text();
+                throw new Error(
+                  `Code gen error: ${codeResponse.status} - ${t}`,
+                );
+              }
+
+              const codeReader = codeResponse.body?.getReader();
+              if (!codeReader) throw new Error('No code response body');
+
+              const codeDecoder = new TextDecoder();
+              let codeBuffer = '';
+
+              while (true) {
+                const { done, value } = await codeReader.read();
+                if (done) break;
+
+                codeBuffer += codeDecoder.decode(value, { stream: true });
+                const codeLines = codeBuffer.split('\n');
+                codeBuffer = codeLines.pop() || '';
+
+                for (const line of codeLines) {
+                  if (!line || line.startsWith(':')) continue;
+                  if (!line.startsWith('data: ')) continue;
+                  const data = line.slice(6);
+                  if (data === '[DONE]') continue;
+
+                  try {
+                    const chunk = JSON.parse(data);
+                    if (chunk.error) {
+                      throw new Error(
+                        chunk.error.message ||
+                          `OpenRouter error: ${JSON.stringify(chunk.error)}`,
+                      );
+                    }
+                    const deltaContent = chunk.choices?.[0]?.delta?.content;
+                    if (typeof deltaContent === 'string' && deltaContent) {
+                      rawCode += deltaContent;
+                      const streamed = stripCodeFences(rawCode);
+                      content = {
+                        ...content,
+                        artifact: {
+                          title: 'Adam Object',
+                          version: 'v1',
+                          code: streamed,
+                          parameters: [],
+                        },
+                      };
+                      streamMessage(controller, {
+                        ...newMessageData,
+                        content,
+                      });
+                    }
+                  } catch (e) {
+                    console.error('Error parsing code SSE chunk:', e);
+                  }
                 }
-                return r.json();
-              }),
-              generateTitleFromMessages(messagesToSend),
-            ]);
-
-            let code = '';
-            if (
-              codeResult.status === 'fulfilled' &&
-              codeResult.value.choices?.[0]?.message?.content
-            ) {
-              code = codeResult.value.choices[0].message.content.trim();
-            } else if (codeResult.status === 'rejected') {
-              console.error('Code generation failed:', codeResult.reason);
+              }
+            } catch (e) {
+              console.error('Code generation failed:', e);
+              codeGenFailed = true;
             }
 
-            const codeBlockRegex = /^```(?:openscad)?\n?([\s\S]*?)\n?```$/;
-            const match = code.match(codeBlockRegex);
-            if (match) {
-              code = match[1].trim();
-            }
+            const titleResult = await Promise.allSettled([titlePromise]).then(
+              (r) => r[0],
+            );
+
+            const code = stripCodeFences(rawCode.trim()).trim();
 
             let title =
               titleResult.status === 'fulfilled'
@@ -967,8 +1026,14 @@ Deno.serve(async (req) => {
             if (lower.includes('sorry') || lower.includes('apologize'))
               title = 'Adam Object';
 
-            if (!code) {
-              content = markToolAsError(content, toolCall.id);
+            if (codeGenFailed || !code) {
+              content = {
+                ...content,
+                artifact: undefined,
+                toolCalls: (content.toolCalls || []).map((c) =>
+                  c.id === toolCall.id ? { ...c, status: 'error' } : c,
+                ),
+              };
             } else {
               const artifact: ParametricArtifact = {
                 title,

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -991,7 +991,8 @@ Deno.serve(async (req) => {
                 codeBuffer = codeLines.pop() || '';
 
                 for (const line of codeLines) {
-                  if (!line || line.startsWith(':')) continue;
+                  // Skip empty lines, SSE comments (`: OPENROUTER PROCESSING`),
+                  // and anything that isn't a `data:` event.
                   if (!line.startsWith('data: ')) continue;
                   const data = line.slice(6);
                   if (data === '[DONE]') continue;

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -976,34 +976,46 @@ Deno.serve(async (req) => {
                   const data = line.slice(6);
                   if (data === '[DONE]') continue;
 
+                  let chunk: {
+                    error?: { message?: string };
+                    choices?: Array<{
+                      delta?: { content?: string };
+                    }>;
+                  };
                   try {
-                    const chunk = JSON.parse(data);
-                    if (chunk.error) {
-                      throw new Error(
-                        chunk.error.message ||
-                          `OpenRouter error: ${JSON.stringify(chunk.error)}`,
-                      );
-                    }
-                    const deltaContent = chunk.choices?.[0]?.delta?.content;
-                    if (typeof deltaContent === 'string' && deltaContent) {
-                      rawCode += deltaContent;
-                      const streamed = stripCodeFences(rawCode);
-                      content = {
-                        ...content,
-                        artifact: {
-                          title: 'Adam Object',
-                          version: 'v1',
-                          code: streamed,
-                          parameters: [],
-                        },
-                      };
-                      streamMessage(controller, {
-                        ...newMessageData,
-                        content,
-                      });
-                    }
+                    chunk = JSON.parse(data);
                   } catch (e) {
+                    // Malformed chunk — log and skip, don't abort the stream.
                     console.error('Error parsing code SSE chunk:', e);
+                    continue;
+                  }
+
+                  // Surfaced API errors must abort code-gen so the outer
+                  // catch can mark the tool call as failed — never swallow.
+                  if (chunk.error) {
+                    throw new Error(
+                      chunk.error.message ||
+                        `OpenRouter error: ${JSON.stringify(chunk.error)}`,
+                    );
+                  }
+
+                  const deltaContent = chunk.choices?.[0]?.delta?.content;
+                  if (typeof deltaContent === 'string' && deltaContent) {
+                    rawCode += deltaContent;
+                    const streamed = stripCodeFences(rawCode);
+                    content = {
+                      ...content,
+                      artifact: {
+                        title: 'Adam Object',
+                        version: 'v1',
+                        code: streamed,
+                        parameters: [],
+                      },
+                    };
+                    streamMessage(controller, {
+                      ...newMessageData,
+                      content,
+                    });
                   }
                 }
               }

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -675,90 +675,94 @@ Deno.serve(async (req) => {
             buffer = lines.pop() || '';
 
             for (const line of lines) {
-              if (line.startsWith('data: ')) {
-                const data = line.slice(6);
-                if (data === '[DONE]') continue;
+              if (!line.startsWith('data: ')) continue;
+              const data = line.slice(6);
+              if (data === '[DONE]') continue;
 
-                try {
-                  const chunk = JSON.parse(data);
+              let chunk: {
+                error?: { message?: string };
+                choices?: Array<{
+                  delta?: {
+                    content?: string;
+                    reasoning?: string;
+                    tool_calls?: Array<{
+                      index?: number;
+                      id?: string;
+                      function?: { name?: string; arguments?: string };
+                    }>;
+                  };
+                  finish_reason?: string;
+                }>;
+              };
+              try {
+                chunk = JSON.parse(data);
+              } catch (e) {
+                // Malformed chunk — log and skip, don't abort the stream.
+                console.error('Error parsing SSE chunk:', e);
+                continue;
+              }
 
-                  // Detect OpenRouter error responses in the SSE stream
-                  if (chunk.error) {
-                    console.error('OpenRouter stream error:', chunk.error);
-                    throw new Error(
-                      chunk.error.message ||
-                        `OpenRouter error: ${JSON.stringify(chunk.error)}`,
-                    );
-                  }
+              // Surface API errors so the outer catch can mark tools as errored
+              // — never swallow them in the parse-tolerance block above.
+              if (chunk.error) {
+                console.error('OpenRouter stream error:', chunk.error);
+                throw new Error(
+                  chunk.error.message ||
+                    `OpenRouter error: ${JSON.stringify(chunk.error)}`,
+                );
+              }
 
-                  const delta = chunk.choices?.[0]?.delta;
+              const delta = chunk.choices?.[0]?.delta;
+              if (!delta) continue;
 
-                  if (!delta) continue;
+              if (delta.content) {
+                content = {
+                  ...content,
+                  text: (content.text || '') + delta.content,
+                };
+                streamMessage(controller, { ...newMessageData, content });
+              }
 
-                  // Handle text content
-                  if (delta.content) {
+              // delta.reasoning is consumed silently; we don't surface internal
+              // reasoning tokens in the final message.
+
+              if (delta.tool_calls) {
+                for (const toolCall of delta.tool_calls) {
+                  if (toolCall.id) {
+                    currentToolCall = {
+                      id: toolCall.id,
+                      name: toolCall.function?.name || '',
+                      arguments: '',
+                    };
                     content = {
                       ...content,
-                      text: (content.text || '') + delta.content,
+                      toolCalls: [
+                        ...(content.toolCalls || []),
+                        {
+                          name: currentToolCall.name,
+                          id: currentToolCall.id,
+                          status: 'pending',
+                        },
+                      ],
                     };
-                    streamMessage(controller, { ...newMessageData, content });
+                    streamMessage(controller, {
+                      ...newMessageData,
+                      content,
+                    });
                   }
 
-                  // Handle reasoning content (if returned by OpenRouter)
-                  if (delta.reasoning) {
-                    // We can optionally display this, but for now we just consume it so it doesn't break anything
-                    // Or append to text if we want to show it?
-                    // Usually we don't show internal reasoning in the final message unless explicitly requested.
+                  if (toolCall.function?.arguments && currentToolCall) {
+                    currentToolCall.arguments += toolCall.function.arguments;
                   }
-
-                  // Handle tool calls
-                  if (delta.tool_calls) {
-                    for (const toolCall of delta.tool_calls) {
-                      const _index = toolCall.index || 0;
-
-                      // Start of new tool call
-                      if (toolCall.id) {
-                        currentToolCall = {
-                          id: toolCall.id,
-                          name: toolCall.function?.name || '',
-                          arguments: '',
-                        };
-                        content = {
-                          ...content,
-                          toolCalls: [
-                            ...(content.toolCalls || []),
-                            {
-                              name: currentToolCall.name,
-                              id: currentToolCall.id,
-                              status: 'pending',
-                            },
-                          ],
-                        };
-                        streamMessage(controller, {
-                          ...newMessageData,
-                          content,
-                        });
-                      }
-
-                      // Accumulate arguments
-                      if (toolCall.function?.arguments && currentToolCall) {
-                        currentToolCall.arguments +=
-                          toolCall.function.arguments;
-                      }
-                    }
-                  }
-
-                  // Check if tool call is complete (when we get finish_reason)
-                  if (
-                    chunk.choices?.[0]?.finish_reason === 'tool_calls' &&
-                    currentToolCall
-                  ) {
-                    await handleToolCall(currentToolCall);
-                    currentToolCall = null;
-                  }
-                } catch (e) {
-                  console.error('Error parsing SSE chunk:', e);
                 }
+              }
+
+              if (
+                chunk.choices?.[0]?.finish_reason === 'tool_calls' &&
+                currentToolCall
+              ) {
+                await handleToolCall(currentToolCall);
+                currentToolCall = null;
               }
             }
           }
@@ -1040,16 +1044,9 @@ Deno.serve(async (req) => {
               codeGenFailed = true;
             }
 
-            const titleResult = await Promise.allSettled([titlePromise]).then(
-              (r) => r[0],
-            );
-
             const code = stripCodeFences(rawCode.trim()).trim();
 
-            let title =
-              titleResult.status === 'fulfilled'
-                ? titleResult.value
-                : 'Adam Object';
+            let title = await titlePromise.catch(() => 'Adam Object');
             const lower = title.toLowerCase();
             if (lower.includes('sorry') || lower.includes('apologize'))
               title = 'Adam Object';

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -814,6 +814,22 @@ Deno.serve(async (req) => {
             }
           }
 
+          // Safety net: if the outer LLM finished without emitting any text,
+          // tool call, or artifact, surface a retry hint instead of saving
+          // an empty bubble (otherwise isLoading flips false and the UI
+          // renders nothing visible).
+          const hasToolCalls =
+            !!content.toolCalls && content.toolCalls.length > 0;
+          if (!content.artifact && !content.text && !hasToolCalls) {
+            console.error(
+              '[parametric-chat] empty response from model — no text, tool call, or artifact',
+            );
+            content = {
+              ...content,
+              text: "I couldn't generate that — please try again.",
+            };
+          }
+
           let finalMessageData: Message | null = null;
           try {
             const { data } = await supabaseClient


### PR DESCRIPTION
Swap the 'Building CAD...' placeholder for a live, typewriter-revealed code block once the model starts emitting. The parametric-chat edge function now opens an SSE stream against OpenRouter for the code-gen step and pushes partial artifact.code per chunk; the tool call stays 'pending' until the final artifact is ready so the chat UI can swap the generic status row for the streaming block.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams OpenSCAD into the chat so users see code as it’s generated, switching from “Building CAD...” to a live code block once chunks arrive. The streaming block keeps a static “model.scad” header and stays readable as it grows.

- **New Features**
  - Added StreamingCodeBlock with adaptive typewriter reveal, auto‑scroll, compact height, a streaming badge, and a static “model.scad” header with clean truncation for long names.
  - AssistantMessage swaps the pending `build_parametric_model` row for the live code block once `artifact.code` starts streaming and hides ObjectButton until the build completes.
  - Edge function streams SSE from OpenRouter and pushes partial `artifact.code` per chunk, stripping code fences; title generation runs in parallel.

- **Bug Fixes**
  - OpenRouter stream errors now propagate and the SSE prefilter is simplified: JSON parse failures are logged and skipped; `chunk.error` aborts and marks the tool call as error.
  - UI reliability: always render “Building CAD...” for empty parametric replies, and don’t auto re‑stick scroll to bottom if the user scrolled up during reveal.
  - Safety net for empty replies: write a short retry hint if the model finishes without text, tool calls, or an artifact; mark the tool call as error if streaming fails or produces no code.

<sup>Written for commit bbe46aa8ba9044426e18ef42c0fba1458ba9bb2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

