### PR TITLE
fix(mesh): preserve image MIME through upscale + download paths

### DIFF
--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -27,10 +27,19 @@ export function ImageViewer({
   } = useImageData(image);
 
   const handleDownload = () => {
+    const url = imageUrl?.url || '';
+    // Parse MIME from the data URL (e.g. "data:image/jpeg;base64,...") so
+    // the downloaded file's extension matches the actual bytes. gpt-image-2
+    // generates jpeg, Gemini/Flux fallbacks generate png — hardcoding .png
+    // would mislabel jpeg downloads and some viewers reject the mismatch.
+    const mimeMatch = url.match(/^data:(image\/\w+);/);
+    const mime = mimeMatch?.[1] ?? 'image/png';
+    const ext =
+      mime === 'image/jpeg' ? 'jpg' : mime === 'image/webp' ? 'webp' : 'png';
     const link = document.createElement('a');
-    link.href = imageUrl?.url || '';
+    link.href = url;
     const name = getSafeFilename(conversation.title);
-    link.download = `${name}.png`;
+    link.download = `${name}.${ext}`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);

--- a/supabase/functions/mesh/index.ts
+++ b/supabase/functions/mesh/index.ts
@@ -553,12 +553,26 @@ Deno.serve(async (req) => {
         );
       }
 
-      // Upload to FAL storage
-      const imageFile = new File([imageBlob], 'seed-image.png', {
-        type: 'image/png',
+      // Upload to FAL storage. Preserve the blob's actual MIME — seed
+      // images from gpt-image-2 are jpeg, seeds from Gemini/Flux are png.
+      // FAL serves the uploaded bytes with the Content-Type we give it,
+      // and Hunyuan3D's image decoder relies on extension + MIME matching
+      // the actual bytes; hardcoding png would fail on jpeg seeds.
+      const seedMime =
+        imageBlob.type && imageBlob.type.startsWith('image/')
+          ? imageBlob.type
+          : 'image/png';
+      const seedExt =
+        seedMime === 'image/jpeg'
+          ? 'jpg'
+          : seedMime === 'image/webp'
+            ? 'webp'
+            : 'png';
+      const imageFile = new File([imageBlob], `seed-image.${seedExt}`, {
+        type: seedMime,
       });
       const imageUrl = await fal.storage.upload(imageFile);
-      debugLog('Uploaded seed image to FAL:', imageUrl);
+      debugLog('Uploaded seed image to FAL:', imageUrl, { seedMime });
 
       // Create new mesh entry for upscaled result
       const { data: newMeshData, error: newMeshError } = await supabaseClient


### PR DESCRIPTION
## Summary

**Bug**: after PR #112 switched gpt-image-2 output to jpeg, two paths still hardcoded png, corrupting the MIME → file-extension → actual-bytes contract.

### 1. Upscale (the one breaking in prod)

\`supabase/functions/mesh/index.ts\` line ~557:
\`\`\`ts
// Before:
new File([imageBlob], 'seed-image.png', { type: 'image/png' });
\`\`\`

The upscale action downloads the seed image from Supabase Storage (jpeg if gpt-image-2 generated it) and re-uploads to FAL hardcoded as png. FAL serves with png headers, Hunyuan3D v3.1 Pro decoder rejects the mismatched bytes → upscale fails.

Fix: derive extension + MIME from \`imageBlob.type\`.

### 2. Frontend download button

\`src/components/ImageViewer.tsx\` line ~33:
\`\`\`ts
link.download = \`\${name}.png\`;
\`\`\`

jpeg bytes downloaded with a .png name. Some viewers sniff and open, others reject. Fix: parse MIME from the data URL, use matching extension.

## Test plan
- [ ] Deploy mesh function, click upscale on an existing mesh — verify Hunyuan3D accepts and a new mesh row reaches \`status = 'success'\`
- [ ] Generate a gpt-image-2 mesh, click download on the seed image — verify the downloaded file is \`*.jpg\` and opens
- [ ] Generate a mesh via Gemini/Flux fallback — download still works with \`.png\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve image MIME and extension through upscale and download paths to prevent MIME/extension mismatches that caused upscale failures and mislabeled downloads. Server uploads now forward the correct MIME to FAL; the download button names files to match actual bytes (jpg/png/webp).

- **Bug Fixes**
  - Server (`supabase/functions/mesh/index.ts`): Derive MIME and extension from `imageBlob.type` when creating the `File` for FAL upload; remove hardcoded PNG and log `seedMime`.
  - Client (`src/components/ImageViewer.tsx`): Parse MIME from the data URL to set the correct download extension (`jpg`, `png`, `webp`) instead of always `.png`.

<sup>Written for commit f27b4aca9e17c5d9d188e611f8175cfadcb0be70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

