### PR TITLE
feat(mesh): use gpt-image-2 as default image model, nano banana pro as fallback

### DIFF
--- a/supabase/functions/.env.template
+++ b/supabase/functions/.env.template
@@ -5,6 +5,7 @@ NGROK_URL="<NGROK URL>"
 
 SENTRY_DSN="<Sentry DSN>"
 OPENROUTER_API_KEY="<Test OpenRouter API Key>"
+OPENAI_API_KEY="<OpenAI API Key for gpt-image-2 via Responses API>"
 ADAM_URL="<Adam URL or dev URL>"
 GOOGLE_API_KEY="<Google API Key>"
 FAL_KEY="<FAL API Key>"

--- a/supabase/functions/_shared/imageGen.ts
+++ b/supabase/functions/_shared/imageGen.ts
@@ -2,7 +2,7 @@ import { Buffer } from 'node:buffer';
 import { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.49.9';
 import { GoogleGenAI, Modality } from 'npm:@google/genai';
 import { fal } from 'npm:@fal-ai/client';
-import OpenAI from 'npm:openai';
+import OpenAI from 'npm:openai@^6.34.0';
 import { reformatSignedUrl } from './messageUtils.ts';
 
 const DEBUG_LOGS =
@@ -141,28 +141,26 @@ export const generateImageWithGptImage2 = async (
 
     const imageArrayBuffer = await imageData.arrayBuffer();
     const base64Image = Buffer.from(imageArrayBuffer).toString('base64');
+    const mimeType =
+      imageData.type && imageData.type.startsWith('image/')
+        ? imageData.type
+        : 'image/png';
 
     content.push({
       type: 'input_image',
-      image_url: `data:image/png;base64,${base64Image}`,
+      image_url: `data:${mimeType};base64,${base64Image}`,
       detail: 'auto',
     });
   }
 
-  // deno-lint-ignore no-explicit-any
-  const response = await (openAI as any).responses.create({
-    model: 'gpt-5.1',
+  const response = await openAI.responses.create({
+    model: 'gpt-5',
     input: [{ role: 'user', content }],
     tools: [{ type: 'image_generation', model: 'gpt-image-2' }],
   });
 
-  const outputItems: Array<{ type: string; result?: string }> = Array.isArray(
-    response?.output,
-  )
-    ? response.output
-    : [];
-  const imageCalls = outputItems.filter(
-    (item) => item.type === 'image_generation_call',
+  const imageCalls = response.output.flatMap((item) =>
+    item.type === 'image_generation_call' ? [item] : [],
   );
   const base64Result = imageCalls[imageCalls.length - 1]?.result;
 

--- a/supabase/functions/_shared/imageGen.ts
+++ b/supabase/functions/_shared/imageGen.ts
@@ -188,10 +188,11 @@ export const generateImageWithGptImage2 = async (
     });
   }
 
-  // gpt-4o is the lightweight orchestrator for the Responses API
-  // image_generation tool; gpt-image-2 is the actual image model invoked.
+  // gpt-5.4 is the canonical orchestrator for the Responses API
+  // image_generation tool per OpenAI's docs; gpt-image-2 is the actual
+  // image model invoked via the tool.
   const response = await openAI.responses.create({
-    model: 'gpt-4o',
+    model: 'gpt-5.4',
     input,
     tools: [
       {

--- a/supabase/functions/_shared/imageGen.ts
+++ b/supabase/functions/_shared/imageGen.ts
@@ -153,8 +153,10 @@ export const generateImageWithGptImage2 = async (
     });
   }
 
+  // gpt-4o is the lightweight orchestrator for the Responses API
+  // image_generation tool; gpt-image-2 is the actual image model invoked.
   const response = await openAI.responses.create({
-    model: 'gpt-5',
+    model: 'gpt-4o',
     input: [{ role: 'user', content }],
     tools: [{ type: 'image_generation', model: 'gpt-image-2' }],
   });

--- a/supabase/functions/_shared/imageGen.ts
+++ b/supabase/functions/_shared/imageGen.ts
@@ -177,8 +177,10 @@ export const generateImageWithGptImage2 = async (
         result: string | null;
         status: 'completed';
       }
-  > = [{ role: 'user', content }];
+  > = [];
 
+  // Prior assistant-side image_generation_call must precede the new user
+  // message so the model sees the image it produced before the edit request.
   if (priorImageCallId) {
     input.push({
       type: 'image_generation_call',
@@ -187,6 +189,8 @@ export const generateImageWithGptImage2 = async (
       status: 'completed',
     });
   }
+
+  input.push({ role: 'user', content });
 
   // gpt-5.4 is the canonical orchestrator for the Responses API
   // image_generation tool per OpenAI's docs; gpt-image-2 is the actual

--- a/supabase/functions/_shared/imageGen.ts
+++ b/supabase/functions/_shared/imageGen.ts
@@ -105,9 +105,19 @@ export const generateImageWithGemini = async (
 };
 */
 
+export type GptImage2Result = {
+  imageBytes: Buffer;
+  imageCallId: string | null;
+};
+
 /**
  * Generates an image with gpt-image-2 via the OpenAI Responses API.
  * This is the default image model for mesh mode.
+ *
+ * Multi-turn: when `priorImageCallId` is provided, the prior
+ * image_generation_call is referenced by ID (the canonical edit pattern)
+ * instead of re-encoding the image as base64. Newly uploaded references
+ * (no prior call ID) fall through to input_image base64.
  */
 export const generateImageWithGptImage2 = async (
   supabaseClient: SupabaseClient,
@@ -116,12 +126,14 @@ export const generateImageWithGptImage2 = async (
   conversationId: string,
   prompt: string,
   images: string[],
-): Promise<Buffer> => {
+  priorImageCallId: string | null,
+): Promise<GptImage2Result> => {
   debugLog('Generating image with gpt-image-2 via Responses API', {
     userId,
     conversationId,
     prompt,
     imagesCount: images.length,
+    priorImageCallId,
   });
 
   const content: Array<
@@ -129,7 +141,11 @@ export const generateImageWithGptImage2 = async (
     | { type: 'input_image'; image_url: string; detail: 'auto' }
   > = [{ type: 'input_text', text: prompt || 'Generate an image' }];
 
-  if (images.length > 0) {
+  // Base64 path is only used when we have no prior gpt-image-2 call to
+  // reference (e.g. a freshly uploaded user image).
+  const shouldEncodeReference = !priorImageCallId && images.length > 0;
+
+  if (shouldEncodeReference) {
     const latestImageId = images[images.length - 1];
     const { data: imageData } = await supabaseClient.storage
       .from('images')
@@ -153,25 +169,61 @@ export const generateImageWithGptImage2 = async (
     });
   }
 
+  const input: Array<
+    | { role: 'user'; content: typeof content }
+    | {
+        type: 'image_generation_call';
+        id: string;
+        result: string | null;
+        status: 'completed';
+      }
+  > = [{ role: 'user', content }];
+
+  if (priorImageCallId) {
+    input.push({
+      type: 'image_generation_call',
+      id: priorImageCallId,
+      result: null,
+      status: 'completed',
+    });
+  }
+
   // gpt-4o is the lightweight orchestrator for the Responses API
   // image_generation tool; gpt-image-2 is the actual image model invoked.
   const response = await openAI.responses.create({
     model: 'gpt-4o',
-    input: [{ role: 'user', content }],
-    tools: [{ type: 'image_generation', model: 'gpt-image-2' }],
+    input,
+    tools: [
+      {
+        type: 'image_generation',
+        model: 'gpt-image-2',
+        quality: 'high',
+        size: '1024x1024',
+        output_format: 'png',
+        background: 'opaque',
+        moderation: 'low',
+      },
+    ],
   });
 
   const imageCalls = response.output.flatMap((item) =>
     item.type === 'image_generation_call' ? [item] : [],
   );
-  const base64Result = imageCalls[imageCalls.length - 1]?.result;
+  const latestCall = imageCalls[imageCalls.length - 1];
 
-  if (!base64Result) {
+  if (!latestCall?.result) {
     throw new Error('No generated image data from gpt-image-2');
   }
 
-  debugLog('Successfully generated image with gpt-image-2');
-  return Buffer.from(base64Result, 'base64');
+  debugLog('Successfully generated image with gpt-image-2', {
+    imageCallId: latestCall.id,
+    status: latestCall.status,
+  });
+
+  return {
+    imageBytes: Buffer.from(latestCall.result, 'base64'),
+    imageCallId: latestCall.id,
+  };
 };
 
 export const generateImageWithGeminiMultiTurn = async (

--- a/supabase/functions/_shared/imageGen.ts
+++ b/supabase/functions/_shared/imageGen.ts
@@ -2,6 +2,7 @@ import { Buffer } from 'node:buffer';
 import { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2.49.9';
 import { GoogleGenAI, Modality } from 'npm:@google/genai';
 import { fal } from 'npm:@fal-ai/client';
+import OpenAI from 'npm:openai';
 import { reformatSignedUrl } from './messageUtils.ts';
 
 const DEBUG_LOGS =
@@ -103,6 +104,75 @@ export const generateImageWithGemini = async (
   return imageBytes;
 };
 */
+
+/**
+ * Generates an image with gpt-image-2 via the OpenAI Responses API.
+ * This is the default image model for mesh mode.
+ */
+export const generateImageWithGptImage2 = async (
+  supabaseClient: SupabaseClient,
+  openAI: OpenAI,
+  userId: string,
+  conversationId: string,
+  prompt: string,
+  images: string[],
+): Promise<Buffer> => {
+  debugLog('Generating image with gpt-image-2 via Responses API', {
+    userId,
+    conversationId,
+    prompt,
+    imagesCount: images.length,
+  });
+
+  const content: Array<
+    | { type: 'input_text'; text: string }
+    | { type: 'input_image'; image_url: string; detail: 'auto' }
+  > = [{ type: 'input_text', text: prompt || 'Generate an image' }];
+
+  if (images.length > 0) {
+    const latestImageId = images[images.length - 1];
+    const { data: imageData } = await supabaseClient.storage
+      .from('images')
+      .download(`${userId}/${conversationId}/${latestImageId}`);
+
+    if (!imageData) {
+      throw new Error(`Failed to download image ${latestImageId}`);
+    }
+
+    const imageArrayBuffer = await imageData.arrayBuffer();
+    const base64Image = Buffer.from(imageArrayBuffer).toString('base64');
+
+    content.push({
+      type: 'input_image',
+      image_url: `data:image/png;base64,${base64Image}`,
+      detail: 'auto',
+    });
+  }
+
+  // deno-lint-ignore no-explicit-any
+  const response = await (openAI as any).responses.create({
+    model: 'gpt-5.1',
+    input: [{ role: 'user', content }],
+    tools: [{ type: 'image_generation', model: 'gpt-image-2' }],
+  });
+
+  const outputItems: Array<{ type: string; result?: string }> = Array.isArray(
+    response?.output,
+  )
+    ? response.output
+    : [];
+  const imageCalls = outputItems.filter(
+    (item) => item.type === 'image_generation_call',
+  );
+  const base64Result = imageCalls[imageCalls.length - 1]?.result;
+
+  if (!base64Result) {
+    throw new Error('No generated image data from gpt-image-2');
+  }
+
+  debugLog('Successfully generated image with gpt-image-2');
+  return Buffer.from(base64Result, 'base64');
+};
 
 export const generateImageWithGeminiMultiTurn = async (
   supabaseClient: SupabaseClient,

--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -87,10 +87,13 @@ async function getSignedImageUrl(
   return reformatSignedUrl(signedUrlData.signedUrl);
 }
 
-// Returns the image_generation_call_id of the most recent gpt-image-2
-// generation in this conversation, or null if none exists. Used to thread
-// prior image state into multi-turn edits via the canonical Responses API
-// pattern instead of re-encoding the image as base64.
+// Returns the image_generation_call_id of the *immediately* previous image
+// in this conversation, or null if that image was produced by a fallback
+// (Gemini/Flux) and has no call ID. Crucially, we do NOT filter for
+// non-null call IDs here: if the last turn fell back, skipping its null
+// row and surfacing an older gpt-image-2 call ID would make gpt-image-2
+// edit an image two turns ago while the user is looking at the fallback
+// output.
 async function getLatestGptImageCallId(
   supabaseClient: SupabaseClient,
   userId: string,
@@ -102,7 +105,6 @@ async function getLatestGptImageCallId(
     .eq('conversation_id', conversationId)
     .eq('user_id', userId)
     .eq('status', 'success')
-    .not('image_generation_call_id', 'is', null)
     .order('created_at', { ascending: false })
     .limit(1);
 

--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -3,7 +3,7 @@ import { corsHeaders } from '../_shared/cors.ts';
 import { fal } from 'npm:@fal-ai/client';
 import { GoogleGenAI } from 'npm:@google/genai';
 import Anthropic from 'npm:@anthropic-ai/sdk';
-import OpenAI from 'npm:openai';
+import OpenAI from 'npm:openai@^6.34.0';
 import {
   generateImageWithFalFlux,
   generateImageWithGeminiMultiTurn,
@@ -1147,7 +1147,11 @@ async function submitMeshJob(
             conversationalPrompt,
             allImages,
           );
-        } catch (_gptImageError) {
+        } catch (gptImageError) {
+          debugLog(
+            'gpt-image-2 failed, falling back to Gemini Multi-Turn (nano banana pro):',
+            gptImageError,
+          );
           try {
             imageBytes = await generateImageWithGeminiMultiTurn(
               supabaseClient,
@@ -1157,7 +1161,11 @@ async function submitMeshJob(
               conversationalPrompt,
               allImages,
             );
-          } catch (_fallbackError) {
+          } catch (geminiError) {
+            debugLog(
+              'Gemini Multi-Turn failed, falling back to Flux:',
+              geminiError,
+            );
             imageBytes = await generateImageWithFalFlux(
               supabaseClient,
               userId,

--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -87,6 +87,28 @@ async function getSignedImageUrl(
   return reformatSignedUrl(signedUrlData.signedUrl);
 }
 
+// Returns the image_generation_call_id of the most recent gpt-image-2
+// generation in this conversation, or null if none exists. Used to thread
+// prior image state into multi-turn edits via the canonical Responses API
+// pattern instead of re-encoding the image as base64.
+async function getLatestGptImageCallId(
+  supabaseClient: SupabaseClient,
+  userId: string,
+  conversationId: string,
+): Promise<string | null> {
+  const { data } = await supabaseClient
+    .from('images')
+    .select('image_generation_call_id')
+    .eq('conversation_id', conversationId)
+    .eq('user_id', userId)
+    .eq('status', 'success')
+    .not('image_generation_call_id', 'is', null)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  return data?.[0]?.image_generation_call_id ?? null;
+}
+
 // Helper function to get the most recent mesh preview from the conversation
 async function getRecentMeshPreview(
   supabaseClient: SupabaseClient,
@@ -850,18 +872,35 @@ async function submitMeshJob(
             : `${instructions3D} Generate a new image: ${text}`;
 
         let imageBytes: Buffer;
+        let imageCallId: string | null = null;
+
+        // Prefer the canonical Responses API multi-turn pattern: reference the
+        // prior gpt-image-2 call by ID instead of re-encoding base64. A fresh
+        // user upload in this turn overrides — treat it as new reference
+        // material via input_image.
+        const hasFreshUserImages = (images ?? []).length > 0;
+        const priorImageCallId = hasFreshUserImages
+          ? null
+          : await getLatestGptImageCallId(
+              supabaseClient,
+              userId,
+              conversationId,
+            );
 
         try {
           // Default: gpt-image-2 via OpenAI Responses API
           debugLog('Attempting image generation with gpt-image-2');
-          imageBytes = await generateImageWithGptImage2(
+          const result = await generateImageWithGptImage2(
             supabaseClient,
             openAI,
             userId,
             conversationId,
             newPrompt,
             allImages,
+            priorImageCallId,
           );
+          imageBytes = result.imageBytes;
+          imageCallId = result.imageCallId;
           debugLog('Successfully generated image with gpt-image-2');
         } catch (gptImageError) {
           debugLog(
@@ -907,6 +946,7 @@ async function submitMeshJob(
           .from('images')
           .update({
             status: 'success',
+            image_generation_call_id: imageCallId,
           })
           .eq('id', imageData.id);
 
@@ -1105,6 +1145,7 @@ async function submitMeshJob(
         'You are generating a fully textured and rendered 3D model. Output one centered 3D model or multiple centered objects, no text. Plain white background (or an empty background which provides optimal contrast with the textures of the 3D model), neutral lighting, and a soft shadow directly under the 3D model. Keep the entire object fully in-frame with 5–10% padding; no cropping. Make sure the description strongly impacts the form and shape of the 3D Model not just the surface texture';
 
       let imageBytes: Buffer;
+      let imageCallId: string | null = null;
 
       if (useGeminiFlash) {
         const flashPrompt = `${instructions3D} Generate: ${text}`;
@@ -1137,16 +1178,31 @@ async function submitMeshJob(
             ? `${instructions3D} Edit/modify the previous generation: ${text}`
             : `${instructions3D} Enhance and optimize the previous generation`;
 
+        // Prefer referencing the prior gpt-image-2 call by ID for true
+        // conversational continuity; fall back to base64 only when the user
+        // just uploaded fresh reference material.
+        const hasFreshUserImages = (images ?? []).length > 0;
+        const priorImageCallId = hasFreshUserImages
+          ? null
+          : await getLatestGptImageCallId(
+              supabaseClient,
+              userId,
+              conversationId,
+            );
+
         try {
           // Default: gpt-image-2 via OpenAI Responses API
-          imageBytes = await generateImageWithGptImage2(
+          const result = await generateImageWithGptImage2(
             supabaseClient,
             openAI,
             userId,
             conversationId,
             conversationalPrompt,
             allImages,
+            priorImageCallId,
           );
+          imageBytes = result.imageBytes;
+          imageCallId = result.imageCallId;
         } catch (gptImageError) {
           debugLog(
             'gpt-image-2 failed, falling back to Gemini Multi-Turn (nano banana pro):',
@@ -1190,7 +1246,10 @@ async function submitMeshJob(
 
       await supabaseClient
         .from('images')
-        .update({ status: 'success' })
+        .update({
+          status: 'success',
+          image_generation_call_id: imageCallId,
+        })
         .eq('id', imageData.id);
 
       // Get signed URL for the base image to send to Meshy

--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -886,6 +886,13 @@ async function submitMeshJob(
               userId,
               conversationId,
             );
+        // When the user uploaded fresh reference images this turn, the
+        // base64 path must pick from those — not from allImages (which
+        // trails with meshImages / recentMeshPreview and would shadow
+        // the upload with an older image).
+        const gptImageReferenceImages = hasFreshUserImages
+          ? (images ?? [])
+          : allImages;
 
         try {
           // Default: gpt-image-2 via OpenAI Responses API
@@ -896,7 +903,7 @@ async function submitMeshJob(
             userId,
             conversationId,
             newPrompt,
-            allImages,
+            gptImageReferenceImages,
             priorImageCallId,
           );
           imageBytes = result.imageBytes;
@@ -1189,6 +1196,12 @@ async function submitMeshJob(
               userId,
               conversationId,
             );
+        // When the user uploaded fresh reference images this turn, the
+        // base64 path must pick from those — not from allImages (which
+        // trails with meshImages and would shadow the upload).
+        const gptImageReferenceImages = hasFreshUserImages
+          ? (images ?? [])
+          : allImages;
 
         try {
           // Default: gpt-image-2 via OpenAI Responses API
@@ -1198,7 +1211,7 @@ async function submitMeshJob(
             userId,
             conversationId,
             conversationalPrompt,
-            allImages,
+            gptImageReferenceImages,
             priorImageCallId,
           );
           imageBytes = result.imageBytes;

--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -3,11 +3,13 @@ import { corsHeaders } from '../_shared/cors.ts';
 import { fal } from 'npm:@fal-ai/client';
 import { GoogleGenAI } from 'npm:@google/genai';
 import Anthropic from 'npm:@anthropic-ai/sdk';
+import OpenAI from 'npm:openai';
 import {
   generateImageWithFalFlux,
   generateImageWithGeminiMultiTurn,
   generateImageWithGeminiFlash,
   generateImageWithGeminiFlashEdit,
+  generateImageWithGptImage2,
 } from '../_shared/imageGen.ts';
 import { Model, MeshFileType } from '@shared/types.ts';
 import {
@@ -134,6 +136,11 @@ fal.config({
 // Initialize Google GenAI client
 const googleGenAI = new GoogleGenAI({
   apiKey: Deno.env.get('GOOGLE_API_KEY') ?? '',
+});
+
+// Initialize OpenAI client for gpt-image-2 via Responses API
+const openAI = new OpenAI({
+  apiKey: Deno.env.get('OPENAI_API_KEY') ?? '',
 });
 
 const supabaseClient = getServiceRoleSupabaseClient();
@@ -845,30 +852,45 @@ async function submitMeshJob(
         let imageBytes: Buffer;
 
         try {
-          // Try Gemini Multi-Turn first
-          debugLog('Attempting image generation with Gemini Multi-Turn');
-          imageBytes = await generateImageWithGeminiMultiTurn(
+          // Default: gpt-image-2 via OpenAI Responses API
+          debugLog('Attempting image generation with gpt-image-2');
+          imageBytes = await generateImageWithGptImage2(
             supabaseClient,
-            googleGenAI,
+            openAI,
             userId,
             conversationId,
             newPrompt,
             allImages,
           );
-          debugLog('Successfully generated image with Gemini Multi-Turn');
-        } catch (geminiError) {
+          debugLog('Successfully generated image with gpt-image-2');
+        } catch (gptImageError) {
           debugLog(
-            'Gemini Multi-Turn failed, falling back to Flux:',
-            geminiError,
+            'gpt-image-2 failed, falling back to Gemini Multi-Turn (nano banana pro):',
+            gptImageError,
           );
-          // Fall back to Flux
-          imageBytes = await generateImageWithFalFlux(
-            supabaseClient,
-            userId,
-            conversationId,
-            newPrompt,
-            allImages,
-          );
+          try {
+            imageBytes = await generateImageWithGeminiMultiTurn(
+              supabaseClient,
+              googleGenAI,
+              userId,
+              conversationId,
+              newPrompt,
+              allImages,
+            );
+            debugLog('Successfully generated image with Gemini Multi-Turn');
+          } catch (geminiError) {
+            debugLog(
+              'Gemini Multi-Turn failed, falling back to Flux:',
+              geminiError,
+            );
+            imageBytes = await generateImageWithFalFlux(
+              supabaseClient,
+              userId,
+              conversationId,
+              newPrompt,
+              allImages,
+            );
+          }
         }
 
         const { error: imageUploadError } = await supabaseClient.storage
@@ -1116,22 +1138,34 @@ async function submitMeshJob(
             : `${instructions3D} Enhance and optimize the previous generation`;
 
         try {
-          imageBytes = await generateImageWithGeminiMultiTurn(
+          // Default: gpt-image-2 via OpenAI Responses API
+          imageBytes = await generateImageWithGptImage2(
             supabaseClient,
-            googleGenAI,
+            openAI,
             userId,
             conversationId,
             conversationalPrompt,
             allImages,
           );
-        } catch (_fallbackError) {
-          imageBytes = await generateImageWithFalFlux(
-            supabaseClient,
-            userId,
-            conversationId,
-            conversationalPrompt,
-            allImages,
-          );
+        } catch (_gptImageError) {
+          try {
+            imageBytes = await generateImageWithGeminiMultiTurn(
+              supabaseClient,
+              googleGenAI,
+              userId,
+              conversationId,
+              conversationalPrompt,
+              allImages,
+            );
+          } catch (_fallbackError) {
+            imageBytes = await generateImageWithFalFlux(
+              supabaseClient,
+              userId,
+              conversationId,
+              conversationalPrompt,
+              allImages,
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

- Adds **gpt-image-2** via the OpenAI Responses API as the default image generator for mesh mode.
- Demotes **Gemini 3 Pro Image Preview (nano banana pro)** to first fallback; Flux remains the final fallback.
- Applies to both the `quality` model path and the `ultra` model's conversational-edit path.

## Changes

- `supabase/functions/_shared/imageGen.ts`: new `generateImageWithGptImage2` helper using `openai.responses.create` with `tools: [{ type: 'image_generation', model: 'gpt-image-2' }]`. Accepts the latest conversation image as an `input_image` for multi-turn edits.
- `supabase/functions/mesh/index.ts`: imports OpenAI SDK, initializes an `OpenAI` client, and rewires the fallback chain to **gpt-image-2 → Gemini Multi-Turn → Flux** in the quality path (line 854) and the ultra conversational path (line 1128). First-generation ultra paths (Gemini Flash / Flash Edit) are unchanged since they never used nano banana pro.
- `supabase/functions/.env.template`: adds `OPENAI_API_KEY`.

## Reviewer notes

- `OPENAI_API_KEY` must be added to the Supabase function secrets before this is deployed, otherwise the primary path will fail and fall through to nano banana pro.
- The Responses API image-generation tool returns output items of type `image_generation_call` with base64 in `result` — the helper grabs the last one to cover cases where multiple are emitted.

## Test plan

- [ ] Set `OPENAI_API_KEY` in Supabase env and run a quality mesh generation with text only — verify image produced via gpt-image-2.
- [ ] Run a quality mesh generation with an uploaded reference image — verify `input_image` multi-turn edit works.
- [ ] Temporarily set an invalid `OPENAI_API_KEY` — verify fallback to Gemini Multi-Turn succeeds.
- [ ] Run an ultra conversational edit (second generation in the same conversation) — verify gpt-image-2 is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Mesh image generation to `gpt-image-2` via the OpenAI Responses API by default, with Gemini 3 Pro Image Preview (nano banana pro) as the first fallback and Flux as the final fallback. Adds canonical multi-turn editing and prevents stale edit references after fallback; orchestrated by `gpt-5.4`.

- New Features
  - Default image generation uses `gpt-image-2` for quality and ultra conversational-edit paths; fallback chain: `gpt-image-2` → Gemini Multi-Turn (nano banana pro) → Flux.
  - Canonical multi-turn edits: reference prior `image_generation_call` id (placed before the new user turn); fresh uploads go via `input_image` base64 and are taken from current `images[]` (not `allImages`). Persist `image_generation_call_id` on `images` rows.
  - Prevent stale IDs: only consider the immediately previous image’s call id; if it’s null (fallback), use base64 so edits match the on-screen result.
  - Tuned tool config: quality `high`, size `1024x1024`, format `png`, background `opaque`, moderation `low`.

- Dependencies
  - Add `OPENAI_API_KEY` to Supabase function secrets; pin `openai@^6.34.0`.
  - Use `gpt-5.4` as the Responses API orchestrator; derive `input_image` MIME from storage blobs; log fallback errors.

<sup>Written for commit f579bd35c5b2c614a729be4ef6a458178adb3eeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

