### PR TITLE
feat(mesh): upgrade upscale + fast-tier fal endpoints

### DIFF
--- a/supabase/functions/fal-webhook/index.ts
+++ b/supabase/functions/fal-webhook/index.ts
@@ -153,7 +153,7 @@ Deno.serve(async (request) => {
       debugLog('Using model_glb.url:', payload.model_glb.url);
       modelUrl = payload.model_glb.url;
     } else if (payload.model_urls?.glb?.url) {
-      // Meshy v6 / Hunyuan v3.1 Pro alternative format
+      // Meshy v6 / Hunyuan v3.1 Pro / Tripo H3.1 alternative format
       debugLog('Using model_urls.glb.url:', payload.model_urls.glb.url);
       modelUrl = payload.model_urls.glb.url;
     } else if (payload.textured_glb?.url) {

--- a/supabase/functions/fal-webhook/index.ts
+++ b/supabase/functions/fal-webhook/index.ts
@@ -149,11 +149,11 @@ Deno.serve(async (request) => {
 
     // Handle different model response formats
     if (payload.model_glb?.url) {
-      // SAM 3D Objects and Meshy v6 Preview format
+      // SAM 3D Objects, Meshy v6, Hunyuan v3.1 Pro format
       debugLog('Using model_glb.url:', payload.model_glb.url);
       modelUrl = payload.model_glb.url;
     } else if (payload.model_urls?.glb?.url) {
-      // Meshy v6 Preview alternative format
+      // Meshy v6 / Hunyuan v3.1 Pro alternative format
       debugLog('Using model_urls.glb.url:', payload.model_urls.glb.url);
       modelUrl = payload.model_urls.glb.url;
     } else if (payload.textured_glb?.url) {
@@ -173,15 +173,15 @@ Deno.serve(async (request) => {
       debugLog('Using glb (string):', payload.glb);
       modelUrl = payload.glb;
     } else if (payload.model_mesh?.url) {
-      // Tripo v2.5 and Trellis format
+      // Tripo H3.1 and Trellis format
       debugLog('Using model_mesh.url:', payload.model_mesh.url);
       modelUrl = payload.model_mesh.url;
     } else if (payload.base_model?.url) {
-      // Tripo v2.5 with texture='no' (textureless)
+      // Tripo H3.1 with texture=false (textureless)
       debugLog('Using base_model.url (textureless):', payload.base_model.url);
       modelUrl = payload.base_model.url;
     } else if (payload.pbr_model?.url) {
-      // Tripo v2.5 with PBR enabled
+      // Tripo H3.1 with pbr=true
       debugLog('Using pbr_model.url:', payload.pbr_model.url);
       modelUrl = payload.pbr_model.url;
     } else if (payload.model?.url) {

--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -488,7 +488,7 @@ Deno.serve(async (req) => {
                 : Deno.env.get('SUPABASE_URL')
               )?.trim() ?? '';
 
-            await fal.queue.submit('fal-ai/hunyuan3d-v3/image-to-3d', {
+            await fal.queue.submit('fal-ai/hunyuan-3d/v3.1/pro/image-to-3d', {
               input: {
                 input_image_url: imageUrl,
                 enable_pbr: true,
@@ -497,7 +497,9 @@ Deno.serve(async (req) => {
               webhookUrl: `${supabaseHost}/functions/v1/fal-webhook?id=${newMeshData.id}`,
             });
 
-            debugLog('Successfully submitted to Hunyuan3D V3 for upscaling');
+            debugLog(
+              'Successfully submitted to Hunyuan3D v3.1 Pro for upscaling',
+            );
 
             // Create a preview for the upscaled mesh (non-blocking)
             createHunyuanPreview(
@@ -1401,22 +1403,23 @@ Output:`;
         throw new Error('No valid image found for textureless mesh generation');
       }
 
-      // Submit to Tripo with the generated image
+      // Submit to Tripo H3.1 with the generated image
       const tripoInput = {
         image_url: imageInputs[0],
-        texture: 'no' as const,
+        texture: false,
+        pbr: false,
         orientation: 'default' as const,
         // Cap face count for textureless generations at 50k
         ...(polygonCount !== undefined
           ? { face_limit: Math.min(polygonCount, TEXTURELESS_MAX_POLYGONS) }
           : { face_limit: TEXTURELESS_MAX_POLYGONS }),
       };
-      await fal.queue.submit('tripo3d/tripo/v2.5/image-to-3d', {
+      await fal.queue.submit('tripo3d/h3.1/image-to-3d', {
         input: tripoInput,
         webhookUrl: `${supabaseHost}/functions/v1/fal-webhook?id=${meshId}`,
       });
       debugLog(
-        'Successfully submitted to Tripo textureless with conversational context',
+        'Successfully submitted to Tripo H3.1 textureless with conversational context',
       );
 
       // Create preview using the generated image


### PR DESCRIPTION
Swap to newer generations with matching schemas:
- upscale: hunyuan3d-v3 -> hunyuan-3d/v3.1/pro (same input shape, superset)
- fast textureless: tripo3d/v2.5 -> tripo3d/h3.1 (texture enum -> boolean; explicit pbr:false since H3.1 auto-enables textures when pbr defaults to true)

Webhook already parses both new output shapes (model_glb.url for Hunyuan Pro, model_mesh.url/base_model.url for Tripo H3.1).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded mesh upscaling and fast textureless generation to the latest FAL endpoints for better quality and schema alignment. Inputs were updated for the new models; webhooks prefer the new output fields and remain backward compatible.

- **New Features**
  - Upscale: switch to `fal-ai/hunyuan-3d/v3.1/pro/image-to-3d` (same input); webhook reads `model_glb.url` or `model_urls.glb.url`.
  - Fast textureless: switch to `tripo3d/h3.1/image-to-3d`; set `texture: false` and `pbr: false`; webhook prefers `model_urls.glb.url` and still accepts `model_mesh.url`/`base_model.url`.

- **Refactors**
  - Clarified webhook comments for Tripo H3.1 and Hunyuan v3.1 Pro, including the `model_urls.glb` branch; no behavior change.

<sup>Written for commit cecaf0d6d29ac86658be28611608cbdad37548c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

