### PR TITLE
feat(mesh): jpeg output + per-mode gpt-image-2 quality

### DIFF
--- a/supabase/functions/_shared/imageGen.ts
+++ b/supabase/functions/_shared/imageGen.ts
@@ -276,10 +276,18 @@ export const generateImageWithGeminiMultiTurn = async (
     const imageArrayBuffer = await imageData.arrayBuffer();
     const buffer = Buffer.from(imageArrayBuffer);
     const base64Image = buffer.toString('base64');
+    // Derive mimeType from the blob rather than hardcoding png —
+    // gpt-image-2 stores jpeg, so a Gemini fallback on a later turn
+    // would otherwise send jpeg bytes declared as png and get rejected
+    // (or produce corrupt output).
+    const mimeType =
+      imageData.type && imageData.type.startsWith('image/')
+        ? imageData.type
+        : 'image/png';
 
     imagePart = {
       inlineData: {
-        mimeType: 'image/png',
+        mimeType,
         data: base64Image,
       },
     };

--- a/supabase/functions/_shared/imageGen.ts
+++ b/supabase/functions/_shared/imageGen.ts
@@ -105,9 +105,15 @@ export const generateImageWithGemini = async (
 };
 */
 
+export type GptImageQuality = 'low' | 'medium' | 'high';
+
 export type GptImage2Result = {
   imageBytes: Buffer;
   imageCallId: string | null;
+  // MIME of the returned bytes — gpt-image-2 returns jpeg per our tool
+  // config. Callers must use this when persisting to storage so the
+  // Content-Type header matches the actual bytes.
+  contentType: 'image/jpeg';
 };
 
 /**
@@ -118,6 +124,10 @@ export type GptImage2Result = {
  * image_generation_call is referenced by ID (the canonical edit pattern)
  * instead of re-encoding the image as base64. Newly uploaded references
  * (no prior call ID) fall through to input_image base64.
+ *
+ * Output format: jpeg. Per OpenAI's docs, jpeg is faster than png with
+ * the image_generation tool, and our downstream 3D pipelines don't need
+ * alpha (we also set background=opaque). Latency win.
  */
 export const generateImageWithGptImage2 = async (
   supabaseClient: SupabaseClient,
@@ -127,6 +137,9 @@ export const generateImageWithGptImage2 = async (
   prompt: string,
   images: string[],
   priorImageCallId: string | null,
+  // 'low' (~$0.006) for fast/draft use, 'high' (~$0.21) for final mesh
+  // seeds. 'medium' also available (~$0.053).
+  quality: GptImageQuality,
 ): Promise<GptImage2Result> => {
   debugLog('Generating image with gpt-image-2 via Responses API', {
     userId,
@@ -202,9 +215,9 @@ export const generateImageWithGptImage2 = async (
       {
         type: 'image_generation',
         model: 'gpt-image-2',
-        quality: 'high',
+        quality,
         size: '1024x1024',
-        output_format: 'png',
+        output_format: 'jpeg',
         background: 'opaque',
         moderation: 'low',
       },
@@ -228,6 +241,7 @@ export const generateImageWithGptImage2 = async (
   return {
     imageBytes: Buffer.from(latestCall.result, 'base64'),
     imageCallId: latestCall.id,
+    contentType: 'image/jpeg',
   };
 };
 

--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -256,10 +256,17 @@ async function generateMeshImage(
   // One line per mesh generation — low noise, high signal. Grep for
   // "provider=flux" or "quality=low" etc. in Supabase function logs to
   // audit fallback + cost-tier distribution.
+  //
+  // `quality` is only logged when gpt-image-2 actually ran — it's a
+  // gpt-image-2 tool parameter, not a concept that applies to the
+  // Gemini/Flux fallbacks, so including it on fallback rows would be
+  // misleading.
   console.log(
     `[mesh] image_gen provider=${provider} meshModel=${sentryStage.meshModel}` +
       (sentryStage.subStage ? ` subStage=${sentryStage.subStage}` : '') +
-      ` quality=${QUALITY_BY_MESH_MODEL[sentryStage.meshModel]}` +
+      (provider === 'gpt-image-2'
+        ? ` quality=${QUALITY_BY_MESH_MODEL[sentryStage.meshModel]}`
+        : '') +
       ` contentType=${result.contentType}` +
       ` callId=${result.imageCallId ?? 'none'}`,
   );

--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -254,10 +254,13 @@ async function generateMeshImage(
   }
 
   // One line per mesh generation — low noise, high signal. Grep for
-  // "provider=flux" etc. in Supabase function logs to audit fallback rate.
+  // "provider=flux" or "quality=low" etc. in Supabase function logs to
+  // audit fallback + cost-tier distribution.
   console.log(
     `[mesh] image_gen provider=${provider} meshModel=${sentryStage.meshModel}` +
       (sentryStage.subStage ? ` subStage=${sentryStage.subStage}` : '') +
+      ` quality=${QUALITY_BY_MESH_MODEL[sentryStage.meshModel]}` +
+      ` contentType=${result.contentType}` +
       ` callId=${result.imageCallId ?? 'none'}`,
   );
 

--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -9,6 +9,7 @@ import {
   generateImageWithGeminiMultiTurn,
   generateImageWithGptImage2,
   INSTRUCTIONS_3D as instructions3D,
+  type GptImageQuality,
 } from '../_shared/imageGen.ts';
 import { Model, MeshFileType } from '@shared/types.ts';
 import {
@@ -106,6 +107,20 @@ async function getPriorImageCallId(
 //
 // Flux is also the sole provider for mesh previews (see submitPreviewJob),
 // which intentionally does not go through this chain.
+// Per-mode gpt-image-2 quality. fast mode defaults to `low` ($0.006/image,
+// cheaper than the Flux it replaced) since fast-mode output is inherently
+// draft quality. quality/ultra use `high` ($0.21/image) for final seed
+// fidelity. See https://developers.openai.com/api/docs/guides/image-generation
+// for pricing tiers.
+const QUALITY_BY_MESH_MODEL: Record<
+  'fast' | 'quality' | 'ultra',
+  GptImageQuality
+> = {
+  fast: 'low',
+  quality: 'high',
+  ultra: 'high',
+};
+
 async function generateMeshImage(
   userId: string,
   conversationId: string,
@@ -119,7 +134,11 @@ async function generateMeshImage(
   // Makes the multi-turn lookup branch-aware.
   priorMeshId: string | undefined,
   sentryStage: { meshModel: 'fast' | 'quality' | 'ultra'; subStage?: string },
-): Promise<{ imageBytes: Buffer; imageCallId: string | null }> {
+): Promise<{
+  imageBytes: Buffer;
+  imageCallId: string | null;
+  contentType: 'image/jpeg' | 'image/png';
+}> {
   const hasFreshUserImages = freshUserImages.length > 0;
   // Skip the call-id lookup when the user is providing fresh reference
   // material — we want gpt-image-2 to anchor on the new upload, not a
@@ -158,7 +177,11 @@ async function generateMeshImage(
   };
 
   let provider: 'gpt-image-2' | 'nano-banana-pro' | 'flux';
-  let result: { imageBytes: Buffer; imageCallId: string | null };
+  let result: {
+    imageBytes: Buffer;
+    imageCallId: string | null;
+    contentType: 'image/jpeg' | 'image/png';
+  };
 
   try {
     result = await generateImageWithGptImage2(
@@ -169,6 +192,7 @@ async function generateMeshImage(
       prompt,
       gptImageReferenceImages,
       priorImageCallId,
+      QUALITY_BY_MESH_MODEL[sentryStage.meshModel],
     );
     provider = 'gpt-image-2';
   } catch (gptImageError) {
@@ -190,7 +214,8 @@ async function generateMeshImage(
         prompt,
         gptImageReferenceImages,
       );
-      result = { imageBytes, imageCallId: null };
+      // Gemini Multi-Turn returns png.
+      result = { imageBytes, imageCallId: null, contentType: 'image/png' };
       provider = 'nano-banana-pro';
     } catch (geminiError) {
       logError(geminiError, {
@@ -210,7 +235,8 @@ async function generateMeshImage(
           prompt,
           gptImageReferenceImages,
         );
-        result = { imageBytes, imageCallId: null };
+        // Flux returns png per its output_format config.
+        result = { imageBytes, imageCallId: null, contentType: 'image/png' };
         provider = 'flux';
       } catch (fluxError) {
         logError(fluxError, {
@@ -997,20 +1023,21 @@ async function submitMeshJob(
             ? `${instructions3D} Edit the provided image(s) to: ${text}`
             : `${instructions3D} Generate a new image: ${text}`;
 
-        const { imageBytes, imageCallId } = await generateMeshImage(
-          userId,
-          conversationId,
-          newPrompt,
-          images ?? [],
-          allImages,
-          mesh,
-          { meshModel: 'quality' },
-        );
+        const { imageBytes, imageCallId, contentType } =
+          await generateMeshImage(
+            userId,
+            conversationId,
+            newPrompt,
+            images ?? [],
+            allImages,
+            mesh,
+            { meshModel: 'quality' },
+          );
 
         const { error: imageUploadError } = await supabaseClient.storage
           .from('images')
           .upload(`${userId}/${conversationId}/${imageData.id}`, imageBytes, {
-            contentType: 'image/png',
+            contentType,
           });
 
         if (imageUploadError) {
@@ -1071,20 +1098,21 @@ async function submitMeshJob(
             ? `${instructions3D} Edit the provided image(s) to: ${text}`
             : `${instructions3D} Generate a new image: ${text}`;
 
-        const { imageBytes, imageCallId } = await generateMeshImage(
-          userId,
-          conversationId,
-          newPrompt,
-          images ?? [],
-          allImages,
-          mesh,
-          { meshModel: 'fast' },
-        );
+        const { imageBytes, imageCallId, contentType } =
+          await generateMeshImage(
+            userId,
+            conversationId,
+            newPrompt,
+            images ?? [],
+            allImages,
+            mesh,
+            { meshModel: 'fast' },
+          );
 
         const { error: imageUploadError } = await supabaseClient.storage
           .from('images')
           .upload(`${userId}/${conversationId}/${imageData.id}`, imageBytes, {
-            contentType: 'image/png',
+            contentType,
           });
 
         if (imageUploadError) {
@@ -1232,7 +1260,7 @@ async function submitMeshJob(
         ultraSubStage = 'conversational';
       }
 
-      const { imageBytes, imageCallId } = await generateMeshImage(
+      const { imageBytes, imageCallId, contentType } = await generateMeshImage(
         userId,
         conversationId,
         ultraPrompt,
@@ -1246,7 +1274,7 @@ async function submitMeshJob(
       const { error: imageUploadError } = await supabaseClient.storage
         .from('images')
         .upload(`${userId}/${conversationId}/${imageData.id}`, imageBytes, {
-          contentType: 'image/png',
+          contentType,
         });
 
       if (imageUploadError) {


### PR DESCRIPTION
## Two gpt-image-2 optimizations per the [OpenAI docs](https://developers.openai.com/api/docs/guides/image-generation)

### 1. `output_format: 'png'` → `'jpeg'`

Docs: *"Using jpeg is faster than png, so you should prioritize this format if latency is a concern."*

- Downstream 3D pipelines (Hunyuan3D, Meshy, Flux) all accept jpeg
- We already set \`background: 'opaque'\` → no alpha needed
- Net: faster responses, smaller storage footprint, zero quality impact for 3D seeds

Storage uploads now use the **actual bytes' Content-Type**. \`generateMeshImage\` returns \`{ contentType: 'image/jpeg' | 'image/png' }\` depending on which provider succeeded (gpt-image-2 = jpeg, Gemini/Flux = png).

### 2. Per-mode quality

Before: every mode hardcoded \`quality: 'high'\` (~$0.21/image).

After:

| Mode | Quality | Cost/image | Note |
|------|---------|-----------|------|
| fast | \`low\` | ~$0.006 | **cheaper than the Flux it replaced** (~$0.03) |
| quality | \`high\` | ~$0.21 | this mode is named after quality |
| ultra | \`high\` | ~$0.21 | top tier |

Fast mode is now the **cheapest gpt-image-2 path** and undercuts Flux on cost while still getting gpt-image-2 coherence.

## Plumbing

- \`generateImageWithGptImage2\` gains a \`quality: GptImageQuality\` parameter
- \`generateMeshImage\` looks up quality via \`QUALITY_BY_MESH_MODEL\` const keyed on \`sentryStage.meshModel\`
- Call sites destructure \`{ contentType }\` from the helper and pass it to \`.upload()\`

## Test plan

- [ ] Deploy to AdamChat
- [ ] Generate a fast-mode mesh — check function logs for \`provider=gpt-image-2 meshModel=fast\`, verify \`ig_…\` call_id in DB, confirm stored image is jpeg (download from storage, check magic bytes)
- [ ] Generate a quality-mode mesh — same checks, \`meshModel=quality\`
- [ ] Generate ultra first-gen — same checks
- [ ] Compare visual quality fast-mode-before vs fast-mode-after. Fast is \`quality: low\` now; if it looks unacceptably worse than before, bump to \`medium\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `gpt-image-2` mesh image generation to JPEG and adds per-mode quality to cut latency and lower fast-mode cost. Uploads now use the image’s actual `Content-Type`, and logs include `contentType` plus `quality` only when `gpt-image-2` runs.

- **New Features**
  - `generateImageWithGptImage2` adds `quality: 'low'|'medium'|'high'` and uses `output_format: 'jpeg'` with `background: 'opaque'`.
  - Per-mode mapping via `QUALITY_BY_MESH_MODEL`: fast → `low` (~$0.006), quality/ultra → `high` (~$0.21). Fast undercuts `Flux` (~$0.03).
  - `generateMeshImage` returns `{ imageBytes, imageCallId, contentType }`; callers pass `contentType` to `.upload()`. Fallbacks (`Gemini Multi-Turn`, `Flux`) remain PNG.

- **Bug Fixes**
  - Gemini fallback now derives `mimeType` from the stored blob instead of hardcoding `image/png`, preventing JPEG/PNG mismatches on prior-image references.
  - Audit log adds `contentType` and conditionally includes `quality` only for `gpt-image-2`, ensuring accurate fallback and cost-tier tracking.

<sup>Written for commit 31649757ad5c179c0b4f04bc22a511dd5b0a6901. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

