### PR TITLE
fix(parametric): prevent panel crash + preserve partial artifact on failure

### DIFF
--- a/src/views/ParametricView.tsx
+++ b/src/views/ParametricView.tsx
@@ -2,6 +2,7 @@ import { ChatSection } from '@/components/chat/ChatSection';
 import { ParameterSection } from '@/components/parameter/ParameterSection';
 import { Content, Message, Model, Parameter } from '@shared/types';
 import OpenSCADError from '@/lib/OpenSCADError';
+import { cn } from '@/lib/utils';
 import { useRef, useState, useMemo, useCallback } from 'react';
 import {
   ImperativePanelHandle,
@@ -283,58 +284,71 @@ export default function ParametricView({
               fixError={!limitReached ? fixError : undefined}
             />
           </Panel>
-          {hasArtifact && (
-            <>
-              <PanelResizeHandle className="resize-handle group relative">
-                {!isParametersPanelCollapsed && (
-                  <div className="absolute right-1 top-1/2 z-50 -translate-y-1/2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-                    <Button
-                      variant="ghost"
-                      className="rounded-l-lg rounded-r-none border-b border-l border-t border-gray-200/20 bg-adam-bg-secondary-dark p-2 text-adam-text-primary transition-colors dark:border-gray-800 [@media(hover:hover)]:hover:bg-adam-neutral-950 [@media(hover:hover)]:hover:text-adam-neutral-10"
-                      onClick={handleParametersCollapse}
-                    >
-                      <ChevronsRight className="h-5 w-5" />
-                    </Button>
+          {/*
+            Always mount the resize handle + parameters Panel so the
+            PanelGroup's registered panel count never changes. Toggling
+            `hasArtifact` caused react-resizable-panels to throw
+            "Panel data not found for index 2", which unmounted the
+            view mid-stream and orphaned the SSE mutation.
+            When no artifact exists we collapse the panel to zero size
+            and hide the handle so the layout reads as two panels.
+          */}
+          <PanelResizeHandle
+            disabled={!hasArtifact}
+            className={cn(
+              'resize-handle group relative',
+              !hasArtifact && 'pointer-events-none !w-0 before:hidden',
+            )}
+          >
+            {hasArtifact && !isParametersPanelCollapsed && (
+              <div className="absolute right-1 top-1/2 z-50 -translate-y-1/2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                <Button
+                  variant="ghost"
+                  className="rounded-l-lg rounded-r-none border-b border-l border-t border-gray-200/20 bg-adam-bg-secondary-dark p-2 text-adam-text-primary transition-colors dark:border-gray-800 [@media(hover:hover)]:hover:bg-adam-neutral-950 [@media(hover:hover)]:hover:text-adam-neutral-10"
+                  onClick={handleParametersCollapse}
+                >
+                  <ChevronsRight className="h-5 w-5" />
+                </Button>
+              </div>
+            )}
+            {hasArtifact && isParametersPanelCollapsed && (
+              <div className="absolute right-0 top-1/2 z-50 -translate-y-1/2">
+                <Button
+                  aria-label="Expand parameters panel"
+                  onClick={handleParametersExpand}
+                  className="flex h-[140px] w-9 flex-col items-center rounded-l-lg rounded-r-none bg-adam-bg-secondary-dark p-2 px-1.5 py-2 text-adam-text-primary"
+                >
+                  <ChevronsRight className="mb-3 h-5 w-5 rotate-180 text-white" />
+                  <div className="flex flex-1 items-center justify-center">
+                    <span className="min-w-[100px] -rotate-90 transform text-center text-base font-semibold text-white">
+                      Parameters
+                    </span>
                   </div>
-                )}
-                {isParametersPanelCollapsed && (
-                  <div className="absolute right-0 top-1/2 z-50 -translate-y-1/2">
-                    <Button
-                      aria-label="Expand parameters panel"
-                      onClick={handleParametersExpand}
-                      className="flex h-[140px] w-9 flex-col items-center rounded-l-lg rounded-r-none bg-adam-bg-secondary-dark p-2 px-1.5 py-2 text-adam-text-primary"
-                    >
-                      <ChevronsRight className="mb-3 h-5 w-5 rotate-180 text-white" />
-                      <div className="flex flex-1 items-center justify-center">
-                        <span className="min-w-[100px] -rotate-90 transform text-center text-base font-semibold text-white">
-                          Parameters
-                        </span>
-                      </div>
-                    </Button>
-                  </div>
-                )}
-              </PanelResizeHandle>
-              <Panel
-                collapsible
-                ref={parameterPanelRef}
-                defaultSize={parametersPanelSizes.defaultSize}
-                minSize={parametersPanelSizes.minSize}
-                maxSize={parametersPanelSizes.maxSize}
-                id="parameters-panel"
-                order={2}
-              >
-                <div className="relative h-full">
-                  <ParameterSection
-                    parameters={
-                      currentMessage?.content.artifact?.parameters ?? []
-                    }
-                    onSubmit={changeParameters}
-                    currentOutput={currentOutput}
-                  />
-                </div>
-              </Panel>
-            </>
-          )}
+                </Button>
+              </div>
+            )}
+          </PanelResizeHandle>
+          <Panel
+            collapsible
+            ref={parameterPanelRef}
+            defaultSize={hasArtifact ? parametersPanelSizes.defaultSize : 0}
+            minSize={hasArtifact ? parametersPanelSizes.minSize : 0}
+            maxSize={hasArtifact ? parametersPanelSizes.maxSize : 0}
+            id="parameters-panel"
+            order={2}
+          >
+            {hasArtifact && (
+              <div className="relative h-full">
+                <ParameterSection
+                  parameters={
+                    currentMessage?.content.artifact?.parameters ?? []
+                  }
+                  onSubmit={changeParameters}
+                  currentOutput={currentOutput}
+                />
+              </div>
+            )}
+          </Panel>
         </PanelGroup>
       )}
     </div>

--- a/src/views/ParametricView.tsx
+++ b/src/views/ParametricView.tsx
@@ -3,7 +3,7 @@ import { ParameterSection } from '@/components/parameter/ParameterSection';
 import { Content, Message, Model, Parameter } from '@shared/types';
 import OpenSCADError from '@/lib/OpenSCADError';
 import { cn } from '@/lib/utils';
-import { useRef, useState, useMemo, useCallback } from 'react';
+import { useRef, useState, useMemo, useCallback, useLayoutEffect } from 'react';
 import {
   ImperativePanelHandle,
   Panel,
@@ -150,6 +150,23 @@ export default function ParametricView({
     () => !!currentMessage?.content.artifact,
     [currentMessage],
   );
+
+  // `react-resizable-panels` only honors `defaultSize` at initial mount, and
+  // the PanelGroup's `autoSaveId` can restore a persisted size of 0 from a
+  // prior no-artifact session. Drive visibility imperatively via
+  // collapse/expand so the panel actually opens when the artifact arrives
+  // and shrinks to 0 when it's gone. useLayoutEffect avoids a visible flash
+  // on first paint when the persisted layout disagrees with `hasArtifact`.
+  useLayoutEffect(() => {
+    const panel = parameterPanelRef.current;
+    if (!panel) return;
+    if (hasArtifact) {
+      panel.expand();
+      setIsParametersPanelCollapsed(false);
+    } else {
+      panel.collapse();
+    }
+  }, [hasArtifact]);
 
   // Optimized collapse/expand handlers
   const handleChatCollapse = useCallback(() => {
@@ -330,10 +347,11 @@ export default function ParametricView({
           </PanelResizeHandle>
           <Panel
             collapsible
+            collapsedSize={0}
             ref={parameterPanelRef}
-            defaultSize={hasArtifact ? parametersPanelSizes.defaultSize : 0}
-            minSize={hasArtifact ? parametersPanelSizes.minSize : 0}
-            maxSize={hasArtifact ? parametersPanelSizes.maxSize : 0}
+            defaultSize={parametersPanelSizes.defaultSize}
+            minSize={parametersPanelSizes.minSize}
+            maxSize={parametersPanelSizes.maxSize}
             id="parameters-panel"
             order={2}
           >

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -1107,9 +1107,15 @@ Deno.serve(async (req) => {
               title = 'Adam Object';
 
             if (codeGenFailed || !code) {
+              // Preserve whatever partial artifact was streamed rather than
+              // unsetting it. Clearing `artifact` here flipped `hasArtifact`
+              // back to false on the client mid-stream, which crashed the
+              // conditional parameters Panel in react-resizable-panels. The
+              // `toolCalls[].status === 'error'` signal already carries the
+              // failure; keeping the partial code lets the user see what was
+              // generated before the error.
               content = {
                 ...content,
-                artifact: undefined,
                 toolCalls: (content.toolCalls || []).map((c) =>
                   c.id === toolCall.id ? { ...c, status: 'error' } : c,
                 ),


### PR DESCRIPTION
## Summary

Fixes the "loading forever" symptom users are hitting after yesterday's code-gen changes. Two coupled fixes:

- **Client** — `ParametricView` now always mounts the parameters Panel + resize handle. Previously it conditionally rendered them based on `hasArtifact`, which changed the `PanelGroup`'s registered panel count mid-stream and threw `Panel data not found for index 2` in `react-resizable-panels`. That error unmounted the view via React Router's error boundary and orphaned the SSE mutation — `isMutating` stuck true → `isLoading` stuck true → UI appeared to stream forever.
- **Server** — `parametric-chat` no longer clears `content.artifact` on code-gen failure. That was the exact signal that made `hasArtifact` flip `true → false` mid-stream and trigger the panel crash above. The failure is still carried by `toolCall.status = 'error'`, and users now see whatever partial code was generated before the failure.

## Why now

Yesterday's `max_tokens` bump (16k → 48k/60k in [593b1d5](https://github.com/Adam-CAD/CADAM/commit/593b1d5)) 3–4x'd generation wall time, which proportionally increased the likelihood of mid-stream errors that hit the `artifact: undefined` path. The panel bug was latent; the longer streams surfaced it.

## Test plan

- [ ] Fresh parametric conversation, send a prompt, watch artifact slide in mid-stream — no console errors, parameters panel opens cleanly.
- [ ] Existing conversation with an artifact, reload — panel lays out correctly with no ghost resize handle on the preview edge.
- [ ] Force a code-gen error (throttle network / bad model) — partial streamed code stays visible with error chip, UI does not crash.
- [ ] Navigate away mid-stream — no `Panel data not found` error in console.

## Follow-ups (not in this PR)

- Add an `AbortController` to the parametric-chat mutation so fetches get cancelled on unmount instead of running to completion in the background.
- Guarantee every server exit path marks the tool call as `'error'` or removes it — never persist `status: 'pending'` in the DB, which renders as a permanent streaming UI after reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Parametric panel crash and “loading forever” by stabilizing the panel count and imperatively controlling the parameters panel. Also preserves partial artifacts when code-gen fails so users keep partial code.

- **Bug Fixes**
  - Client: Always mount the resize handle and parameters Panel. Imperatively `expand()`/`collapse()` in `useLayoutEffect` keyed to `hasArtifact`, set `collapsedSize={0}`, and disable/hide the handle when no artifact. Prevents `react-resizable-panels` “Panel data not found for index 2”, avoids persisted size-0 restores, and removes first-paint flicker.
  - Server: On code-gen failure, keep `content.artifact` and mark the tool call as `'error'` instead of clearing the artifact. Preserves partial code and stops mid-stream `hasArtifact` flips.

<sup>Written for commit 4fa51dd22f9fcbbc1b10a927c8bdde7e8ce8165f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

