### PR TITLE
fix(chat): abort streaming fetch on unmount / stopGenerating

### DIFF
--- a/src/services/messageService.ts
+++ b/src/services/messageService.ts
@@ -27,11 +27,7 @@ export function abortActiveStream(conversationId: string) {
 }
 
 function isAbortError(error: unknown): boolean {
-  return (
-    !!error &&
-    typeof error === 'object' &&
-    (error as { name?: string }).name === 'AbortError'
-  );
+  return error instanceof Error && error.name === 'AbortError';
 }
 
 function messageSentConversationUpdate(
@@ -345,7 +341,7 @@ export function useCreativeChatMutation({
 
         return finalMessage;
       } catch (error) {
-        if (isAbortError(error) || controller.signal.aborted) {
+        if (isAbortError(error)) {
           // Client-initiated cancellation. If we captured any partial message,
           // resolve with it so the leaf state is preserved; otherwise surface
           // a tagged AbortError so onError can drop it silently.
@@ -586,7 +582,7 @@ export function useParametricChatMutation({
 
         return finalMessage;
       } catch (error) {
-        if (isAbortError(error) || controller.signal.aborted) {
+        if (isAbortError(error)) {
           if (finalMessage) return finalMessage;
           const abortError = new Error('Stream aborted');
           abortError.name = 'AbortError';

--- a/src/services/messageService.ts
+++ b/src/services/messageService.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useConversation } from '@/contexts/ConversationContext';
 import { supabase } from '@/lib/supabase';
 import { Content, Conversation, Message, Model } from '@shared/types';
@@ -10,6 +11,28 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import * as Sentry from '@sentry/react';
+
+// Per-conversation registry of in-flight stream AbortControllers. Shared so
+// that multiple hook instances (useSendContent, useRetry, useEdit) that all
+// wrap the same chat mutation can coordinate cancellation, and so the View
+// can abort via abortActiveStream(conversationId).
+const activeStreamControllers = new Map<string, AbortController>();
+
+export function abortActiveStream(conversationId: string) {
+  const controller = activeStreamControllers.get(conversationId);
+  if (controller) {
+    controller.abort();
+    activeStreamControllers.delete(conversationId);
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    (error as { name?: string }).name === 'AbortError'
+  );
+}
 
 function messageSentConversationUpdate(
   newMessage: Message,
@@ -147,6 +170,12 @@ export function useCreativeChatMutation({
   const queryClient = useQueryClient();
   const { mutateAsync: insertMessageAsync } = useInsertMessageMutation();
 
+  useEffect(() => {
+    return () => {
+      abortActiveStream(conversationId);
+    };
+  }, [conversationId]);
+
   return useMutation({
     mutationKey: ['creative-chat', conversationId],
     mutationFn: async ({
@@ -160,87 +189,129 @@ export function useCreativeChatMutation({
     }) => {
       const newMessageId = crypto.randomUUID();
       let initialized = false;
-
-      // Start streaming request
-      const response = await fetch(
-        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/creative-chat`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${
-              (await supabase.auth.getSession()).data.session?.access_token
-            }`,
-          },
-          body: JSON.stringify({
-            conversationId,
-            messageId,
-            model,
-            newMessageId,
-          }),
-        },
-      );
-
-      if (!response.ok) {
-        throw new Error(
-          `Network response was not ok: ${response.status} ${response.statusText}`,
-        );
-      }
-
-      if (response.headers.get('Content-Type')?.includes('application/json')) {
-        const data = await response.json();
-        if (data.message) {
-          return data.message;
-        } else {
-          throw new Error('No message received');
-        }
-      }
-
-      async function initialize() {
-        // Cancel any pending queries and update conversation leaf ID
-        await queryClient.cancelQueries({
-          queryKey: ['conversation', conversationId],
-        });
-        queryClient.setQueryData(
-          ['conversation', conversationId],
-          (oldConversation: Conversation) => ({
-            ...oldConversation,
-            current_message_leaf_id: newMessageId,
-          }),
-        );
-      }
-
-      const reader = response.body?.getReader();
-      if (!reader) {
-        throw new Error('No reader available');
-      }
-
-      const decoder = new TextDecoder();
-      let leftover = '';
-
       let finalMessage: Message | null = null;
 
+      // Abort any prior in-flight stream for this conversation and register
+      // our own controller so stopGenerating / unmount can cancel.
+      activeStreamControllers.get(conversationId)?.abort();
+      const controller = new AbortController();
+      activeStreamControllers.set(conversationId, controller);
+
       try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
+        const response = await fetch(
+          `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/creative-chat`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${
+                (await supabase.auth.getSession()).data.session?.access_token
+              }`,
+            },
+            body: JSON.stringify({
+              conversationId,
+              messageId,
+              model,
+              newMessageId,
+            }),
+            signal: controller.signal,
+          },
+        );
 
-          // Append decoded chunk to leftover buffer
-          leftover += decoder.decode(value, { stream: true });
+        if (!response.ok) {
+          throw new Error(
+            `Network response was not ok: ${response.status} ${response.statusText}`,
+          );
+        }
 
-          // Split into lines; keep the last partial line in leftover
-          const lines = leftover.split('\n');
-          leftover = lines.pop() ?? '';
+        if (
+          response.headers.get('Content-Type')?.includes('application/json')
+        ) {
+          const data = await response.json();
+          if (data.message) {
+            return data.message;
+          } else {
+            throw new Error('No message received');
+          }
+        }
 
-          for (const rawLine of lines) {
-            const line = rawLine.trim();
-            if (!line) continue;
+        async function initialize() {
+          // Cancel any pending queries and update conversation leaf ID
+          await queryClient.cancelQueries({
+            queryKey: ['conversation', conversationId],
+          });
+          queryClient.setQueryData(
+            ['conversation', conversationId],
+            (oldConversation: Conversation) => ({
+              ...oldConversation,
+              current_message_leaf_id: newMessageId,
+            }),
+          );
+        }
+
+        const reader = response.body?.getReader();
+        if (!reader) {
+          throw new Error('No reader available');
+        }
+
+        const decoder = new TextDecoder();
+        let leftover = '';
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            // Append decoded chunk to leftover buffer
+            leftover += decoder.decode(value, { stream: true });
+
+            // Split into lines; keep the last partial line in leftover
+            const lines = leftover.split('\n');
+            leftover = lines.pop() ?? '';
+
+            for (const rawLine of lines) {
+              const line = rawLine.trim();
+              if (!line) continue;
+              try {
+                const data: Message = JSON.parse(line);
+
+                finalMessage = data;
+
+                // Update existing streaming message
+                queryClient.setQueryData(
+                  ['messages', conversationId],
+                  (oldMessages: Message[] | undefined) => {
+                    if (!oldMessages || oldMessages.length === 0) {
+                      return [data];
+                    }
+                    if (oldMessages.find((msg) => msg.id === data.id)) {
+                      return oldMessages.map((msg) =>
+                        msg.id === data.id ? data : msg,
+                      );
+                    } else {
+                      return [...oldMessages, data];
+                    }
+                  },
+                );
+
+                if (!initialized) {
+                  await initialize();
+                  initialized = true;
+                }
+              } catch (parseError) {
+                console.error('Error parsing streaming data:', parseError);
+              }
+            }
+          }
+
+          // Flush decoder and process any remaining buffered content
+          const flushRemainder = decoder.decode();
+          if (flushRemainder) leftover += flushRemainder;
+          const tail = leftover.trim();
+          if (tail) {
             try {
-              const data: Message = JSON.parse(line);
-
+              const data: Message = JSON.parse(tail);
               finalMessage = data;
-
-              // Update existing streaming message
               queryClient.setQueryData(
                 ['messages', conversationId],
                 (oldMessages: Message[] | undefined) => {
@@ -256,53 +327,39 @@ export function useCreativeChatMutation({
                   }
                 },
               );
-
-              if (!initialized) {
-                await initialize();
-                initialized = true;
-              }
             } catch (parseError) {
-              console.error('Error parsing streaming data:', parseError);
+              console.error('Error parsing final streaming data:', parseError);
             }
           }
-        }
-
-        // Flush decoder and process any remaining buffered content
-        const flushRemainder = decoder.decode();
-        if (flushRemainder) leftover += flushRemainder;
-        const tail = leftover.trim();
-        if (tail) {
+        } finally {
           try {
-            const data: Message = JSON.parse(tail);
-            finalMessage = data;
-            queryClient.setQueryData(
-              ['messages', conversationId],
-              (oldMessages: Message[] | undefined) => {
-                if (!oldMessages || oldMessages.length === 0) {
-                  return [data];
-                }
-                if (oldMessages.find((msg) => msg.id === data.id)) {
-                  return oldMessages.map((msg) =>
-                    msg.id === data.id ? data : msg,
-                  );
-                } else {
-                  return [...oldMessages, data];
-                }
-              },
-            );
-          } catch (parseError) {
-            console.error('Error parsing final streaming data:', parseError);
+            reader.releaseLock();
+          } catch {
+            // Reader may already be released/cancelled after abort.
           }
         }
+
+        if (!finalMessage) {
+          throw new Error('No final message received');
+        }
+
+        return finalMessage;
+      } catch (error) {
+        if (isAbortError(error) || controller.signal.aborted) {
+          // Client-initiated cancellation. If we captured any partial message,
+          // resolve with it so the leaf state is preserved; otherwise surface
+          // a tagged AbortError so onError can drop it silently.
+          if (finalMessage) return finalMessage;
+          const abortError = new Error('Stream aborted');
+          abortError.name = 'AbortError';
+          throw abortError;
+        }
+        throw error;
       } finally {
-        reader.releaseLock();
+        if (activeStreamControllers.get(conversationId) === controller) {
+          activeStreamControllers.delete(conversationId);
+        }
       }
-
-      if (!finalMessage) {
-        throw new Error('No final message received');
-      }
-
-      return finalMessage;
     },
     onSuccess: (newMessage) => {
       messageInsertedConversationUpdate(
@@ -315,6 +372,7 @@ export function useCreativeChatMutation({
       queryClient.invalidateQueries({ queryKey: ['userExtraData'] });
     },
     onError: async (error, { messageId }) => {
+      if (isAbortError(error)) return;
       Sentry.captureException(error, {
         extra: {
           hook: 'useCreativeChatMutation',
@@ -353,6 +411,12 @@ export function useParametricChatMutation({
   const queryClient = useQueryClient();
   const { mutateAsync: insertMessageAsync } = useInsertMessageMutation();
 
+  useEffect(() => {
+    return () => {
+      abortActiveStream(conversationId);
+    };
+  }, [conversationId]);
+
   return useMutation({
     mutationKey: ['parametric-chat', conversationId],
     mutationFn: async ({
@@ -366,87 +430,129 @@ export function useParametricChatMutation({
     }) => {
       const newMessageId = crypto.randomUUID();
       let initialized = false;
-
-      // Start streaming request
-      const response = await fetch(
-        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/parametric-chat`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${
-              (await supabase.auth.getSession()).data.session?.access_token
-            }`,
-          },
-          body: JSON.stringify({
-            conversationId,
-            messageId,
-            model,
-            newMessageId,
-          }),
-        },
-      );
-
-      if (!response.ok) {
-        throw new Error(
-          `Network response was not ok: ${response.status} ${response.statusText}`,
-        );
-      }
-
-      if (response.headers.get('Content-Type')?.includes('application/json')) {
-        const data = await response.json();
-        if (data.message) {
-          return data.message;
-        } else {
-          throw new Error('No message received');
-        }
-      }
-
-      async function initialize() {
-        // Cancel any pending queries and update conversation leaf ID
-        await queryClient.cancelQueries({
-          queryKey: ['conversation', conversationId],
-        });
-        queryClient.setQueryData(
-          ['conversation', conversationId],
-          (oldConversation: Conversation) => ({
-            ...oldConversation,
-            current_message_leaf_id: newMessageId,
-          }),
-        );
-      }
-
-      const reader = response.body?.getReader();
-      if (!reader) {
-        throw new Error('No reader available');
-      }
-
-      const decoder = new TextDecoder();
-      let leftover = '';
-
       let finalMessage: Message | null = null;
 
+      // Abort any prior in-flight stream for this conversation and register
+      // our own controller so stopGenerating / unmount can cancel.
+      activeStreamControllers.get(conversationId)?.abort();
+      const controller = new AbortController();
+      activeStreamControllers.set(conversationId, controller);
+
       try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
+        const response = await fetch(
+          `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/parametric-chat`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${
+                (await supabase.auth.getSession()).data.session?.access_token
+              }`,
+            },
+            body: JSON.stringify({
+              conversationId,
+              messageId,
+              model,
+              newMessageId,
+            }),
+            signal: controller.signal,
+          },
+        );
 
-          // Append decoded chunk to leftover buffer
-          leftover += decoder.decode(value, { stream: true });
+        if (!response.ok) {
+          throw new Error(
+            `Network response was not ok: ${response.status} ${response.statusText}`,
+          );
+        }
 
-          // Split into lines; keep the last partial line in leftover
-          const lines = leftover.split('\n');
-          leftover = lines.pop() ?? '';
+        if (
+          response.headers.get('Content-Type')?.includes('application/json')
+        ) {
+          const data = await response.json();
+          if (data.message) {
+            return data.message;
+          } else {
+            throw new Error('No message received');
+          }
+        }
 
-          for (const rawLine of lines) {
-            const line = rawLine.trim();
-            if (!line) continue;
+        async function initialize() {
+          // Cancel any pending queries and update conversation leaf ID
+          await queryClient.cancelQueries({
+            queryKey: ['conversation', conversationId],
+          });
+          queryClient.setQueryData(
+            ['conversation', conversationId],
+            (oldConversation: Conversation) => ({
+              ...oldConversation,
+              current_message_leaf_id: newMessageId,
+            }),
+          );
+        }
+
+        const reader = response.body?.getReader();
+        if (!reader) {
+          throw new Error('No reader available');
+        }
+
+        const decoder = new TextDecoder();
+        let leftover = '';
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            // Append decoded chunk to leftover buffer
+            leftover += decoder.decode(value, { stream: true });
+
+            // Split into lines; keep the last partial line in leftover
+            const lines = leftover.split('\n');
+            leftover = lines.pop() ?? '';
+
+            for (const rawLine of lines) {
+              const line = rawLine.trim();
+              if (!line) continue;
+              try {
+                const data: Message = JSON.parse(line);
+
+                finalMessage = data;
+
+                // Update existing streaming message
+                queryClient.setQueryData(
+                  ['messages', conversationId],
+                  (oldMessages: Message[] | undefined) => {
+                    if (!oldMessages || oldMessages.length === 0) {
+                      return [data];
+                    }
+                    if (oldMessages.find((msg) => msg.id === data.id)) {
+                      return oldMessages.map((msg) =>
+                        msg.id === data.id ? data : msg,
+                      );
+                    } else {
+                      return [...oldMessages, data];
+                    }
+                  },
+                );
+
+                if (!initialized) {
+                  await initialize();
+                  initialized = true;
+                }
+              } catch (parseError) {
+                console.error('Error parsing streaming data:', parseError);
+              }
+            }
+          }
+
+          // Flush decoder and process any remaining buffered content
+          const flushRemainder = decoder.decode();
+          if (flushRemainder) leftover += flushRemainder;
+          const tail = leftover.trim();
+          if (tail) {
             try {
-              const data: Message = JSON.parse(line);
-
+              const data: Message = JSON.parse(tail);
               finalMessage = data;
-
-              // Update existing streaming message
               queryClient.setQueryData(
                 ['messages', conversationId],
                 (oldMessages: Message[] | undefined) => {
@@ -462,53 +568,36 @@ export function useParametricChatMutation({
                   }
                 },
               );
-
-              if (!initialized) {
-                await initialize();
-                initialized = true;
-              }
             } catch (parseError) {
-              console.error('Error parsing streaming data:', parseError);
+              console.error('Error parsing final streaming data:', parseError);
             }
           }
-        }
-
-        // Flush decoder and process any remaining buffered content
-        const flushRemainder = decoder.decode();
-        if (flushRemainder) leftover += flushRemainder;
-        const tail = leftover.trim();
-        if (tail) {
+        } finally {
           try {
-            const data: Message = JSON.parse(tail);
-            finalMessage = data;
-            queryClient.setQueryData(
-              ['messages', conversationId],
-              (oldMessages: Message[] | undefined) => {
-                if (!oldMessages || oldMessages.length === 0) {
-                  return [data];
-                }
-                if (oldMessages.find((msg) => msg.id === data.id)) {
-                  return oldMessages.map((msg) =>
-                    msg.id === data.id ? data : msg,
-                  );
-                } else {
-                  return [...oldMessages, data];
-                }
-              },
-            );
-          } catch (parseError) {
-            console.error('Error parsing final streaming data:', parseError);
+            reader.releaseLock();
+          } catch {
+            // Reader may already be released/cancelled after abort.
           }
         }
+
+        if (!finalMessage) {
+          throw new Error('No final message received');
+        }
+
+        return finalMessage;
+      } catch (error) {
+        if (isAbortError(error) || controller.signal.aborted) {
+          if (finalMessage) return finalMessage;
+          const abortError = new Error('Stream aborted');
+          abortError.name = 'AbortError';
+          throw abortError;
+        }
+        throw error;
       } finally {
-        reader.releaseLock();
+        if (activeStreamControllers.get(conversationId) === controller) {
+          activeStreamControllers.delete(conversationId);
+        }
       }
-
-      if (!finalMessage) {
-        throw new Error('No final message received');
-      }
-
-      return finalMessage;
     },
     onSuccess: (newMessage) => {
       messageInsertedConversationUpdate(
@@ -521,6 +610,7 @@ export function useParametricChatMutation({
       queryClient.invalidateQueries({ queryKey: ['userExtraData'] });
     },
     onError: async (error, { messageId }) => {
+      if (isAbortError(error)) return;
       Sentry.captureException(error, {
         extra: {
           hook: 'useParametricChatMutation',

--- a/src/services/messageService.ts
+++ b/src/services/messageService.ts
@@ -177,11 +177,9 @@ export function useCreativeChatMutation({
     mutationFn: async ({
       model,
       messageId,
-      conversationId,
     }: {
       model: Model;
       messageId: string;
-      conversationId: string;
     }) => {
       const newMessageId = crypto.randomUUID();
       let initialized = false;
@@ -342,10 +340,10 @@ export function useCreativeChatMutation({
         return finalMessage;
       } catch (error) {
         if (isAbortError(error)) {
-          // Client-initiated cancellation. If we captured any partial message,
-          // resolve with it so the leaf state is preserved; otherwise surface
-          // a tagged AbortError so onError can drop it silently.
-          if (finalMessage) return finalMessage;
+          // Client-initiated cancellation. Always surface as AbortError so
+          // onError drops it silently and onSuccess does not run — avoids
+          // writing a partial message as the conversation leaf into the
+          // sidebar cache when the server may not have persisted it.
           const abortError = new Error('Stream aborted');
           abortError.name = 'AbortError';
           throw abortError;
@@ -418,11 +416,9 @@ export function useParametricChatMutation({
     mutationFn: async ({
       model,
       messageId,
-      conversationId,
     }: {
       model: Model;
       messageId: string;
-      conversationId: string;
     }) => {
       const newMessageId = crypto.randomUUID();
       let initialized = false;
@@ -583,7 +579,10 @@ export function useParametricChatMutation({
         return finalMessage;
       } catch (error) {
         if (isAbortError(error)) {
-          if (finalMessage) return finalMessage;
+          // Client-initiated cancellation. Always surface as AbortError so
+          // onError drops it silently and onSuccess does not run — avoids
+          // writing a partial message as the conversation leaf into the
+          // sidebar cache when the server may not have persisted it.
           const abortError = new Error('Stream aborted');
           abortError.name = 'AbortError';
           throw abortError;
@@ -723,13 +722,11 @@ export function useSendContentMutation({
         await sendToCreativeChat({
           model: content.model ?? conversation.settings?.model ?? 'quality',
           messageId: userMessage.id,
-          conversationId: conversation.id,
         });
       } else {
         await sendToParametricChat({
           model: content.model ?? conversation.settings?.model ?? 'fast',
           messageId: userMessage.id,
-          conversationId: conversation.id,
         });
       }
     },
@@ -822,13 +819,11 @@ export function useEditMessageMutation({
         sendToCreativeChat({
           model: conversation.settings?.model ?? 'quality',
           messageId: userMessage.id,
-          conversationId: conversation.id,
         });
       } else {
         sendToParametricChat({
           model: conversation.settings?.model ?? 'fast',
           messageId: userMessage.id,
-          conversationId: conversation.id,
         });
       }
     },
@@ -885,13 +880,11 @@ export function useRetryMessageMutation({
         sendToCreativeChat({
           model: model,
           messageId: id,
-          conversationId: conversation.id,
         });
       } else {
         sendToParametricChat({
           model: model,
           messageId: id,
-          conversationId: conversation.id,
         });
       }
     },

--- a/src/views/CreativeEditorView.tsx
+++ b/src/views/CreativeEditorView.tsx
@@ -4,6 +4,7 @@ import { CreativeView } from './CreativeView';
 import { useConversation } from '@/contexts/ConversationContext';
 import { useCurrentMessage } from '@/contexts/CurrentMessageContext';
 import {
+  abortActiveStream,
   useMessagesQuery,
   useSendContentMutation,
   useEditMessageMutation,
@@ -97,13 +98,14 @@ export function CreativeEditorView() {
   const stopGenerating = useCallback(async () => {
     if (currentProcessingMessageRef.current) {
       try {
+        abortActiveStream(conversation.id);
         await cancelRequest(currentProcessingMessageRef.current);
         currentProcessingMessageRef.current = null;
       } catch (error) {
         console.error('Failed to cancel request:', error);
       }
     }
-  }, [cancelRequest]);
+  }, [cancelRequest, conversation.id]);
 
   useEffect(() => {
     setCurrentMessage(null);

--- a/src/views/ParametricEditorView.tsx
+++ b/src/views/ParametricEditorView.tsx
@@ -7,6 +7,7 @@ import { useConversation } from '@/contexts/ConversationContext';
 import OpenSCADError from '@/lib/OpenSCADError';
 import { useCurrentMessage } from '@/contexts/CurrentMessageContext';
 import {
+  abortActiveStream,
   useEditMessageMutation,
   useMessagesQuery,
   useRestoreMessageMutation,
@@ -98,13 +99,14 @@ export function ParametricEditorView() {
   const stopGenerating = useCallback(async () => {
     if (currentProcessingMessageRef.current) {
       try {
+        abortActiveStream(conversation.id);
         await cancelRequest(currentProcessingMessageRef.current);
         currentProcessingMessageRef.current = null;
       } catch (error) {
         console.error('Failed to cancel request:', error);
       }
     }
-  }, [cancelRequest]);
+  }, [cancelRequest, conversation.id]);
 
   useEffect(() => {
     setCurrentMessage(null);


### PR DESCRIPTION
## Summary
- Wire an `AbortController` into `useCreativeChatMutation` and `useParametricChatMutation` so the streaming `fetch` + reader are cancelled when the view unmounts or `stopGenerating` fires.
- Fixes the "stuck loading forever" bug where a mid-stream unmount (error boundary from the react-resizable-panels crash, route change, tab close before `pagehide`) left the mutation orphaned — `useIsMutating(['parametric-chat', conversationId])` stayed truthy and `isLoading` never cleared.

## What changed
- Module-level `Map<conversationId, AbortController>` registry + exported `abortActiveStream(id)` so the View can abort externally.
- `signal: controller.signal` threaded through both `fetch` calls; catch block tags abort as `AbortError` and `onError` short-circuits — no Sentry noise, no "An error occurred" placeholder message written to the thread.
- `useEffect` unmount cleanup in each hook invokes `abortActiveStream(conversationId)` — this is the path that actually fixes the orphan case.
- `stopGenerating` in `ParametricEditorView` and `CreativeEditorView` now aborts client-side before the existing `cancelRequest` realtime signal (client drops connection → server-side signal tells the edge function to wind down).
- Streaming reader itself is untouched — scope is cancellation plumbing only.

## Test plan
> ⚠️ Author could not test locally — browser verification still owed before merge.

- [ ] Start a long parametric generation, navigate away mid-stream; confirm Network tab shows the request cancelled and `useIsMutating` returns 0.
- [ ] Trigger an error during stream (throw in the reader loop); confirm no unhandled rejection, mutation settles cleanly.
- [ ] Verify the `stopGenerating` button still works end-to-end for both parametric and creative chat.
- [ ] Verify a stream that completes normally (no abort) still runs onSuccess and updates the conversation leaf as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Abort streaming chat requests on unmount and when Stop Generating is pressed to prevent orphaned mutations and stuck loading states. Adds a per-conversation `AbortController` and ensures aborts are silent and never commit partial messages.

- **Bug Fixes**
  - Cancel streaming via `AbortController` on unmount and `stopGenerating`; views call `abortActiveStream(conversationId)` before `cancelRequest`.
  - Threaded `signal` into `fetch`; aborts throw `AbortError` and are ignored by `onError` (no Sentry, no user error).
  - Removed shadowed `conversationId` param from mutation fns to avoid abort registry misses; callers no longer pass it.
  - Fixed orphaned mutations where `useIsMutating(['parametric-chat', conversationId])` stayed truthy after mid-stream unmount.
  - Hardened abort detection: `isAbortError` uses `instanceof Error`; dropped `signal.aborted` fallback.

<sup>Written for commit 375b5db9a710e5964bdafb078443edd1ce8417c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

