### PR TITLE
fix(edge): replace retired Haiku 3 model with Haiku 4.5

### DIFF
--- a/supabase/functions/creative-chat/index.ts
+++ b/supabase/functions/creative-chat/index.ts
@@ -291,7 +291,7 @@ Examples:
 
       const suggestionResponse = await anthropic.messages.create(
         {
-          model: 'claude-3-haiku-20240307',
+          model: 'claude-haiku-4-5-20251001',
           max_tokens: 200,
           messages: [
             {

--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -429,7 +429,7 @@ Deno.serve(async (req) => {
 
             // Stream the message generation using Claude
             const stream = await anthropic.messages.create({
-              model: 'claude-3-haiku-20240307',
+              model: 'claude-haiku-4-5-20251001',
               max_tokens: 100,
               system: upscaleSystemPrompt,
               messages: [

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -193,7 +193,7 @@ async function generateTitleFromMessages(
         'X-Title': 'Adam CAD',
       },
       body: JSON.stringify({
-        model: 'anthropic/claude-3.5-haiku',
+        model: 'anthropic/claude-haiku-4.5',
         max_tokens: 30,
         messages: [
           { role: 'system', content: titleSystemPrompt },

--- a/supabase/functions/prompt-generator/index.ts
+++ b/supabase/functions/prompt-generator/index.ts
@@ -166,7 +166,7 @@ Return only the enhanced prompt text, no introductory phrases.`;
 
     // Configure Claude API call
     const response = await anthropic.messages.create({
-      model: 'claude-3-haiku-20240307',
+      model: 'claude-haiku-4-5-20251001',
       max_tokens: 200,
       system: systemPrompt,
       messages: [

--- a/supabase/functions/title-generator/index.ts
+++ b/supabase/functions/title-generator/index.ts
@@ -102,7 +102,7 @@ Deno.serve(async (req) => {
   try {
     // Configure Claude API call
     const response = await anthropic.messages.create({
-      model: 'claude-3-haiku-20240307',
+      model: 'claude-haiku-4-5-20251001',
       max_tokens: 100,
       system: TITLE_SYSTEM_PROMPT,
       messages: [userMessage],


### PR DESCRIPTION
## Summary

- Magic-wand prompt generator was throwing `FunctionsHttpError: Edge Function returned a non-2xx status code` on every click. Root cause: the edge function calls Anthropic with `claude-3-haiku-20240307`, which Anthropic retired in 2025.
- Swept the rest of the edge functions on the same retired model: `title-generator`, `creative-chat` (the 2-suggestion call), `mesh` (upscale messaging), and `parametric-chat` (title generation via OpenRouter, was on `anthropic/claude-3.5-haiku` which is also retired).
- All now target Haiku 4.5 (`claude-haiku-4-5-20251001` direct; `anthropic/claude-haiku-4.5` on OpenRouter, matching the existing `anthropic/claude-opus-4.7` slug pattern in `src/lib/utils.ts`).

## Test plan

- [ ] Deploy: `supabase functions deploy prompt-generator title-generator creative-chat mesh parametric-chat`
- [ ] Magic-wand on an empty prompt → returns a creative/parametric suggestion
- [ ] Magic-wand with existing text → returns an augmented prompt
- [ ] New conversation gets an auto-generated title (title-generator)
- [ ] Creative chat shows 2 follow-up suggestion chips after a response
- [ ] Mesh upscale shows the streamed "fun message" while upscaling
- [ ] Parametric-chat conversation gets an auto-generated title
- [ ] Confirm OpenRouter accepts `anthropic/claude-haiku-4.5` slug (parametric-chat). If not, adjust to whatever OpenRouter's current Haiku 4.5 slug is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced retired Anthropic Haiku models across all edge functions to stop 500s and restore prompt generation, titles, suggestions, and upscale messaging. This fixes the magic-wand FunctionsHttpError and aligns OpenRouter slugs with current usage.

- **Bug Fixes**
  - `prompt-generator`, `title-generator`, `creative-chat` (suggestions), `mesh` (upscale message): `claude-3-haiku-20240307` → `claude-haiku-4-5-20251001`
  - `parametric-chat` (title via OpenRouter): `anthropic/claude-3.5-haiku` → `anthropic/claude-haiku-4.5`

- **Migration**
  - Deploy updated functions: `supabase functions deploy prompt-generator title-generator creative-chat mesh parametric-chat`

<sup>Written for commit d60e15553bf36a93c80f119ee3edb542c10ba7f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

