### PR TITLE
fix(history): list/visual toggle hover regression

### DIFF
--- a/src/views/HistoryView.tsx
+++ b/src/views/HistoryView.tsx
@@ -299,15 +299,15 @@ export function HistoryView() {
 
             {/* View Toggle */}
             <div
-              role="tablist"
+              role="group"
               aria-label="View mode"
               className="flex items-center gap-1 rounded-lg border border-adam-neutral-700 bg-adam-background-2 p-1"
             >
               <Button
                 variant="ghost"
                 size="sm"
-                role="tab"
-                aria-selected={viewMode === 'list'}
+                aria-pressed={viewMode === 'list'}
+                aria-label="List view"
                 onClick={() => setViewMode('list')}
                 className={`h-8 px-3 transition-colors duration-150 ${
                   viewMode === 'list'
@@ -321,8 +321,8 @@ export function HistoryView() {
               <Button
                 variant="ghost"
                 size="sm"
-                role="tab"
-                aria-selected={viewMode === 'visual'}
+                aria-pressed={viewMode === 'visual'}
+                aria-label="Visual view"
                 onClick={() => setViewMode('visual')}
                 className={`h-8 px-3 transition-colors duration-150 ${
                   viewMode === 'visual'

--- a/src/views/HistoryView.tsx
+++ b/src/views/HistoryView.tsx
@@ -298,15 +298,21 @@ export function HistoryView() {
             </h1>
 
             {/* View Toggle */}
-            <div className="flex items-center gap-2 rounded-lg border border-adam-neutral-700 bg-adam-background-2 p-1">
+            <div
+              role="tablist"
+              aria-label="View mode"
+              className="flex items-center gap-1 rounded-lg border border-adam-neutral-700 bg-adam-background-2 p-1"
+            >
               <Button
                 variant="ghost"
                 size="sm"
+                role="tab"
+                aria-selected={viewMode === 'list'}
                 onClick={() => setViewMode('list')}
-                className={`h-8 px-3 ${
+                className={`h-8 px-3 transition-colors duration-150 ${
                   viewMode === 'list'
-                    ? 'bg-adam-neutral-950 text-adam-neutral-50'
-                    : 'text-adam-neutral-400 hover:bg-transparent hover:text-adam-neutral-50'
+                    ? 'bg-adam-neutral-950 text-adam-neutral-50 hover:bg-adam-neutral-950 hover:text-adam-neutral-50'
+                    : 'text-adam-neutral-400 hover:bg-adam-neutral-950/40 hover:text-adam-neutral-50'
                 }`}
               >
                 <List className="mr-2 h-4 w-4" />
@@ -315,11 +321,13 @@ export function HistoryView() {
               <Button
                 variant="ghost"
                 size="sm"
+                role="tab"
+                aria-selected={viewMode === 'visual'}
                 onClick={() => setViewMode('visual')}
-                className={`h-8 px-3 ${
+                className={`h-8 px-3 transition-colors duration-150 ${
                   viewMode === 'visual'
-                    ? 'bg-adam-neutral-950 text-adam-neutral-50'
-                    : 'text-adam-neutral-400 hover:bg-transparent hover:text-adam-neutral-50'
+                    ? 'bg-adam-neutral-950 text-adam-neutral-50 hover:bg-adam-neutral-950 hover:text-adam-neutral-50'
+                    : 'text-adam-neutral-400 hover:bg-adam-neutral-950/40 hover:text-adam-neutral-50'
                 }`}
               >
                 <LayoutGrid className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary

- The active pill in the History page's `List | Visual` segmented control changed color on hover. The shadcn `<Button variant=\"ghost\">` adds `hover:bg-accent hover:text-accent-foreground`. The inactive branch overrode it with `hover:bg-transparent`; the active branch did not, so hovering the selected pill flashed it to the accent color.
- Pin the active pill's hover to its selected colors so the selection holds steady on hover.
- Give the inactive pill a subtle `hover:bg-adam-neutral-950/40` so it has clickable affordance instead of only a text-color shift.
- Add `transition-colors duration-150` so state changes are smooth, not abrupt.
- Add `role=\"tablist\"` / `role=\"tab\"` / `aria-selected` to the segmented control so screen readers announce the selection state.

All changes are in [src/views/HistoryView.tsx:301-330](src/views/HistoryView.tsx).

## Test plan

- [ ] Open `/history` (Past Creations).
- [ ] Hover the currently-selected pill — its background and text color should not change.
- [ ] Hover the unselected pill — it should pick up a faint dark background and brighter text.
- [ ] Click between List and Visual — the transition should ease over ~150ms instead of snapping.
- [ ] With a screen reader (or DevTools accessibility tree), confirm the container is announced as a tab list and the active pill as the selected tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the hover color regression in the History page’s “List | Visual” toggle so the selected view doesn’t change on hover, and improves affordance and accessibility.

- **Bug Fixes**
  - Active pill stays on selected colors; overrides `ghost` hover styles and adds `transition-colors duration-150`.
  - Inactive pill gets a subtle `bg-adam-neutral-950/40` hover and brighter text on hover.
  - A11y: model as a labeled `role="group"` with per-button `aria-pressed` and `aria-label` (replaces partial tab roles).

<sup>Written for commit 2193799a7b158228a7b46f10ba69fb9b7a83ee06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

