### PR TITLE
fix(parametric-chat): prevent forever-pending tool calls after edge kill

### DIFF
--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -130,6 +130,25 @@ function markToolAsError(content: Content, toolId: string): Content {
   };
 }
 
+// Helper to flip every still-`pending` tool call to `error`. Used at terminal
+// checkpoints so an aborted request never persists a forever-streaming bubble.
+function markPendingToolsAsError(content: Content): Content {
+  if (!content.toolCalls || content.toolCalls.length === 0) return content;
+  const hasPending = content.toolCalls.some((c) => c.status === 'pending');
+  if (!hasPending) return content;
+  return {
+    ...content,
+    toolCalls: content.toolCalls.map((c: ToolCall) =>
+      c.status === 'pending' ? { ...c, status: 'error' } : c,
+    ),
+  };
+}
+
+// Supabase edge functions have a wall-clock budget (~400s on Pro). Abort
+// upstream fetches well before that so the server-side error paths run and
+// flush a terminal state, instead of the runtime killing us mid-stream.
+const UPSTREAM_FETCH_TIMEOUT_MS = 4 * 60 * 1000;
+
 // Anthropic block types for type safety
 interface AnthropicTextBlock {
   type: 'text';
@@ -640,6 +659,14 @@ Deno.serve(async (req) => {
       requestBody.max_tokens = 20000;
     }
 
+    // Matched to the code-gen budget so neither upstream can outlive
+    // the Supabase wall-clock silently.
+    const agentAbort = new AbortController();
+    const agentTimeout = setTimeout(
+      () => agentAbort.abort(new Error('agent upstream timeout')),
+      UPSTREAM_FETCH_TIMEOUT_MS,
+    );
+
     const response = await fetch(OPENROUTER_API_URL, {
       method: 'POST',
       headers: {
@@ -649,9 +676,11 @@ Deno.serve(async (req) => {
         'X-Title': 'Adam CAD',
       },
       body: JSON.stringify(requestBody),
+      signal: agentAbort.signal,
     });
 
     if (!response.ok) {
+      clearTimeout(agentTimeout);
       const errorText = await response.text();
       console.error(`OpenRouter API Error: ${response.status} - ${errorText}`);
       throw new Error(
@@ -804,6 +833,11 @@ Deno.serve(async (req) => {
           }
           markAllToolsError();
         } finally {
+          clearTimeout(agentTimeout);
+          // Last-line defense: even if markAllToolsError was skipped (e.g.
+          // the outer try completed without throwing but a tool call was
+          // left pending by an unreachable path), never persist pending.
+          content = markPendingToolsAsError(content);
           // Fallback: If no artifact was created but text contains OpenSCAD code,
           // extract it and create an artifact. This handles cases where the LLM
           // outputs code directly instead of using tools (common in long conversations).
@@ -890,246 +924,285 @@ Deno.serve(async (req) => {
           arguments: string;
         }) {
           if (toolCall.name === 'build_parametric_model') {
-            // Deduct parametric tokens (5) for model building
+            // `resolved` tracks whether this tool call reached a terminal
+            // state (success = entry removed, or explicit `error`). The
+            // finally below guarantees that *every* exit — throw, early
+            // return, upstream hang unmasked by AbortController — leaves
+            // the persisted tool call as `error` rather than forever-
+            // pending. Without this, a mid-stream kill produces a message
+            // that renders as a perpetually streaming code block.
+            let resolved = false;
             try {
-              const paramResult = await billing.consume(userData.user!.email!, {
-                tokens: PARAMETRIC_TOKEN_COST,
-                operation: 'parametric',
-                referenceId: toolCall.id,
-              });
-              if (!paramResult.ok) {
+              // Deduct parametric tokens (5) for model building
+              try {
+                const paramResult = await billing.consume(
+                  userData.user!.email!,
+                  {
+                    tokens: PARAMETRIC_TOKEN_COST,
+                    operation: 'parametric',
+                    referenceId: toolCall.id,
+                  },
+                );
+                if (!paramResult.ok) {
+                  content = {
+                    ...markToolAsError(content, toolCall.id),
+                    error: 'insufficient_tokens',
+                  };
+                  streamMessage(controller, { ...newMessageData, content });
+                  resolved = true;
+                  return;
+                }
+              } catch (err) {
+                const status =
+                  err instanceof BillingClientError ? err.status : 502;
+                logError(err, {
+                  functionName: 'parametric-chat',
+                  statusCode: status,
+                  userId: userData.user?.id,
+                  conversationId,
+                  additionalContext: {
+                    operation: 'parametric',
+                    toolCallId: toolCall.id,
+                  },
+                });
                 content = {
-                  ...content,
-                  error: 'insufficient_tokens',
+                  ...markToolAsError(content, toolCall.id),
+                  error: 'billing_unavailable',
                 };
                 streamMessage(controller, { ...newMessageData, content });
+                resolved = true;
                 return;
               }
-            } catch (err) {
-              const status =
-                err instanceof BillingClientError ? err.status : 502;
-              logError(err, {
-                functionName: 'parametric-chat',
-                statusCode: status,
-                userId: userData.user?.id,
-                conversationId,
-                additionalContext: {
-                  operation: 'parametric',
-                  toolCallId: toolCall.id,
-                },
-              });
-              content = {
-                ...content,
-                error: 'billing_unavailable',
-              };
-              streamMessage(controller, { ...newMessageData, content });
-              return;
-            }
-            let toolInput: {
-              text?: string;
-              imageIds?: string[];
-              baseCode?: string;
-              error?: string;
-            } = {};
-            try {
-              toolInput = JSON.parse(toolCall.arguments);
-            } catch (e) {
-              console.error('Invalid tool input JSON', e);
-              content = markToolAsError(content, toolCall.id);
-              streamMessage(controller, { ...newMessageData, content });
-              return;
-            }
-
-            // Build code generation messages
-            const baseContext: OpenAIMessage[] = toolInput.baseCode
-              ? [{ role: 'assistant' as const, content: toolInput.baseCode }]
-              : [];
-
-            // If baseContext adds an assistant message, re-state user request so conversation ends with user
-            const userText = newMessage?.content.text || '';
-            const needsUserMessage = baseContext.length > 0 || toolInput.error;
-            const finalUserMessage: OpenAIMessage[] = needsUserMessage
-              ? [
-                  {
-                    role: 'user' as const,
-                    content: toolInput.error
-                      ? `${userText}\n\nFix this OpenSCAD error: ${toolInput.error}`
-                      : userText,
-                  },
-                ]
-              : [];
-
-            const codeMessages: OpenAIMessage[] = [
-              ...messagesToSend,
-              ...baseContext,
-              ...finalUserMessage,
-            ];
-
-            // Code generation request logic (SSE streaming)
-            const codeRequestBody: OpenRouterRequest = {
-              model,
-              messages: [
-                { role: 'system', content: STRICT_CODE_PROMPT },
-                ...codeMessages,
-              ],
-              max_tokens: 48000,
-              stream: true,
-            };
-
-            // Also apply thinking to code generation if enabled
-            if (thinking) {
-              codeRequestBody.reasoning = {
-                max_tokens: 12000,
-              };
-              codeRequestBody.max_tokens = 60000;
-            }
-
-            // Kick off title generation alongside the streamed code.
-            const titlePromise = generateTitleFromMessages(messagesToSend);
-
-            let rawCode = '';
-            let codeGenFailed = false;
-
-            const stripCodeFences = (s: string): string => {
-              let out = s;
-              out = out.replace(/^```(?:openscad)?\s*\n?/, '');
-              out = out.replace(/\n?```\s*$/, '');
-              return out;
-            };
-
-            try {
-              const codeResponse = await fetch(OPENROUTER_API_URL, {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Authorization: `Bearer ${OPENROUTER_API_KEY}`,
-                  'HTTP-Referer': 'https://adam-cad.com',
-                  'X-Title': 'Adam CAD',
-                },
-                body: JSON.stringify(codeRequestBody),
-              });
-
-              if (!codeResponse.ok) {
-                const t = await codeResponse.text();
-                throw new Error(
-                  `Code gen error: ${codeResponse.status} - ${t}`,
-                );
+              let toolInput: {
+                text?: string;
+                imageIds?: string[];
+                baseCode?: string;
+                error?: string;
+              } = {};
+              try {
+                toolInput = JSON.parse(toolCall.arguments);
+              } catch (e) {
+                console.error('Invalid tool input JSON', e);
+                content = markToolAsError(content, toolCall.id);
+                streamMessage(controller, { ...newMessageData, content });
+                resolved = true;
+                return;
               }
 
-              const codeReader = codeResponse.body?.getReader();
-              if (!codeReader) throw new Error('No code response body');
+              // Build code generation messages
+              const baseContext: OpenAIMessage[] = toolInput.baseCode
+                ? [{ role: 'assistant' as const, content: toolInput.baseCode }]
+                : [];
 
-              const codeDecoder = new TextDecoder();
-              let codeBuffer = '';
-              // Throttle SSE flushes to avoid O(n^2) memory blow-up on long
-              // generations — without this, each of hundreds of deltas
-              // re-serializes the full accumulated artifact.
-              let lastFlushTime = 0;
-              let lastFlushedLen = 0;
-              const FLUSH_INTERVAL_MS = 120;
+              // If baseContext adds an assistant message, re-state user request so conversation ends with user
+              const userText = newMessage?.content.text || '';
+              const needsUserMessage =
+                baseContext.length > 0 || toolInput.error;
+              const finalUserMessage: OpenAIMessage[] = needsUserMessage
+                ? [
+                    {
+                      role: 'user' as const,
+                      content: toolInput.error
+                        ? `${userText}\n\nFix this OpenSCAD error: ${toolInput.error}`
+                        : userText,
+                    },
+                  ]
+                : [];
 
-              while (true) {
-                const { done, value } = await codeReader.read();
-                if (done) break;
+              const codeMessages: OpenAIMessage[] = [
+                ...messagesToSend,
+                ...baseContext,
+                ...finalUserMessage,
+              ];
 
-                codeBuffer += codeDecoder.decode(value, { stream: true });
-                const codeLines = codeBuffer.split('\n');
-                codeBuffer = codeLines.pop() || '';
+              // Code generation request logic (SSE streaming)
+              const codeRequestBody: OpenRouterRequest = {
+                model,
+                messages: [
+                  { role: 'system', content: STRICT_CODE_PROMPT },
+                  ...codeMessages,
+                ],
+                max_tokens: 48000,
+                stream: true,
+              };
 
-                for (const line of codeLines) {
-                  // Skip empty lines, SSE comments (`: OPENROUTER PROCESSING`),
-                  // and anything that isn't a `data:` event.
-                  if (!line.startsWith('data: ')) continue;
-                  const data = line.slice(6);
-                  if (data === '[DONE]') continue;
+              // Also apply thinking to code generation if enabled
+              if (thinking) {
+                codeRequestBody.reasoning = {
+                  max_tokens: 12000,
+                };
+                codeRequestBody.max_tokens = 60000;
+              }
 
-                  let chunk: {
-                    error?: { message?: string };
-                    choices?: Array<{
-                      delta?: { content?: string };
-                    }>;
-                  };
-                  try {
-                    chunk = JSON.parse(data);
-                  } catch (e) {
-                    // Malformed chunk — log and skip, don't abort the stream.
-                    console.error('Error parsing code SSE chunk:', e);
-                    continue;
-                  }
+              // Kick off title generation alongside the streamed code.
+              const titlePromise = generateTitleFromMessages(messagesToSend);
 
-                  // Surfaced API errors must abort code-gen so the outer
-                  // catch can mark the tool call as failed — never swallow.
-                  if (chunk.error) {
-                    throw new Error(
-                      chunk.error.message ||
-                        `OpenRouter error: ${JSON.stringify(chunk.error)}`,
-                    );
-                  }
+              let rawCode = '';
+              let codeGenFailed = false;
 
-                  const deltaContent = chunk.choices?.[0]?.delta?.content;
-                  if (typeof deltaContent === 'string' && deltaContent) {
-                    rawCode += deltaContent;
-                    const now = Date.now();
-                    if (
-                      now - lastFlushTime >= FLUSH_INTERVAL_MS &&
-                      rawCode.length > lastFlushedLen
-                    ) {
-                      const streamed = stripCodeFences(rawCode);
-                      content = {
-                        ...content,
-                        artifact: {
-                          title: 'Adam Object',
-                          version: 'v1',
-                          code: streamed,
-                          parameters: [],
-                        },
-                      };
-                      streamMessage(controller, {
-                        ...newMessageData,
-                        content,
-                      });
-                      lastFlushTime = now;
-                      lastFlushedLen = rawCode.length;
+              const stripCodeFences = (s: string): string => {
+                let out = s;
+                out = out.replace(/^```(?:openscad)?\s*\n?/, '');
+                out = out.replace(/\n?```\s*$/, '');
+                return out;
+              };
+
+              // Hard timeout below the Supabase edge budget so a hung
+              // upstream aborts in userland, letting the catch below mark
+              // this tool call as `error` instead of being silently SIGKILLed.
+              const codeGenAbort = new AbortController();
+              const codeGenTimeout = setTimeout(
+                () =>
+                  codeGenAbort.abort(new Error('code-gen upstream timeout')),
+                UPSTREAM_FETCH_TIMEOUT_MS,
+              );
+              try {
+                const codeResponse = await fetch(OPENROUTER_API_URL, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+                    'HTTP-Referer': 'https://adam-cad.com',
+                    'X-Title': 'Adam CAD',
+                  },
+                  body: JSON.stringify(codeRequestBody),
+                  signal: codeGenAbort.signal,
+                });
+
+                if (!codeResponse.ok) {
+                  const t = await codeResponse.text();
+                  throw new Error(
+                    `Code gen error: ${codeResponse.status} - ${t}`,
+                  );
+                }
+
+                const codeReader = codeResponse.body?.getReader();
+                if (!codeReader) throw new Error('No code response body');
+
+                const codeDecoder = new TextDecoder();
+                let codeBuffer = '';
+                // Throttle SSE flushes to avoid O(n^2) memory blow-up on long
+                // generations — without this, each of hundreds of deltas
+                // re-serializes the full accumulated artifact.
+                let lastFlushTime = 0;
+                let lastFlushedLen = 0;
+                const FLUSH_INTERVAL_MS = 120;
+
+                while (true) {
+                  const { done, value } = await codeReader.read();
+                  if (done) break;
+
+                  codeBuffer += codeDecoder.decode(value, { stream: true });
+                  const codeLines = codeBuffer.split('\n');
+                  codeBuffer = codeLines.pop() || '';
+
+                  for (const line of codeLines) {
+                    // Skip empty lines, SSE comments (`: OPENROUTER PROCESSING`),
+                    // and anything that isn't a `data:` event.
+                    if (!line.startsWith('data: ')) continue;
+                    const data = line.slice(6);
+                    if (data === '[DONE]') continue;
+
+                    let chunk: {
+                      error?: { message?: string };
+                      choices?: Array<{
+                        delta?: { content?: string };
+                      }>;
+                    };
+                    try {
+                      chunk = JSON.parse(data);
+                    } catch (e) {
+                      // Malformed chunk — log and skip, don't abort the stream.
+                      console.error('Error parsing code SSE chunk:', e);
+                      continue;
+                    }
+
+                    // Surfaced API errors must abort code-gen so the outer
+                    // catch can mark the tool call as failed — never swallow.
+                    if (chunk.error) {
+                      throw new Error(
+                        chunk.error.message ||
+                          `OpenRouter error: ${JSON.stringify(chunk.error)}`,
+                      );
+                    }
+
+                    const deltaContent = chunk.choices?.[0]?.delta?.content;
+                    if (typeof deltaContent === 'string' && deltaContent) {
+                      rawCode += deltaContent;
+                      const now = Date.now();
+                      if (
+                        now - lastFlushTime >= FLUSH_INTERVAL_MS &&
+                        rawCode.length > lastFlushedLen
+                      ) {
+                        const streamed = stripCodeFences(rawCode);
+                        content = {
+                          ...content,
+                          artifact: {
+                            title: 'Adam Object',
+                            version: 'v1',
+                            code: streamed,
+                            parameters: [],
+                          },
+                        };
+                        streamMessage(controller, {
+                          ...newMessageData,
+                          content,
+                        });
+                        lastFlushTime = now;
+                        lastFlushedLen = rawCode.length;
+                      }
                     }
                   }
                 }
+              } catch (e) {
+                console.error('Code generation failed:', e);
+                codeGenFailed = true;
+              } finally {
+                clearTimeout(codeGenTimeout);
               }
-            } catch (e) {
-              console.error('Code generation failed:', e);
-              codeGenFailed = true;
+
+              const code = stripCodeFences(rawCode.trim()).trim();
+
+              let title = await titlePromise.catch(() => 'Adam Object');
+              const lower = title.toLowerCase();
+              if (lower.includes('sorry') || lower.includes('apologize'))
+                title = 'Adam Object';
+
+              if (codeGenFailed || !code) {
+                content = {
+                  ...content,
+                  artifact: undefined,
+                  toolCalls: (content.toolCalls || []).map((c) =>
+                    c.id === toolCall.id ? { ...c, status: 'error' } : c,
+                  ),
+                };
+              } else {
+                const artifact: ParametricArtifact = {
+                  title,
+                  version: 'v1',
+                  code,
+                  parameters: parseParameters(code),
+                };
+                content = {
+                  ...content,
+                  toolCalls: (content.toolCalls || []).filter(
+                    (c) => c.id !== toolCall.id,
+                  ),
+                  artifact,
+                };
+              }
+              streamMessage(controller, { ...newMessageData, content });
+              resolved = true;
+            } finally {
+              // Safety net: any escape from the block above (thrown error,
+              // forgotten return, upstream abort) that left this tool call
+              // `pending` gets flipped to `error` here so the DB write in
+              // the outer finally never persists a zombie pending state.
+              if (!resolved) {
+                content = markToolAsError(content, toolCall.id);
+                streamMessage(controller, { ...newMessageData, content });
+              }
             }
-
-            const code = stripCodeFences(rawCode.trim()).trim();
-
-            let title = await titlePromise.catch(() => 'Adam Object');
-            const lower = title.toLowerCase();
-            if (lower.includes('sorry') || lower.includes('apologize'))
-              title = 'Adam Object';
-
-            if (codeGenFailed || !code) {
-              content = {
-                ...content,
-                artifact: undefined,
-                toolCalls: (content.toolCalls || []).map((c) =>
-                  c.id === toolCall.id ? { ...c, status: 'error' } : c,
-                ),
-              };
-            } else {
-              const artifact: ParametricArtifact = {
-                title,
-                version: 'v1',
-                code,
-                parameters: parseParameters(code),
-              };
-              content = {
-                ...content,
-                toolCalls: (content.toolCalls || []).filter(
-                  (c) => c.id !== toolCall.id,
-                ),
-                artifact,
-              };
-            }
-            streamMessage(controller, { ...newMessageData, content });
           } else if (toolCall.name === 'apply_parameter_changes') {
             let toolInput: {
               updates?: Array<{ name: string; value: string }>;
@@ -1230,6 +1303,10 @@ Deno.serve(async (req) => {
         text: 'An error occurred while processing your request.',
       };
     }
+    // Symmetric to the stream's inner finally: if we bail before/around
+    // returning the ReadableStream with tool calls already populated,
+    // never leave a pending entry in the persisted row.
+    content = markPendingToolsAsError(content);
 
     const { data: updatedMessageData } = await supabaseClient
       .from('messages')

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -144,10 +144,14 @@ function markPendingToolsAsError(content: Content): Content {
   };
 }
 
-// Supabase edge functions have a wall-clock budget (~400s on Pro). Abort
-// upstream fetches well before that so the server-side error paths run and
-// flush a terminal state, instead of the runtime killing us mid-stream.
-const UPSTREAM_FETCH_TIMEOUT_MS = 4 * 60 * 1000;
+// Single request-scoped budget. Supabase edge functions have a ~400s
+// wall-clock on Pro, so we anchor one deadline to the start of the
+// request and share it across every upstream fetch. Independent per-fetch
+// timers would compound (agent 4 min + code-gen 4 min = 8 min), blowing
+// past the edge budget and getting SIGKILLed — exactly the failure mode
+// this file is meant to prevent.
+const REQUEST_BUDGET_MS = 350 * 1000;
+const MIN_ABORT_MS = 1000;
 
 // Anthropic block types for type safety
 interface AnthropicTextBlock {
@@ -439,6 +443,13 @@ Deno.serve(async (req) => {
     });
   }
 
+  // Shared deadline: every upstream fetch in this request gets at most
+  // `requestDeadline - now` ms before aborting, so the agent + code-gen
+  // fetches together can never outlive the Supabase edge wall-clock.
+  const requestDeadline = Date.now() + REQUEST_BUDGET_MS;
+  const remainingBudgetMs = () =>
+    Math.max(MIN_ABORT_MS, requestDeadline - Date.now());
+
   const supabaseClient = getAnonSupabaseClient({
     global: {
       headers: { Authorization: req.headers.get('Authorization') ?? '' },
@@ -659,12 +670,12 @@ Deno.serve(async (req) => {
       requestBody.max_tokens = 20000;
     }
 
-    // Matched to the code-gen budget so neither upstream can outlive
-    // the Supabase wall-clock silently.
+    // Shares the request-scoped deadline with code-gen below so the two
+    // fetches together can never outlive the Supabase wall-clock budget.
     const agentAbort = new AbortController();
     const agentTimeout = setTimeout(
       () => agentAbort.abort(new Error('agent upstream timeout')),
-      UPSTREAM_FETCH_TIMEOUT_MS,
+      remainingBudgetMs(),
     );
 
     const response = await fetch(OPENROUTER_API_URL, {
@@ -1047,14 +1058,15 @@ Deno.serve(async (req) => {
                 return out;
               };
 
-              // Hard timeout below the Supabase edge budget so a hung
-              // upstream aborts in userland, letting the catch below mark
-              // this tool call as `error` instead of being silently SIGKILLed.
+              // Draws from the same request deadline as the agent fetch —
+              // whatever budget remains after the outer stream is ours.
+              // A hung upstream aborts in userland so the catch below
+              // marks this tool call `error` instead of being SIGKILLed.
               const codeGenAbort = new AbortController();
               const codeGenTimeout = setTimeout(
                 () =>
                   codeGenAbort.abort(new Error('code-gen upstream timeout')),
-                UPSTREAM_FETCH_TIMEOUT_MS,
+                remainingBudgetMs(),
               );
               try {
                 const codeResponse = await fetch(OPENROUTER_API_URL, {

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -1203,8 +1203,12 @@ Deno.serve(async (req) => {
                   artifact,
                 };
               }
-              streamMessage(controller, { ...newMessageData, content });
+              // Mark resolved *before* the side-effectful streamMessage:
+              // `content` already reflects the terminal state (artifact set
+              // or tool call removed), so if streamMessage ever threw, the
+              // finally below must not clobber that with an `error` flip.
               resolved = true;
+              streamMessage(controller, { ...newMessageData, content });
             } finally {
               // Safety net: any escape from the block above (thrown error,
               // forgotten return, upstream abort) that left this tool call


### PR DESCRIPTION
## Summary

- A killed edge function (Supabase wall-clock timeout, OOM, billing early-return) could persist `toolCalls[i].status === 'pending'` forever, making the assistant bubble render as a perpetually streaming code block after reload.
- Every terminal path in `build_parametric_model` now leaves the tool call as either removed (success) or `'error'` — never pending. Billing early-returns were the most visible offender; a mid-stream kill was the stealthier one.
- Added AbortController timeouts (4 min, below Supabase's edge budget) on both upstream OpenRouter fetches so a hung upstream throws in userland instead of being SIGKILLed — letting the existing `codeGenFailed = true` path run.

## What changed

- `markPendingToolsAsError()` helper flips any still-`pending` entry to `'error'` at a terminal checkpoint.
- `build_parametric_model` body wrapped in `try { … } finally { … }` with a `resolved` flag; the finally flips the tool call to `'error'` on any non-terminal exit (throw, forgotten return, upstream abort).
- `insufficient_tokens` and `billing_unavailable` early returns now mark the tool call as `'error'` alongside the `error` field (UI rendering contract preserved — `content.error` branch in `AssistantMessage` hides the tool-calls block regardless).
- `AbortController` timeouts on the agent fetch and the code-gen fetch, cleared in the corresponding `finally` blocks.
- Defense-in-depth: `markPendingToolsAsError(content)` in the stream's outer finally and in the `Deno.serve` outer catch, before the DB update.

## Test plan

- [ ] Inject `throw new Error('boom')` inside the code-stream reader loop (`supabase/functions/parametric-chat/index.ts` inside the code-gen `while` loop) and confirm the persisted assistant message ends with `toolCalls[0].status === 'error'`, not `'pending'`.
- [ ] Submit a prompt with `max_tokens` large enough to exceed the Supabase edge wall-clock; confirm `AbortController` fires first and the DB row ends with the tool call marked `'error'`.
- [ ] Exercise the billing `insufficient_tokens` path and confirm the row has no pending tool call (the payment-required UI continues to render as expected).
- [ ] Regression: happy-path build still removes the tool call from `toolCalls[]` on success and shows the streamed artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents forever‑pending tool calls in parametric chat after edge timeouts or crashes, so assistant bubbles no longer appear as perpetually streaming. Enforces terminal states for `build_parametric_model` and uses a single request‑scoped deadline shared across upstream fetches.

- **Bug Fixes**
  - Mark any still‑pending tool calls as `error` at terminal checkpoints (stream finally and at the `Deno.serve` tail before the DB write) so none persist as `pending`.
  - Wrap `build_parametric_model` in try/finally with a `resolved` flag; billing early‑returns (`insufficient_tokens`, `billing_unavailable`) now mark `error`; set `resolved` before the final `streamMessage` on success to avoid flipping a succeeded call to `error` if streaming throws.
  - Anchor a single ~350s request budget to the start of the request and share it across agent and code‑gen OpenRouter calls; each fetch uses an `AbortController` with the remaining time (timeouts cleared in finally) so hung upstreams abort in userland and trigger the failure path.

<sup>Written for commit baa0bb8f64d774e1a43dd88b5b355a4f72a74a29. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/113?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

