### PR TITLE
fix(credits): skip hover card on mobile, tap routes to /subscription

### DIFF
--- a/src/components/CreditsButton.tsx
+++ b/src/components/CreditsButton.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { UpgradeModal } from '@/components/UpgradeModal';
 import { useAuth } from '@/contexts/AuthContext';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { cn } from '@/lib/utils';
 
 function formatCompact(n: number): string {
@@ -32,6 +33,7 @@ export function CreditsButton() {
     subscriptionTokens,
     subscriptionTokenLimit,
   } = useAuth();
+  const isMobile = useIsMobile();
 
   const [open, setOpen] = useState(false);
   // Card opened by click stays pinned — mouse-leave alone won't dismiss it.
@@ -66,6 +68,24 @@ export function CreditsButton() {
   }, []);
 
   if (!user) return null;
+
+  if (isMobile) {
+    return (
+      <Link
+        to="/subscription"
+        aria-label="View credits"
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-full',
+          'bg-adam-neutral-950 px-3 py-1.5 text-sm font-medium',
+          'text-adam-neutral-10 shadow-sm',
+          'border border-white/5',
+        )}
+      >
+        <Zap className="h-3.5 w-3.5" fill="currentColor" />
+        <span>{formatCompact(totalTokens)}</span>
+      </Link>
+    );
+  }
 
   const isFree = subscription === 'free';
   const periodLabel = isFree ? '/ day' : '/ mo';

--- a/src/components/CreditsButton.tsx
+++ b/src/components/CreditsButton.tsx
@@ -67,6 +67,22 @@ export function CreditsButton() {
     };
   }, []);
 
+  // Drop any pinned/hover state when crossing into the mobile renderer so
+  // resizing back to desktop doesn't re-surface a stale popover.
+  useEffect(() => {
+    if (!isMobile) return;
+    setOpen(false);
+    setPinnedByClick(false);
+    if (openTimer.current) {
+      window.clearTimeout(openTimer.current);
+      openTimer.current = null;
+    }
+    if (closeTimer.current) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  }, [isMobile]);
+
   if (!user) return null;
 
   if (isMobile) {


### PR DESCRIPTION
## Summary

- On mobile (`< 640px`), the `CreditsButton` now renders as a plain `Link` to `/subscription` — no hover-intent handlers, no popover card, no hover-state classes.
- Desktop behavior is unchanged: hover opens the credits breakdown card, click pins it.

## Why

On touch devices the popover would pop open after a tap (sticky-hover) and the pill could flash its hover background. Per request, the mobile pill should be purely a navigational shortcut to the subscriptions page.

## Test plan

- [ ] On a viewport < 640px, tap the credits pill on `/` → navigates to `/subscription` without flashing a hover card or hover background.
- [ ] On desktop (≥ 640px), hover still opens the popover and clicking still pins it; "View plans" link and "Upgrade" button still work.
- [ ] Resizing across the 640px breakpoint swaps between the two renderers cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On mobile (<640px), the credits pill now renders as a plain link to `/subscription` with no hover handlers or popover card, fixing sticky-hover and hover-flash on touch. Entering mobile clears any open/pinned popover state and timers so resizing back to desktop doesn’t surface a stale card; desktop hover and click-to-pin behavior is unchanged.

<sup>Written for commit 991beb72060ffb3a1996b886b2163ce5d34cd358. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

