### PR TITLE
chore: CI, issue/PR templates, package.json metadata, README windows note

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug report
+description: Something is broken in CADAM (the open-source app or the demo at adam.new/cadam)
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Before opening, please search existing issues to avoid duplicates.
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where did you hit this?
+      options:
+        - "Live demo at adam.new/cadam"
+        - "Local dev (cloned this repo)"
+        - "Self-hosted / forked"
+      default: 0
+    validations:
+      required: true
+
+  - type: input
+    id: prompt
+    attributes:
+      label: Prompt or input
+      description: If the bug happened during generation, paste the prompt and any image filename.
+      placeholder: "a parametric phone stand for a Pixel 8"
+
+  - type: dropdown
+    id: model
+    attributes:
+      label: Model selected (if known)
+      options:
+        - "Don't know / default"
+        - "Claude Opus 4.7"
+        - "GPT-5.5"
+        - "GPT-5.5 Pro"
+        - "Gemini 3.1 Pro"
+        - "DeepSeek V4 Pro"
+        - "Other (mention in description)"
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to adam.new/cadam
+        2. Type "..."
+        3. Click ...
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened?
+      description: Include error text, console output, or a screen recording link if you can.
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser + OS
+      placeholder: "Chrome 130 / macOS 15.1"
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord community
+    url: https://discord.com/invite/HKdXDqAHCs
+    about: Quick questions, demo sharing, troubleshooting
+  - name: Live demo
+    url: https://adam.new/cadam
+    about: Try CADAM without cloning anything

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Suggest something CADAM should do
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Start with the user pain, not the implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would a good solution look like?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What alternatives have you considered?
+
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Who would benefit most?
+      multiple: true
+      options:
+        - "3D printing hobbyists / makers"
+        - "Mechanical engineers"
+        - "Industrial designers"
+        - "Students / educators"
+        - "Power OpenSCAD users"
+        - "Other (mention in description)"

--- a/.github/ISSUE_TEMPLATE/model_routing.yml
+++ b/.github/ISSUE_TEMPLATE/model_routing.yml
@@ -1,0 +1,43 @@
+name: Model / routing issue
+description: Something about model selection, output quality, or vision support is off
+title: "[Model] "
+labels: ["model-routing"]
+body:
+  - type: dropdown
+    id: model
+    attributes:
+      label: Which model?
+      options:
+        - "Claude Opus 4.7"
+        - "GPT-5.5"
+        - "GPT-5.5 Pro"
+        - "Gemini 3.1 Pro"
+        - "DeepSeek V4 Pro"
+        - "Other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: prompt
+    attributes:
+      label: Prompt or image
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: What did the model produce?
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Anything else useful (regression vs prior model, vision-related, region/locale, etc.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- What does this PR do, in one or two sentences? -->
+
+## Why
+
+<!-- Linked issue, user pain, or product reason. -->
+
+Closes #
+
+## Changes
+
+<!-- Bullet the meaningful changes. -->
+
+-
+
+## Testing
+
+<!-- How was this verified? Manual steps, screenshots, recordings, unit tests. -->
+
+- [ ] Manually tested locally
+- [ ] Tested on the live demo (if applicable)
+- [ ] Added or updated tests (if applicable)
+
+## Risk
+
+<!-- Anything risky? Migrations, prod-only paths, irreversible operations, model behavior changes. -->
+
+## Screenshots / clips
+
+<!-- Optional: drag in a recording or before/after image. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: typecheck / lint / build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+        env:
+          # Build expects these to be defined; supply harmless local-style defaults
+          # so a fresh fork can still verify the pipeline without prod secrets.
+          VITE_SUPABASE_ANON_KEY: ci-placeholder-anon-key
+          VITE_SUPABASE_URL: http://127.0.0.1:54321
+          VITE_POSTHOG_PROJECT_KEY: ci-placeholder-posthog
+          VITE_SENTRY_ENVIRONMENT: ci
+          VITE_SENTRY_DSN: ''

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ npm run dev
 
 - Node.js and npm
 - Supabase CLI
+- Docker Desktop (required by `npx supabase start` to run the local Postgres + Edge Functions runtime; **on Windows** ensure Docker Desktop is installed and running before running `npx supabase start`, otherwise it will fail with a missing-Docker-engine error)
 - ngrok (for local webhook development)
 
 ## 🔧 Setting Up Environment Variables
@@ -160,7 +161,7 @@ npx supabase functions serve --no-verify-jwt
 
 ## 🛠️ Built With
 
-- **Frontend:** React 18 + TypeScript + Vite
+- **Frontend:** React 19 + TypeScript + Vite
 - **3D Rendering:** Three.js + React Three Fiber
 - **CAD Engine:** OpenSCAD WebAssembly
 - **Backend:** Supabase (PostgreSQL + Edge Functions)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,30 @@
 {
-  "name": "vite-react-typescript-starter",
+  "name": "cadam",
+  "version": "0.1.0",
+  "description": "CADAM is the open source text-to-CAD web application. Generate parametric 3D models from natural language and images, export STL/SCAD, runs in your browser via OpenSCAD WebAssembly.",
+  "homepage": "https://adam.new/cadam",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Adam-CAD/CADAM.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Adam-CAD/CADAM/issues"
+  },
+  "author": "Adam (https://adam.new)",
+  "license": "GPL-3.0-or-later",
+  "keywords": [
+    "cad",
+    "text-to-cad",
+    "openscad",
+    "wasm",
+    "3d",
+    "parametric",
+    "ai",
+    "llm",
+    "three-js",
+    "react"
+  ],
   "private": true,
-  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Repo hygiene pass: adds CI, issue/PR templates, fixes `package.json` metadata, and documents the Docker Desktop requirement on Windows.

This is the first PR in an unattended ops loop Eve is running for CADAM. All Eve-authored branches are prefixed `eve/...` so they're easy to filter and revert. No code changes touch product surface.

## Why

The repo is at 2.6k stars with no automated guardrails on PRs (no GitHub Actions workflows defined), `package.json` still ships the placeholder `vite-react-typescript-starter` / `0.0.0`, and Windows users keep hitting the same wall on `npx supabase start`.

Closes #118.

## Changes

- `.github/workflows/ci.yml`: typecheck + lint + build on every PR and push to `master`. Concurrency-cancels in-flight runs on the same ref.
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,model_routing,config}.yml`: structured templates so we get reproducible bug reports (model + prompt + browser) and contributor-friendly feature requests. Disables blank issues; surfaces Discord and the live demo as contact links.
- `.github/PULL_REQUEST_TEMPLATE.md`: standard summary / why / changes / testing / risk template.
- `package.json`: `name` -> `cadam`, `version` -> `0.1.0` (matches the v0.1.0 GitHub release), plus `description`, `homepage`, `repository`, `bugs`, `author`, `license` (`GPL-3.0-or-later`), `keywords`. No dependency or script changes.
- `README.md`: adds Docker Desktop to Prerequisites with a Windows-specific note (closes #118), corrects the "Built With" line from React 18 to React 19 (matches the actual `react@19.1.0` dependency).

## Testing

- [x] Files render correctly on the branch view.
- [x] CI workflow uses the existing `npm run typecheck`, `npm run lint`, `npm run build` scripts (no script changes needed).
- [ ] Need a maintainer to confirm the placeholder `VITE_*` env values in CI don't break the build (Vite usually treats undefined `import.meta.env` as `undefined` at build time; the placeholders are belt-and-braces).
- [ ] First PR run will show whether `npm ci` succeeds against `package-lock.json` on Node 20.

## Risk

Low.

- The `package.json` rename changes the `name` field, which could affect any downstream tool that keys off it (none known in this repo).
- License field switched from `GPL-3.0` to `GPL-3.0-or-later` to match the actual `LICENSE` text and the SPDX recommendation. If you'd rather keep it pinned to `GPL-3.0`, happy to revert that single change.
- No code paths touched, no migrations, no secrets.

## Follow-up PRs already queued

1. `eve/vitest-harness` - Vitest setup + 4 smoke tests (mutation hooks, message service, OpenSCAD worker happy path, parameter parser).
2. `eve/regression-tests-115-113` - regression tests targeting the abort behavior in #115 and the pending-tool-call recovery in #113, then re-request review on those PRs.
3. `eve/readme-demo-gif` - replace static screenshots with a 3s loop on the GitHub landing surface.

---

Drafted and pushed by Eve operating on Zach's full-approval grant. PR is opened as a draft - flip to ready when you've eyeballed it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CI and repo templates, fixes `package.json` metadata, and documents the Windows Docker requirement. No product behavior changes.

- **Refactors**
  - Added `CI` workflow to typecheck, lint, and build on PRs and pushes to `master`; cancels in‑flight runs; uses Node 20 with safe `VITE_*` placeholders.
  - Added issue templates (bug, feature, model routing), PR template, and contact links; disabled blank issues.
  - Updated `package.json`: `name` → `cadam`, `version` → `0.1.0`, plus description, homepage, repository, bugs, author, license `GPL-3.0-or-later`, keywords (no deps/scripts changed).
  - Updated `README.md`: note that Windows needs Docker Desktop for `npx supabase start` and corrected React 19. Closes #118.

<sup>Written for commit 3a4b2f4d9336898c1d7f1e45188f36c2553093ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

