### PR TITLE
fix(parametric-chat): tolerate client disconnect mid-stream

### DIFF
--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -34,10 +34,9 @@ function streamMessage(
   controller: ReadableStreamDefaultController,
   message: Message,
 ) {
+  const encoded = new TextEncoder().encode(JSON.stringify(message) + '\n');
   try {
-    controller.enqueue(
-      new TextEncoder().encode(JSON.stringify(message) + '\n'),
-    );
+    controller.enqueue(encoded);
   } catch {
     // Controller closed — client has gone away. Nothing more to do.
   }

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -24,12 +24,23 @@ initSentry();
 const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
 const OPENROUTER_API_KEY = Deno.env.get('OPENROUTER_API_KEY') ?? '';
 
-// Helper to stream updated assistant message rows
+// Helper to stream updated assistant message rows.
+// Silently noop if the controller is already closed (e.g. the client
+// disconnected mid-stream). Without this guard the enqueue throws
+// `The stream controller cannot close or enqueue`, which bubbles up
+// and gets logged as a generation failure even though the generation
+// may have completed successfully.
 function streamMessage(
   controller: ReadableStreamDefaultController,
   message: Message,
 ) {
-  controller.enqueue(new TextEncoder().encode(JSON.stringify(message) + '\n'));
+  try {
+    controller.enqueue(
+      new TextEncoder().encode(JSON.stringify(message) + '\n'),
+    );
+  } catch {
+    // Controller closed — client has gone away. Nothing more to do.
+  }
 }
 
 // Helper to escape regex special characters
@@ -867,7 +878,11 @@ Deno.serve(async (req) => {
             controller,
             finalMessageData ?? { ...newMessageData, content },
           );
-          controller.close();
+          try {
+            controller.close();
+          } catch {
+            // Already closed (client disconnected) — safe to ignore.
+          }
         }
 
         async function handleToolCall(toolCall: {


### PR DESCRIPTION
## Summary
- In prod we're seeing \`TypeError: The stream controller cannot close or enqueue\` followed by \`Http: connection closed before message completed\`.
- Root cause: when a client disconnects mid-generation, Deno closes the \`ReadableStream\`. Our next \`controller.enqueue\` throws, and the exception bubbles into the code-gen \`try/catch\` at [supabase/functions/parametric-chat/index.ts:1069](supabase/functions/parametric-chat/index.ts#L1069), which sets \`codeGenFailed = true\`. The artifact is then written to the DB as errored at [index.ts:1081-1088](supabase/functions/parametric-chat/index.ts#L1081-L1088) — even when the generation itself completed fine.
- Fix: swallow enqueue/close errors at the helper level. The DB update still happens, so the user's completed artifact is preserved and visible on reload.

## Why the user-visible bug is worse than the log suggests
\`Code generation failed\` was firing on successful generations whenever the user looked away, navigated, or hit a transient proxy timeout. That's why we were seeing \"failed to generate\" reports that were unrelated to the actual model/token behavior.

## Not done here (deliberate)
- We don't bail early on disconnect. The function keeps processing after a client drop, which wastes a bit of compute but preserves the DB write. If wasted compute becomes measurable we can add a \`streamClosed\` flag that the long loops check.

## Test plan
- [ ] Start a long generation in the UI and close the tab mid-stream; confirm no \`Code generation failed\` in function logs and the artifact still appears in the conversation on reload.
- [ ] Short/normal generation unaffected: completes and renders as before.
- [ ] Error path (OpenRouter 4xx/5xx) still marks the artifact as errored — we only swallowed the \*stream-closed\* error, not all errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents false “generation failed” errors when a client disconnects mid-stream by safely no-oping stream writes/closes after the `ReadableStream` is closed. Try/catch is scoped to the controller only so serialization errors still surface. Completed artifacts still get written to the DB and show on reload.

- **Bug Fixes**
  - Guard `controller.enqueue` and `controller.close` with try/catch; do `JSON.stringify`/`TextEncoder` outside the catch so only controller-closed errors are ignored.
  - Avoid setting `codeGenFailed=true` on successful generations when the client drops.

<sup>Written for commit af81c3d37378aff225c97759c5a92e0916f04ad3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

