### PR TITLE
fix(ParametricView): remount PanelGroup when parameters panel toggles

### DIFF
--- a/src/views/ParametricView.tsx
+++ b/src/views/ParametricView.tsx
@@ -209,9 +209,15 @@ export default function ParametricView({
         </div>
       ) : (
         <PanelGroup
+          // Remount cleanly when the parameters panel appears/disappears.
+          // Without this, react-resizable-panels' internal registry
+          // desyncs and throws `Panel data not found for index 2`.
+          key={hasArtifact ? 'editor-panels-with-params' : 'editor-panels'}
           direction="horizontal"
           className="h-full w-full"
-          autoSaveId="editor-panels"
+          autoSaveId={
+            hasArtifact ? 'editor-panels-with-params' : 'editor-panels'
+          }
         >
           <Panel
             collapsible


### PR DESCRIPTION
## Summary
- Prod is throwing \`Error: Panel data not found for index 2\` from \`react-resizable-panels\`, caught by React Router's error boundary.
- Happens the moment \`hasArtifact\` flips true/false — e.g. when a generation finishes and the parameters panel mounts, or when switching conversations.
- Root cause: [ParametricView.tsx:211-338](src/views/ParametricView.tsx#L211-L338) shares \`autoSaveId=\"editor-panels\"\` between the 2-panel (no artifact) and 3-panel (with artifact) layouts. The library's internal panel registry desyncs when the mounted panel set changes mid-render.
- Fix: key the \`PanelGroup\` (and vary \`autoSaveId\`) by \`hasArtifact\` so the two configurations are separate React subtrees with their own layout persistence.

## Why this matters for the \"loading forever\" symptom
The error fires exactly when an artifact first appears — which is the transition from \"generating\" to \"done\" in the UI. React Router's error boundary catches the render crash and can leave the generation UI visually stuck. Fixing this likely eliminates a class of \"loading forever\" reports.

## Test plan
- [ ] Start a generation from an empty conversation; confirm no \`Panel data not found\` in console when the artifact first renders.
- [ ] Switch between conversations where some have artifacts and some don't; confirm no panel errors.
- [ ] Confirm collapse/expand of chat and parameters panels still works and persists per mode.
- [ ] Mobile (\`isTabletOrMobile\`) path unaffected — uses a different layout entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in ParametricView when the parameters panel appears or disappears. Remounts the editor panel group so `react-resizable-panels` no longer throws “Panel data not found for index 2” and prevents stuck “loading” screens.

- **Bug Fixes**
  - Key the panel group by hasArtifact and use distinct layout IDs so 2-panel and 3-panel layouts are separate.
  - Prevents the library’s internal registry from desyncing when panels change mid-render.
  - Preserves collapse/expand persistence per mode; mobile layout unchanged.

<sup>Written for commit 4cbdce11f32f11a61f9b25a83af7c698eb3433e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

