### PR TITLE
fix(parametric-chat): throttle code-stream SSE flushes to avoid OOM

### DIFF
--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -958,7 +958,7 @@ Deno.serve(async (req) => {
                 { role: 'system', content: STRICT_CODE_PROMPT },
                 ...codeMessages,
               ],
-              max_tokens: 16000,
+              max_tokens: 48000,
               stream: true,
             };
 
@@ -967,7 +967,7 @@ Deno.serve(async (req) => {
               codeRequestBody.reasoning = {
                 max_tokens: 12000,
               };
-              codeRequestBody.max_tokens = 20000;
+              codeRequestBody.max_tokens = 60000;
             }
 
             // Kick off title generation alongside the streamed code.

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -1007,6 +1007,12 @@ Deno.serve(async (req) => {
 
               const codeDecoder = new TextDecoder();
               let codeBuffer = '';
+              // Throttle SSE flushes to avoid O(n^2) memory blow-up on long
+              // generations — without this, each of hundreds of deltas
+              // re-serializes the full accumulated artifact.
+              let lastFlushTime = 0;
+              let lastFlushedLen = 0;
+              const FLUSH_INTERVAL_MS = 120;
 
               while (true) {
                 const { done, value } = await codeReader.read();
@@ -1049,20 +1055,28 @@ Deno.serve(async (req) => {
                   const deltaContent = chunk.choices?.[0]?.delta?.content;
                   if (typeof deltaContent === 'string' && deltaContent) {
                     rawCode += deltaContent;
-                    const streamed = stripCodeFences(rawCode);
-                    content = {
-                      ...content,
-                      artifact: {
-                        title: 'Adam Object',
-                        version: 'v1',
-                        code: streamed,
-                        parameters: [],
-                      },
-                    };
-                    streamMessage(controller, {
-                      ...newMessageData,
-                      content,
-                    });
+                    const now = Date.now();
+                    if (
+                      now - lastFlushTime >= FLUSH_INTERVAL_MS &&
+                      rawCode.length > lastFlushedLen
+                    ) {
+                      const streamed = stripCodeFences(rawCode);
+                      content = {
+                        ...content,
+                        artifact: {
+                          title: 'Adam Object',
+                          version: 'v1',
+                          code: streamed,
+                          parameters: [],
+                        },
+                      };
+                      streamMessage(controller, {
+                        ...newMessageData,
+                        content,
+                      });
+                      lastFlushTime = now;
+                      lastFlushedLen = rawCode.length;
+                    }
                   }
                 }
               }


### PR DESCRIPTION
## Summary
- After bumping the code-gen cap to 48k in [CADAM#108](https://github.com/Adam-CAD/CADAM/pull/108), prod started hitting \`Memory limit exceeded\` on long OpenSCAD generations.
- Root cause: for every token delta we re-serialized the entire accumulated artifact and streamed it over SSE, producing O(n²) bytes for a long generation and holding growing copies in flight.
- Throttle the in-loop flush to at most one update every 120ms (only when \`rawCode\` actually grew) at [supabase/functions/parametric-chat/index.ts:1061](supabase/functions/parametric-chat/index.ts#L1061).
- The post-loop final flush at [index.ts:1104](supabase/functions/parametric-chat/index.ts#L1104) is unchanged, so the client still receives the full completed artifact on success or error.

## Why
Supabase function logs showed \`Memory limit exceeded\` / \`shutdown\` events correlated with long generations. Token-cap fix alone is valid; it just exposed a latent O(n²) serialization cost that tipped the function past the edge-function memory ceiling.

## Test plan
- [ ] Reproduce the "Peugeot 405 Mi16" class of long generation in prod; confirm no \`Memory limit exceeded\` in function logs.
- [ ] Confirm the final artifact still renders correctly (UI should see the last in-loop flush + the post-loop final flush).
- [ ] Spot check short generations (cube, bracket) — visual streaming still feels live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttle streamed code updates to once every 120ms to prevent memory spikes during long generations after raising the code-gen token cap. The client still receives the final full artifact at completion.

- **Bug Fixes**
  - Throttle SSE flushes only when `rawCode` grows, cutting O(n²) re-serialization and fixing Supabase "Memory limit exceeded" crashes.

- **New Features**
  - Increase code-gen `max_tokens` to 48k (60k with reasoning) so detailed OpenSCAD outputs aren’t truncated.

<sup>Written for commit 741e3f1fa27e315d321217f84c153f4098d5c6d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

