### PR TITLE
fix(parametric-chat): raise code-gen max_tokens to fit detailed models

### DIFF
--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -958,7 +958,7 @@ Deno.serve(async (req) => {
                 { role: 'system', content: STRICT_CODE_PROMPT },
                 ...codeMessages,
               ],
-              max_tokens: 16000,
+              max_tokens: 48000,
               stream: true,
             };
 
@@ -967,7 +967,7 @@ Deno.serve(async (req) => {
               codeRequestBody.reasoning = {
                 max_tokens: 12000,
               };
-              codeRequestBody.max_tokens = 20000;
+              codeRequestBody.max_tokens = 60000;
             }
 
             // Kick off title generation alongside the streamed code.


### PR DESCRIPTION
16k was clipping complex OpenSCAD outputs (e.g. detailed car models) mid-stream, saving truncated code that failed to compile. Bump to 48k (60k with thinking) so realistic objects fit under the cap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase code-gen `max_tokens` from 16k to 48k (60k when reasoning is enabled) to prevent truncation of large OpenSCAD outputs in parametric chat. This fixes compile failures for detailed models and lets realistic objects stream to completion.

<sup>Written for commit e4dbb8ab5d9470fc23d93faccc5a8408d59d7cfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

