### PR TITLE
feat(models): swap GPT-5.5 Pro for DeepSeek V4 Pro

### DIFF
--- a/src/components/TextAreaChat.tsx
+++ b/src/components/TextAreaChat.tsx
@@ -18,7 +18,12 @@ import {
   Box,
   X,
 } from 'lucide-react';
-import { cn, CREATIVE_MODELS, PARAMETRIC_MODELS } from '@/lib/utils';
+import {
+  cn,
+  CREATIVE_MODELS,
+  PARAMETRIC_MODELS,
+  parametricModelSupportsVision,
+} from '@/lib/utils';
 import { Content, CreativeModel, MeshFileType, Model } from '@shared/types';
 import {
   shouldShowPolygonControls,
@@ -1566,36 +1571,39 @@ function TextAreaChat({
         </div>
         <div className="flex items-center justify-between border-t border-[#2a2a2a] p-3">
           <div className="flex items-center gap-1">
-            <div
-              className={cn(
-                'transition-all duration-300 ease-out',
-                'pointer-events-auto scale-100 opacity-100',
-              )}
-            >
-              <Button
-                variant="outline"
-                className="flex h-8 w-8 items-center gap-2 rounded-lg border border-[#2a2a2a] bg-adam-background-2 p-0 text-sm text-adam-text-secondary hover:bg-adam-bg-secondary-dark"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  const input = document.createElement('input');
-                  input.type = 'file';
-                  input.accept = `${VALID_IMAGE_FORMATS.join(', ')}, ${
-                    type === 'creative'
-                      ? SUPPORTED_MESH_EXTENSIONS.join(', ')
-                      : '.stl'
-                  }`;
-                  input.onchange = (event) => {
-                    handleItemsChange(
-                      event as unknown as ChangeEvent<HTMLInputElement>,
-                    );
-                  };
-                  input.click();
-                }}
-                disabled={disabled}
+            {(type !== 'parametric' ||
+              parametricModelSupportsVision(model)) && (
+              <div
+                className={cn(
+                  'transition-all duration-300 ease-out',
+                  'pointer-events-auto scale-100 opacity-100',
+                )}
               >
-                <ImagePlus className="h-5 w-5" />
-              </Button>
-            </div>
+                <Button
+                  variant="outline"
+                  className="flex h-8 w-8 items-center gap-2 rounded-lg border border-[#2a2a2a] bg-adam-background-2 p-0 text-sm text-adam-text-secondary hover:bg-adam-bg-secondary-dark"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    const input = document.createElement('input');
+                    input.type = 'file';
+                    input.accept = `${VALID_IMAGE_FORMATS.join(', ')}, ${
+                      type === 'creative'
+                        ? SUPPORTED_MESH_EXTENSIONS.join(', ')
+                        : '.stl'
+                    }`;
+                    input.onchange = (event) => {
+                      handleItemsChange(
+                        event as unknown as ChangeEvent<HTMLInputElement>,
+                      );
+                    };
+                    input.click();
+                  }}
+                  disabled={disabled}
+                >
+                  <ImagePlus className="h-5 w-5" />
+                </Button>
+              </div>
+            )}
 
             {/* Creative mode toggle button */}
             {onTypeChange && (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -264,13 +264,13 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'openai/gpt-5.5-pro',
-    name: 'GPT-5.5 Pro',
-    description: 'Most powerful OpenAI model for complex reasoning',
-    provider: 'OpenAI',
+    id: 'deepseek/deepseek-v4-pro',
+    name: 'DeepSeek V4 Pro',
+    description: 'Long-context MoE model for complex reasoning and code',
+    provider: 'DeepSeek',
     supportsTools: true,
     supportsThinking: true,
-    supportsVision: true,
+    supportsVision: false,
   },
 ];
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -295,6 +295,14 @@ export const CREATIVE_MODELS: ModelConfig[] = [
   },
 ];
 
+// Whether the selected parametric model can accept image / STL-render inputs.
+// Unknown ids (e.g. historical messages tagged with a removed model) fall back
+// to `true` so legacy conversations keep rendering normally.
+export function parametricModelSupportsVision(modelId: string): boolean {
+  const cfg = PARAMETRIC_MODELS.find((m) => m.id === modelId);
+  return cfg?.supportsVision !== false;
+}
+
 export function getBackupModel({
   message,
   parentMessage,


### PR DESCRIPTION
## Summary
- Replace `openai/gpt-5.5-pro` with `deepseek/deepseek-v4-pro` in `PARAMETRIC_MODELS`. Final picker: Gemini 3.1 Pro / Claude Opus 4.7 / GPT-5.5 / DeepSeek V4 Pro.
- Hide the upload button when the active parametric model declares `supportsVision: false`. Smallest viable gate so users can't fire the most likely failure path (click button → attach image → OpenRouter error).

## Scope
- New helper `parametricModelSupportsVision(id)` in [`src/lib/utils.ts`](src/lib/utils.ts). Unknown ids fall back to `true` so historical messages with removed model slugs keep rendering normally.
- Drag-drop and paste paths remain ungated — those are edge cases and gating them properly would mean wiring `supportsVision` enforcement through `addItems` and `handleSubmit`, which expands this beyond a model swap. Left for a follow-up if we want full coverage.

## Test plan
- [ ] Open the chat model picker and confirm DeepSeek V4 Pro is present and GPT-5.5 Pro is gone.
- [ ] Select DeepSeek V4 Pro and confirm the image/STL upload button disappears.
- [ ] Switch back to a vision-capable parametric model (e.g. GPT-5.5) and confirm the upload button reappears.
- [ ] Send a text-only prompt with DeepSeek V4 Pro selected and confirm it routes through OpenRouter end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)