### PR TITLE
feat(models): swap GPT-5.5 Pro for DeepSeek V4 Pro

### DIFF
--- a/src/components/TextAreaChat.tsx
+++ b/src/components/TextAreaChat.tsx
@@ -18,7 +18,12 @@ import {
   Box,
   X,
 } from 'lucide-react';
-import { cn, CREATIVE_MODELS, PARAMETRIC_MODELS } from '@/lib/utils';
+import {
+  cn,
+  CREATIVE_MODELS,
+  PARAMETRIC_MODELS,
+  parametricModelSupportsVision,
+} from '@/lib/utils';
 import { Content, CreativeModel, MeshFileType, Model } from '@shared/types';
 import {
   shouldShowPolygonControls,
@@ -491,6 +496,12 @@ function TextAreaChat({
   const { images, mesh, setImages, setMesh } = useItemSelection();
   const meshFiles = useMeshFiles();
 
+  // Parametric models can opt out of vision (e.g. text-only DeepSeek V4 Pro).
+  // When they do, images and STL uploads (which become rendered images) are
+  // meaningless, so we hide the upload affordance and block all attach paths.
+  const canAttachFiles =
+    type !== 'parametric' || parametricModelSupportsVision(model);
+
   // Parametric mode: bounding box and filename from STL parsing
   const [meshBoundingBox, setMeshBoundingBox] = useState<BoundingBox | null>(
     null,
@@ -732,6 +743,14 @@ function TextAreaChat({
     if (hasNoContent || isLoading || hasUploadingImages) {
       return;
     }
+    if (!canAttachFiles && (images.length > 0 || mesh)) {
+      toast({
+        title: 'Remove attachments to continue',
+        description:
+          'The selected model does not accept images or STL uploads. Remove them or switch to a vision-capable model.',
+      });
+      return;
+    }
     let content: Content = {
       ...(input.trim() !== '' && { text: input.trim() }),
       ...(images.length > 0 && { images: images.map((img) => img.id) }),
@@ -863,6 +882,14 @@ function TextAreaChat({
   });
 
   const addItems = async (files: FileList) => {
+    if (!canAttachFiles) {
+      toast({
+        title: 'This model is text-only',
+        description:
+          'The selected model does not accept images or STL uploads. Switch to a vision-capable model to attach files.',
+      });
+      return;
+    }
     const newItems = Array.from(files);
     let hasSmallImages = false;
     let hasLargeImages = false;
@@ -1566,36 +1593,38 @@ function TextAreaChat({
         </div>
         <div className="flex items-center justify-between border-t border-[#2a2a2a] p-3">
           <div className="flex items-center gap-1">
-            <div
-              className={cn(
-                'transition-all duration-300 ease-out',
-                'pointer-events-auto scale-100 opacity-100',
-              )}
-            >
-              <Button
-                variant="outline"
-                className="flex h-8 w-8 items-center gap-2 rounded-lg border border-[#2a2a2a] bg-adam-background-2 p-0 text-sm text-adam-text-secondary hover:bg-adam-bg-secondary-dark"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  const input = document.createElement('input');
-                  input.type = 'file';
-                  input.accept = `${VALID_IMAGE_FORMATS.join(', ')}, ${
-                    type === 'creative'
-                      ? SUPPORTED_MESH_EXTENSIONS.join(', ')
-                      : '.stl'
-                  }`;
-                  input.onchange = (event) => {
-                    handleItemsChange(
-                      event as unknown as ChangeEvent<HTMLInputElement>,
-                    );
-                  };
-                  input.click();
-                }}
-                disabled={disabled}
+            {canAttachFiles && (
+              <div
+                className={cn(
+                  'transition-all duration-300 ease-out',
+                  'pointer-events-auto scale-100 opacity-100',
+                )}
               >
-                <ImagePlus className="h-5 w-5" />
-              </Button>
-            </div>
+                <Button
+                  variant="outline"
+                  className="flex h-8 w-8 items-center gap-2 rounded-lg border border-[#2a2a2a] bg-adam-background-2 p-0 text-sm text-adam-text-secondary hover:bg-adam-bg-secondary-dark"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    const input = document.createElement('input');
+                    input.type = 'file';
+                    input.accept = `${VALID_IMAGE_FORMATS.join(', ')}, ${
+                      type === 'creative'
+                        ? SUPPORTED_MESH_EXTENSIONS.join(', ')
+                        : '.stl'
+                    }`;
+                    input.onchange = (event) => {
+                      handleItemsChange(
+                        event as unknown as ChangeEvent<HTMLInputElement>,
+                      );
+                    };
+                    input.click();
+                  }}
+                  disabled={disabled}
+                >
+                  <ImagePlus className="h-5 w-5" />
+                </Button>
+              </div>
+            )}
 
             {/* Creative mode toggle button */}
             {onTypeChange && (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -264,13 +264,13 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'openai/gpt-5.5-pro',
-    name: 'GPT-5.5 Pro',
-    description: 'Most powerful OpenAI model for complex reasoning',
-    provider: 'OpenAI',
+    id: 'deepseek/deepseek-v4-pro',
+    name: 'DeepSeek V4 Pro',
+    description: 'Long-context MoE model for complex reasoning and code',
+    provider: 'DeepSeek',
     supportsTools: true,
     supportsThinking: true,
-    supportsVision: true,
+    supportsVision: false,
   },
 ];
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -295,6 +295,14 @@ export const CREATIVE_MODELS: ModelConfig[] = [
   },
 ];
 
+// Whether the selected parametric model can accept image / STL-render inputs.
+// Unknown ids (e.g. historical messages tagged with a removed model) fall back
+// to `true` so legacy conversations keep rendering normally.
+export function parametricModelSupportsVision(modelId: string): boolean {
+  const cfg = PARAMETRIC_MODELS.find((m) => m.id === modelId);
+  return cfg?.supportsVision !== false;
+}
+
 export function getBackupModel({
   message,
   parentMessage,


### PR DESCRIPTION
## Summary
- Remove `openai/gpt-5.5-pro` from `PARAMETRIC_MODELS` and replace with `deepseek/deepseek-v4-pro`.
- Final picker (assuming #119 lands first): Gemini 3.1 Pro / Claude Opus 4.7 / GPT-5.5 / DeepSeek V4 Pro.

## Notes
- **Stacked on [#119](https://github.com/Adam-CAD/CADAM/pull/119).** Base is `claude/zen-mahavira-41ab35` so the diff reads cleanly. Once #119 merges, this will auto-rebase onto `master` (or can be retargeted manually).
- DeepSeek V4 Pro is a long-context MoE tuned for reasoning and agentic coding. `supportsVision: false` — the model is text-only per OpenRouter.
- Routing id stored on historical messages (`openai/gpt-5.5-pro`) falls back to the first entry in [`ModelButton.tsx`](src/components/chat/ModelButton.tsx) — display-only, no crash.

## Test plan
- [ ] After #119 + this land, open the chat model picker and confirm DeepSeek V4 Pro appears with the correct name and description.
- [ ] Select DeepSeek V4 Pro and confirm requests route through OpenRouter end-to-end.
- [ ] Confirm vision-only affordances (image upload flow, etc.) stay hidden/disabled when DeepSeek V4 Pro is selected, since `supportsVision: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `openai/gpt-5.5-pro` with `deepseek/deepseek-v4-pro` in `PARAMETRIC_MODELS` and the chat model picker. Enforced its text-only setting by gating image/STL uploads in `TextAreaChat` (hide upload, block attach/submit with toasts) via `parametricModelSupportsVision()`; unknown ids default to vision-capable.

<sup>Written for commit 1dbc5cf9fcbf0bb7ba4fd1f1cbfaab5719ab89e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

