### PR TITLE
fix(mesh): revert fast path to Tripo v2.5 — H3.1 is 500ing downstream

### DIFF
--- a/supabase/functions/fal-webhook/index.ts
+++ b/supabase/functions/fal-webhook/index.ts
@@ -153,7 +153,7 @@ Deno.serve(async (request) => {
       debugLog('Using model_glb.url:', payload.model_glb.url);
       modelUrl = payload.model_glb.url;
     } else if (payload.model_urls?.glb?.url) {
-      // Meshy v6 / Hunyuan v3.1 Pro / Tripo H3.1 alternative format
+      // Meshy v6 / Hunyuan v3.1 Pro alternative format
       debugLog('Using model_urls.glb.url:', payload.model_urls.glb.url);
       modelUrl = payload.model_urls.glb.url;
     } else if (payload.textured_glb?.url) {
@@ -173,15 +173,15 @@ Deno.serve(async (request) => {
       debugLog('Using glb (string):', payload.glb);
       modelUrl = payload.glb;
     } else if (payload.model_mesh?.url) {
-      // Tripo H3.1 and Trellis format
+      // Tripo v2.5 and Trellis format
       debugLog('Using model_mesh.url:', payload.model_mesh.url);
       modelUrl = payload.model_mesh.url;
     } else if (payload.base_model?.url) {
-      // Tripo H3.1 with texture=false (textureless)
+      // Tripo v2.5 with texture='no' (textureless)
       debugLog('Using base_model.url (textureless):', payload.base_model.url);
       modelUrl = payload.base_model.url;
     } else if (payload.pbr_model?.url) {
-      // Tripo H3.1 with pbr=true
+      // Tripo v2.5 with PBR enabled
       debugLog('Using pbr_model.url:', payload.pbr_model.url);
       modelUrl = payload.pbr_model.url;
     } else if (payload.model?.url) {

--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -488,18 +488,35 @@ Deno.serve(async (req) => {
                 : Deno.env.get('SUPABASE_URL')
               )?.trim() ?? '';
 
-            await fal.queue.submit('fal-ai/hunyuan-3d/v3.1/pro/image-to-3d', {
-              input: {
-                input_image_url: imageUrl,
-                enable_pbr: true,
-                face_count: 500000,
-              },
-              webhookUrl: `${supabaseHost}/functions/v1/fal-webhook?id=${newMeshData.id}`,
-            });
-
-            debugLog(
-              'Successfully submitted to Hunyuan3D v3.1 Pro for upscaling',
-            );
+            const hunyuanInput = {
+              input_image_url: imageUrl,
+              enable_pbr: true,
+              face_count: 500000,
+            };
+            try {
+              await fal.queue.submit('fal-ai/hunyuan-3d/v3.1/pro/image-to-3d', {
+                input: hunyuanInput,
+                webhookUrl: `${supabaseHost}/functions/v1/fal-webhook?id=${newMeshData.id}`,
+              });
+              debugLog(
+                'Successfully submitted to Hunyuan3D v3.1 Pro for upscaling',
+              );
+            } catch (submitError) {
+              const errObj = submitError as {
+                body?: unknown;
+                status?: number;
+              };
+              console.error('Hunyuan v3.1 Pro submit failed:', {
+                message:
+                  submitError instanceof Error
+                    ? submitError.message
+                    : String(submitError),
+                status: errObj?.status,
+                body: errObj?.body,
+                input: hunyuanInput,
+              });
+              throw submitError;
+            }
 
             // Create a preview for the upscaled mesh (non-blocking)
             createHunyuanPreview(
@@ -1414,13 +1431,27 @@ Output:`;
           ? { face_limit: Math.min(polygonCount, TEXTURELESS_MAX_POLYGONS) }
           : { face_limit: TEXTURELESS_MAX_POLYGONS }),
       };
-      await fal.queue.submit('tripo3d/h3.1/image-to-3d', {
-        input: tripoInput,
-        webhookUrl: `${supabaseHost}/functions/v1/fal-webhook?id=${meshId}`,
-      });
-      debugLog(
-        'Successfully submitted to Tripo H3.1 textureless with conversational context',
-      );
+      try {
+        await fal.queue.submit('tripo3d/h3.1/image-to-3d', {
+          input: tripoInput,
+          webhookUrl: `${supabaseHost}/functions/v1/fal-webhook?id=${meshId}`,
+        });
+        debugLog(
+          'Successfully submitted to Tripo H3.1 textureless with conversational context',
+        );
+      } catch (submitError) {
+        const errObj = submitError as { body?: unknown; status?: number };
+        console.error('Tripo H3.1 submit failed:', {
+          message:
+            submitError instanceof Error
+              ? submitError.message
+              : String(submitError),
+          status: errObj?.status,
+          body: errObj?.body,
+          input: tripoInput,
+        });
+        throw submitError;
+      }
 
       // Create preview using the generated image
       await createHunyuanPreview(

--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -1420,11 +1420,12 @@ Output:`;
         throw new Error('No valid image found for textureless mesh generation');
       }
 
-      // Submit to Tripo H3.1 with the generated image
+      // Submit to Tripo v2.5 with the generated image
+      // NOTE: H3.1 (newer model) currently returns downstream_service_error on
+      // textureless requests (Tripo-side 500). Reverted to v2.5 until fixed.
       const tripoInput = {
         image_url: imageInputs[0],
-        texture: false,
-        pbr: false,
+        texture: 'no' as const,
         orientation: 'default' as const,
         // Cap face count for textureless generations at 50k
         ...(polygonCount !== undefined
@@ -1432,16 +1433,16 @@ Output:`;
           : { face_limit: TEXTURELESS_MAX_POLYGONS }),
       };
       try {
-        await fal.queue.submit('tripo3d/h3.1/image-to-3d', {
+        await fal.queue.submit('tripo3d/tripo/v2.5/image-to-3d', {
           input: tripoInput,
           webhookUrl: `${supabaseHost}/functions/v1/fal-webhook?id=${meshId}`,
         });
         debugLog(
-          'Successfully submitted to Tripo H3.1 textureless with conversational context',
+          'Successfully submitted to Tripo v2.5 textureless with conversational context',
         );
       } catch (submitError) {
         const errObj = submitError as { body?: unknown; status?: number };
-        console.error('Tripo H3.1 submit failed:', {
+        console.error('Tripo v2.5 submit failed:', {
           message:
             submitError instanceof Error
               ? submitError.message


### PR DESCRIPTION
## Summary

- Reverts the fast/textureless path from `tripo3d/h3.1/image-to-3d` back to `tripo3d/tripo/v2.5/image-to-3d` (with `texture: 'no'`). Tripo H3.1 is returning `downstream_service_error` (HTTP 500 from Tripo's backend) for schema-valid textureless requests.
- Keeps the Hunyuan v3.1 Pro upscale endpoint unchanged — not affected by this bug.
- Adds try/catch diagnostic logging around both `fal.queue.submit` calls so any future fal failure surfaces the full response body (status, body, input) in function logs instead of a generic "Mesh generation failed".

## Evidence

Real fal webhook payload from the failing prod calls:

```
"status": "ERROR"
"type": "downstream_service_error"
"msg": "Downstream service error"
"error": "Unexpected status code: 500"
"gateway_request_id": "019da99b-4073-71c3-86f8-f9f668a9b494"
```

fal echoed back the full input — every field (`texture:false`, `pbr:false`, `face_limit:50000`, `orientation:'default'`, etc.) matches the H3.1 OpenAPI schema. Our input is valid; Tripo's backend is the failure.

Ref: https://docs.fal.ai/errors#downstream_service_error

## Test plan

- [x] Deployed to prod (AdamChat) ahead of this PR to restore service
- [ ] Textureless generation works on prod after merge
- [ ] Upscale (Hunyuan v3.1 Pro) continues to work — unchanged by this PR
- [ ] Re-attempt H3.1 swap in a follow-up once fal/Tripo resolve the downstream 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverted textureless mesh generation from `tripo3d/h3.1/image-to-3d` to `tripo3d/tripo/v2.5/image-to-3d` to stop downstream 500s. Added better submit error logging. Hunyuan v3.1 Pro upscale is unchanged.

- **Bug Fixes**
  - Textureless path now uses `tripo3d/tripo/v2.5/image-to-3d` with `texture: 'no'` and a `face_limit` capped at 50k. Reverts from `tripo3d/h3.1/image-to-3d` which returned `downstream_service_error` (HTTP 500).
  - Wrapped `fal.queue.submit` for Tripo and `fal-ai/hunyuan-3d/v3.1/pro/image-to-3d` in try/catch to log status, response body, and input on failure. No behavior change on success.

<sup>Written for commit d32d1f00bd859d9e0dd9522ec0d8a55d96915022. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

