### PR TITLE
chore(mesh): gate image_gen diagnostic log on DEBUG_LOGS

### DIFF
--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -253,15 +253,12 @@ async function generateMeshImage(
     }
   }
 
-  // One line per mesh generation — low noise, high signal. Grep for
-  // "provider=flux" or "quality=low" etc. in Supabase function logs to
-  // audit fallback + cost-tier distribution.
-  //
-  // `quality` is only logged when gpt-image-2 actually ran — it's a
-  // gpt-image-2 tool parameter, not a concept that applies to the
-  // Gemini/Flux fallbacks, so including it on fallback rows would be
-  // misleading.
-  console.log(
+  // Diagnostic log — gated on DEBUG_LOGS. In prod, ground truth comes from:
+  //   - images.image_generation_call_id (null = fallback ran, non-null = gpt-image-2)
+  //   - Sentry events tagged stage=gpt_image_2_fallback / nano_banana_pro_fallback
+  //     / flux_fallback with full meshModel + subStage context
+  // This line stays opt-in for live debugging without polluting prod logs.
+  debugLog(
     `[mesh] image_gen provider=${provider} meshModel=${sentryStage.meshModel}` +
       (sentryStage.subStage ? ` subStage=${sentryStage.subStage}` : '') +
       (provider === 'gpt-image-2'


### PR DESCRIPTION
## Summary

The always-on audit log added in #112 was redundant in prod. Ground truth for "did gpt-image-2 run?" is already:
- `images.image_generation_call_id` (null → fallback, `ig_…` → gpt-image-2)
- Sentry events with richer context (`stage=gpt_image_2_fallback` etc.)

Gating the diagnostic line behind the existing `DEBUG_LOGS` env flag keeps prod function logs quiet and makes the signal opt-in for live debugging — flip `DEBUG_LOGS=true` in Supabase function secrets to turn it back on, no redeploy needed.

## Test plan
- [ ] Deploy and generate a mesh — confirm no `[mesh] image_gen …` line in the function logs
- [ ] Flip `DEBUG_LOGS=true` temporarily and generate again — line appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated the mesh image generation diagnostic log behind `DEBUG_LOGS` to keep prod function logs quiet while preserving opt-in debugging. Audit signal now relies on `images.image_generation_call_id` and Sentry events, so no loss of visibility.

- **Migration**
  - To see the diagnostic line, set `DEBUG_LOGS=true` in Supabase function secrets (no redeploy).

<sup>Written for commit 66aaf11c06172783ac07ca6ee74e509541727f55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

