### PR TITLE
feat(parametric): add DXF export to download menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 - 🤖 **AI-Powered Generation** - Transform natural language and images into 3D models
 - 🎛️ **Parametric Controls** - Interactive sliders for instant dimension adjustments
-- 📦 **Multiple Export Formats** - Export as .STL or .SCAD files
+- 📦 **Multiple Export Formats** - Export as .STL, .SCAD, or .DXF files
 - 🌐 **Browser-Based** - Runs entirely in your browser using WebAssembly
 - 📚 **Library Support** - Includes BOSL, BOSL2, and MCAD libraries
 

--- a/src/components/parameter/ParameterSection.tsx
+++ b/src/components/parameter/ParameterSection.tsx
@@ -1,4 +1,10 @@
-import { RefreshCcw, Download, ChevronUp, ChevronDown } from 'lucide-react';
+import {
+  RefreshCcw,
+  Download,
+  ChevronUp,
+  ChevronDown,
+  Loader2,
+} from 'lucide-react';
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -26,21 +32,33 @@ import {
   isColorParameter,
 } from '@/utils/parameterUtils';
 import { useCurrentMessage } from '@/contexts/CurrentMessageContext';
-import { downloadSTLFile, downloadOpenSCADFile } from '@/utils/downloadUtils';
+import {
+  downloadSTLFile,
+  downloadOpenSCADFile,
+  downloadDXFFile,
+  DxfExporter,
+} from '@/utils/downloadUtils';
+import { useToast } from '@/hooks/use-toast';
 
 interface ParameterSectionProps {
   parameters: Parameter[];
   onSubmit: (message: Message | null, parameters: Parameter[]) => void;
   currentOutput?: Blob;
+  dxfExporter?: DxfExporter | null;
 }
+
+type DownloadFormat = 'stl' | 'scad' | 'dxf';
 
 export function ParameterSection({
   parameters,
   onSubmit,
   currentOutput,
+  dxfExporter,
 }: ParameterSectionProps) {
   const { currentMessage } = useCurrentMessage();
-  const [selectedFormat, setSelectedFormat] = useState<'stl' | 'scad'>('stl');
+  const { toast } = useToast();
+  const [selectedFormat, setSelectedFormat] = useState<DownloadFormat>('stl');
+  const [isExporting, setIsExporting] = useState(false);
 
   // Split params into the main list (non-color, shown by default) and a
   // collapsible Colors group below it. Keeps the dimensions the user
@@ -103,14 +121,6 @@ export function ParameterSection({
     debouncedSubmit(updatedParameters);
   };
 
-  const handleDownload = () => {
-    if (selectedFormat === 'stl') {
-      handleDownloadSTL();
-    } else {
-      handleDownloadOpenSCAD();
-    }
-  };
-
   const handleDownloadSTL = () => {
     if (!currentOutput) return;
     downloadSTLFile(currentOutput, currentMessage);
@@ -121,10 +131,48 @@ export function ParameterSection({
     downloadOpenSCADFile(currentMessage.content.artifact.code, currentMessage);
   };
 
-  const isDownloadDisabled =
-    selectedFormat === 'stl'
-      ? !currentOutput
-      : !currentMessage?.content.artifact?.code;
+  const handleDownloadDXF = async () => {
+    if (!dxfExporter) return;
+
+    // DXF is async, generated on click via a fresh OpenSCAD compile, it can reject.
+    try {
+      setIsExporting(true);
+      const dxfOutput = await dxfExporter();
+      downloadDXFFile(dxfOutput, currentMessage);
+    } catch (error) {
+      console.error('[OpenSCAD] Failed to export DXF:', error);
+      // Optional user-facing feedback to surface the failure
+      toast({
+        title: 'DXF export failed',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Adam could not export this model as DXF.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  // Per-format dispatch tables — each supported format is a single line in each map.
+  const downloadHandlers: Record<DownloadFormat, () => void | Promise<void>> = {
+    stl: handleDownloadSTL,
+    scad: handleDownloadOpenSCAD,
+    dxf: handleDownloadDXF,
+  };
+  const formatAvailable: Record<DownloadFormat, boolean> = {
+    stl: !!currentOutput,
+    scad: !!currentMessage?.content.artifact?.code,
+    dxf: !!dxfExporter && !isExporting,
+  };
+
+  const handleDownload = async () => {
+    await downloadHandlers[selectedFormat]();
+  };
+  const isDownloadDisabled = !formatAvailable[selectedFormat];
+  // Keep the format menu available when any download format has content.
+  const isAnyFormatAvailable = Object.values(formatAvailable).some(Boolean);
 
   return (
     <div className="h-full w-full max-w-full border-l border-gray-200/20 bg-adam-bg-secondary-dark dark:border-gray-800">
@@ -240,15 +288,17 @@ export function ParameterSection({
               aria-label={`download ${selectedFormat.toUpperCase()} file`}
               className="h-12 flex-1 rounded-r-none bg-adam-neutral-50 text-adam-neutral-800 hover:bg-adam-neutral-100 hover:text-adam-neutral-900"
             >
-              <Download className="mr-2 h-4 w-4" />
+              {isExporting ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Download className="mr-2 h-4 w-4" />
+              )}
               {selectedFormat.toUpperCase()}
             </Button>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
-                  disabled={
-                    !currentOutput && !currentMessage?.content.artifact?.code
-                  }
+                  disabled={!isAnyFormatAvailable}
                   aria-label="select download format"
                   className="h-12 w-12 rounded-l-none border-l border-adam-neutral-300 bg-adam-neutral-50 p-0 text-adam-neutral-800 hover:bg-adam-neutral-100 hover:text-adam-neutral-900"
                 >
@@ -261,7 +311,7 @@ export function ParameterSection({
               >
                 <DropdownMenuItem
                   onClick={() => setSelectedFormat('stl')}
-                  disabled={!currentOutput}
+                  disabled={!formatAvailable.stl}
                   className="cursor-pointer text-adam-text-primary"
                 >
                   <span className="text-sm">.STL</span>
@@ -271,12 +321,22 @@ export function ParameterSection({
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => setSelectedFormat('scad')}
-                  disabled={!currentMessage?.content.artifact?.code}
+                  disabled={!formatAvailable.scad}
                   className="cursor-pointer text-adam-text-primary"
                 >
                   <span className="text-sm">.SCAD</span>
                   <span className="ml-3 text-xs text-adam-text-primary/60">
                     OpenSCAD Code
+                  </span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => setSelectedFormat('dxf')}
+                  disabled={!formatAvailable.dxf}
+                  className="cursor-pointer text-adam-text-primary"
+                >
+                  <span className="text-sm">.DXF</span>
+                  <span className="ml-3 text-xs text-adam-text-primary/60">
+                    2D Projection to the (x,y) plane
                   </span>
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/src/components/parameter/ParameterSheetContent.tsx
+++ b/src/components/parameter/ParameterSheetContent.tsx
@@ -1,4 +1,4 @@
-import { Download, ChevronUp } from 'lucide-react';
+import { Download, ChevronUp, Loader2 } from 'lucide-react';
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -12,21 +12,33 @@ import {
 import { ParameterInput } from '@/components/parameter/ParameterInput';
 import { validateParameterValue } from '@/utils/parameterUtils';
 import { useCurrentMessage } from '@/contexts/CurrentMessageContext';
-import { downloadSTLFile, downloadOpenSCADFile } from '@/utils/downloadUtils';
+import {
+  downloadSTLFile,
+  downloadOpenSCADFile,
+  downloadDXFFile,
+  DxfExporter,
+} from '@/utils/downloadUtils';
+import { useToast } from '@/hooks/use-toast';
 
 interface ParameterSheetContentProps {
   parameters: Parameter[];
   onSubmit: (message: Message | null, parameters: Parameter[]) => void;
   currentOutput?: Blob;
+  dxfExporter?: DxfExporter | null;
 }
+
+type DownloadFormat = 'stl' | 'scad' | 'dxf';
 
 export function ParameterSheetContent({
   parameters,
   onSubmit,
   currentOutput,
+  dxfExporter,
 }: ParameterSheetContentProps) {
   const { currentMessage } = useCurrentMessage();
-  const [selectedFormat, setSelectedFormat] = useState<'stl' | 'scad'>('stl');
+  const { toast } = useToast();
+  const [selectedFormat, setSelectedFormat] = useState<DownloadFormat>('stl');
+  const [isExporting, setIsExporting] = useState(false);
 
   // Debounce timer for compilation
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -77,14 +89,6 @@ export function ParameterSheetContent({
     debouncedSubmit(updatedParameters);
   };
 
-  const handleDownload = () => {
-    if (selectedFormat === 'stl') {
-      handleDownloadSTL();
-    } else {
-      handleDownloadOpenSCAD();
-    }
-  };
-
   const handleDownloadSTL = () => {
     if (!currentOutput) return;
     downloadSTLFile(currentOutput, currentMessage);
@@ -95,10 +99,48 @@ export function ParameterSheetContent({
     downloadOpenSCADFile(currentMessage.content.artifact.code, currentMessage);
   };
 
-  const isDownloadDisabled =
-    selectedFormat === 'stl'
-      ? !currentOutput
-      : !currentMessage?.content.artifact?.code;
+  const handleDownloadDXF = async () => {
+    if (!dxfExporter) return;
+
+    // DXF is async, generated on click via a fresh OpenSCAD compile, it can reject.
+    try {
+      setIsExporting(true);
+      const dxfOutput = await dxfExporter();
+      downloadDXFFile(dxfOutput, currentMessage);
+    } catch (error) {
+      console.error('[OpenSCAD] Failed to export DXF:', error);
+      // Optional user-facing feedback to surface the failure
+      toast({
+        title: 'DXF export failed',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Adam could not export this model as DXF.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  // Per-format dispatch tables — each supported format is a single line in each map.
+  const downloadHandlers: Record<DownloadFormat, () => void | Promise<void>> = {
+    stl: handleDownloadSTL,
+    scad: handleDownloadOpenSCAD,
+    dxf: handleDownloadDXF,
+  };
+  const formatAvailable: Record<DownloadFormat, boolean> = {
+    stl: !!currentOutput,
+    scad: !!currentMessage?.content.artifact?.code,
+    dxf: !!dxfExporter && !isExporting,
+  };
+
+  const handleDownload = async () => {
+    await downloadHandlers[selectedFormat]();
+  };
+  const isDownloadDisabled = !formatAvailable[selectedFormat];
+  // Keep the format menu available when any download format has content.
+  const isAnyFormatAvailable = Object.values(formatAvailable).some(Boolean);
 
   return (
     <>
@@ -121,15 +163,17 @@ export function ParameterSheetContent({
             aria-label={`download ${selectedFormat.toUpperCase()} file`}
             className="flex-1 rounded-r-none bg-adam-neutral-50 text-adam-neutral-800 hover:bg-adam-neutral-100 hover:text-adam-neutral-900"
           >
-            <Download className="mr-2 h-4 w-4" />
+            {isExporting ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Download className="mr-2 h-4 w-4" />
+            )}
             {selectedFormat.toUpperCase()}
           </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
-                disabled={
-                  !currentOutput && !currentMessage?.content.artifact?.code
-                }
+                disabled={!isAnyFormatAvailable}
                 aria-label="select download format"
                 className="rounded-l-none border-l border-adam-neutral-300 bg-adam-neutral-50 px-2 text-adam-neutral-800 hover:bg-adam-neutral-100 hover:text-adam-neutral-900"
               >
@@ -139,7 +183,7 @@ export function ParameterSheetContent({
             <DropdownMenuContent align="end">
               <DropdownMenuItem
                 onClick={() => setSelectedFormat('stl')}
-                disabled={!currentOutput}
+                disabled={!formatAvailable.stl}
                 className="grid cursor-pointer grid-cols-3 text-adam-text-primary"
               >
                 <span className="text-sm">.STL</span>
@@ -149,12 +193,22 @@ export function ParameterSheetContent({
               </DropdownMenuItem>
               <DropdownMenuItem
                 onClick={() => setSelectedFormat('scad')}
-                disabled={!currentMessage?.content.artifact?.code}
+                disabled={!formatAvailable.scad}
                 className="grid cursor-pointer grid-cols-3 text-adam-text-primary"
               >
                 <span className="text-sm">.SCAD</span>
                 <span className="col-span-2 text-xs text-adam-text-primary/60">
                   OpenSCAD Code
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setSelectedFormat('dxf')}
+                disabled={!formatAvailable.dxf}
+                className="grid cursor-pointer grid-cols-3 text-adam-text-primary"
+              >
+                <span className="text-sm">.DXF</span>
+                <span className="col-span-2 text-xs text-adam-text-primary/60">
+                  2D Projection to the (x,y) plane
                 </span>
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/src/components/viewer/OpenSCADViewer.tsx
+++ b/src/components/viewer/OpenSCADViewer.tsx
@@ -1,5 +1,5 @@
 import { useOpenSCAD } from '@/hooks/useOpenSCAD';
-import { useEffect, useState, useContext, useRef } from 'react';
+import { useCallback, useEffect, useState, useContext, useRef } from 'react';
 import { ThreeScene } from '@/components/viewer/ThreeScene';
 import { STLLoader } from 'three/addons/loaders/STLLoader.js';
 import {
@@ -16,6 +16,8 @@ import { Button } from '@/components/ui/button';
 import OpenSCADError from '@/lib/OpenSCADError';
 import { cn } from '@/lib/utils';
 import { MeshFilesContext } from '@/contexts/MeshFilesContext';
+import { createDXFProjectionCode } from '@/utils/dxfUtils';
+import { DxfExporter } from '@/utils/downloadUtils';
 
 // Extract import() filenames from OpenSCAD code
 function extractImportFilenames(code: string): string[] {
@@ -45,6 +47,7 @@ interface OpenSCADPreviewProps {
   scadCode: string | null;
   color: string;
   onOutputChange?: (output: Blob | undefined) => void;
+  onDxfExportChange?: (exporter: DxfExporter | null) => void;
   fixError?: (error: OpenSCADError) => void;
   isMobile?: boolean;
   backgroundColor?: string;
@@ -54,12 +57,14 @@ export function OpenSCADPreview({
   scadCode,
   color,
   onOutputChange,
+  onDxfExportChange,
   fixError,
   isMobile,
   backgroundColor,
 }: OpenSCADPreviewProps) {
   const {
     compileScad,
+    exportScad,
     writeFile,
     isCompiling,
     output,
@@ -89,29 +94,38 @@ export function OpenSCADPreview({
     fallbackColorRef.current = color;
   }, [color]);
 
+  // Shared by preview compilation and on-demand exports so import() files are
+  // available in the OpenSCAD worker before either operation runs.
+  const prepareMeshFiles = useCallback(
+    async (code: string) => {
+      // Extract any import() filenames from the code
+      const importedFiles = extractImportFilenames(code);
+
+      // Write any mesh files that haven't been written yet
+      if (!meshFilesCtx) return;
+
+      for (const filename of importedFiles) {
+        const meshContent = meshFilesCtx.getMeshFile(filename);
+        const writtenBlob = writtenFilesRef.current.get(filename);
+        const needsWrite =
+          meshContent && (!writtenBlob || writtenBlob !== meshContent);
+
+        if (needsWrite && meshContent) {
+          await writeFile(filename, meshContent);
+          writtenFilesRef.current.set(filename, meshContent);
+        }
+      }
+    },
+    [writeFile, meshFilesCtx],
+  );
+
+  // Recompile the preview whenever the current SCAD code changes.
   useEffect(() => {
     if (!scadCode) return;
 
     const compileWithMeshFiles = async () => {
       try {
-        // Extract any import() filenames from the code
-        const importedFiles = extractImportFilenames(scadCode);
-
-        // Write any mesh files that haven't been written yet
-        if (meshFilesCtx) {
-          for (const filename of importedFiles) {
-            const meshContent = meshFilesCtx.getMeshFile(filename);
-            const writtenBlob = writtenFilesRef.current.get(filename);
-            const needsWrite =
-              meshContent && (!writtenBlob || writtenBlob !== meshContent);
-
-            if (needsWrite && meshContent) {
-              await writeFile(filename, meshContent);
-              writtenFilesRef.current.set(filename, meshContent);
-            }
-          }
-        }
-
+        await prepareMeshFiles(scadCode);
         compileScad(scadCode);
       } catch (err) {
         console.error('[OpenSCAD] Error preparing files for compilation:', err);
@@ -119,7 +133,20 @@ export function OpenSCADPreview({
     };
 
     compileWithMeshFiles();
-  }, [scadCode, compileScad, writeFile, meshFilesCtx]);
+  }, [scadCode, compileScad, prepareMeshFiles]);
+
+  // Register a parent-owned DXF exporter for the current SCAD code. The export
+  // runs only when the user chooses DXF from the download menu.
+  useEffect(() => {
+    if (!scadCode || !onDxfExportChange) return;
+
+    onDxfExportChange(async () => {
+      await prepareMeshFiles(scadCode);
+      return exportScad(createDXFProjectionCode(scadCode), 'dxf');
+    });
+
+    return () => onDxfExportChange(null);
+  }, [scadCode, exportScad, onDxfExportChange, prepareMeshFiles]);
 
   useEffect(() => {
     onOutputChange?.(output);

--- a/src/components/viewer/ParametricPreviewDialog.tsx
+++ b/src/components/viewer/ParametricPreviewDialog.tsx
@@ -21,18 +21,23 @@ import { Message, Parameter } from '@shared/types';
 import * as SheetPrimitive from '@radix-ui/react-dialog';
 import { cn } from '@/lib/utils';
 import { Separator } from '@/components/ui/separator';
+import { DxfExporter } from '@/utils/downloadUtils';
 
 interface ParametricPreviewDialogProps {
   onSubmit: (message: Message | null, parameters: Parameter[]) => void;
   currentOutput?: Blob;
+  dxfExporter?: DxfExporter | null;
   onOutputChange?: (output: Blob | undefined) => void;
+  onDxfExportChange?: (exporter: DxfExporter | null) => void;
   fixError?: (error: OpenSCADError) => void;
 }
 
 export function ParametricPreviewDialog({
   onSubmit,
   currentOutput,
+  dxfExporter,
   onOutputChange,
+  onDxfExportChange,
   fixError,
 }: ParametricPreviewDialogProps) {
   const { currentMessage, setCurrentMessage } = useCurrentMessage();
@@ -158,6 +163,7 @@ export function ParametricPreviewDialog({
                       scadCode={currentMessage.content.artifact.code}
                       color="#F8248A"
                       onOutputChange={onOutputChange}
+                      onDxfExportChange={onDxfExportChange}
                       fixError={fixError}
                       isMobile={true}
                       backgroundColor="#212121"
@@ -171,6 +177,7 @@ export function ParametricPreviewDialog({
                   parameters={currentMessage.content.artifact.parameters ?? []}
                   onSubmit={onSubmit}
                   currentOutput={currentOutput}
+                  dxfExporter={dxfExporter}
                 />
               </div>
             </SheetPrimitive.Content>

--- a/src/components/viewer/ParametricPreviewSection.tsx
+++ b/src/components/viewer/ParametricPreviewSection.tsx
@@ -3,11 +3,13 @@ import { useCurrentMessage } from '@/contexts/CurrentMessageContext';
 import Loader from '@/components/viewer/Loader';
 import { OpenSCADPreview } from './OpenSCADViewer';
 import OpenSCADError from '@/lib/OpenSCADError';
+import { DxfExporter } from '@/utils/downloadUtils';
 
 interface ParametricPreviewSectionProps {
   isLoading: boolean;
   color: string;
   onOutputChange?: (output: Blob | undefined) => void;
+  onDxfExportChange?: (exporter: DxfExporter | null) => void;
   fixError?: (error: OpenSCADError) => void;
   isMobile?: boolean;
 }
@@ -16,6 +18,7 @@ export function ParametricPreviewSection({
   isLoading,
   color,
   onOutputChange,
+  onDxfExportChange,
   fixError,
   isMobile,
 }: ParametricPreviewSectionProps) {
@@ -39,6 +42,7 @@ export function ParametricPreviewSection({
               scadCode={message.content.artifact.code}
               color={color}
               onOutputChange={onOutputChange}
+              onDxfExportChange={onDxfExportChange}
               fixError={fixError}
             />
           )}

--- a/src/hooks/useOpenSCAD.ts
+++ b/src/hooks/useOpenSCAD.ts
@@ -1,6 +1,11 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { WorkerMessage, WorkerMessageType } from '@/worker/types';
+import {
+  OpenSCADWorkerResponseData,
+  WorkerMessage,
+  WorkerMessageType,
+} from '@/worker/types';
 import OpenSCADError from '@/lib/OpenSCADError';
+import { normalizeOpenSCADDxf } from '@/utils/dxfUtils';
 
 // Type for pending request resolvers
 type PendingRequest = {
@@ -145,8 +150,61 @@ export function useOpenSCAD() {
     [getWorker],
   );
 
+  // Export SCAD from the worker without changing preview state.
+  // Used for on-demand downloads like projected DXF.
+  const exportScad = useCallback(
+    async (code: string, fileType: string): Promise<Blob> => {
+      const worker = getWorker();
+      const requestId = `export-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+      const responsePromise = new Promise<OpenSCADWorkerResponseData>(
+        (resolve, reject) => {
+          pendingRequestsRef.current.set(requestId, {
+            resolve: (value) => resolve(value as OpenSCADWorkerResponseData),
+            reject,
+          });
+        },
+      );
+
+      const message: WorkerMessage = {
+        id: requestId,
+        type: WorkerMessageType.EXPORT,
+        data: {
+          code,
+          params: [],
+          fileType,
+        },
+      };
+
+      worker.postMessage(message);
+      const response = await responsePromise;
+
+      if (!response.output) {
+        throw new Error('OpenSCAD did not return an export output');
+      }
+
+      // Copy worker bytes into a normal ArrayBuffer-backed view for Blob/TextDecoder.
+      const outputBytes = new Uint8Array(response.output);
+      const mimeType =
+        response.fileType === 'stl'
+          ? 'model/stl'
+          : response.fileType === 'dxf'
+            ? 'application/dxf'
+            : 'application/octet-stream';
+
+      if (response.fileType === 'dxf') {
+        const dxf = new TextDecoder().decode(outputBytes);
+        return new Blob([normalizeOpenSCADDxf(dxf)], { type: mimeType });
+      }
+
+      return new Blob([outputBytes], { type: mimeType });
+    },
+    [getWorker],
+  );
+
   return {
     compileScad,
+    exportScad,
     writeFile,
     isCompiling,
     output,

--- a/src/utils/downloadUtils.ts
+++ b/src/utils/downloadUtils.ts
@@ -1,6 +1,11 @@
 import { generate3DModelFilename } from '@/utils/file-utils';
 import { Message } from '@shared/types';
 
+// On-demand DXF generator. The OpenSCAD worker produces DXF output by recompiling
+// the source through a top-down projection, so consumers receive a callback rather
+// than a ready blob.
+export type DxfExporter = () => Promise<Blob>;
+
 interface DownloadOptions {
   content: Blob | string;
   filename: string;
@@ -92,5 +97,24 @@ export function downloadOpenSCADFile(
     content: code,
     filename,
     mimeType: 'text/plain',
+  });
+}
+
+/**
+ * Downloads DXF file from blob
+ */
+export function downloadDXFFile(
+  output: Blob,
+  currentMessage?: Message | null,
+): void {
+  const filename = generateDownloadFilename({
+    currentMessage,
+    extension: 'dxf',
+  });
+
+  downloadFile({
+    content: output,
+    filename,
+    mimeType: 'application/dxf',
   });
 }

--- a/src/utils/dxfUtils.ts
+++ b/src/utils/dxfUtils.ts
@@ -1,0 +1,173 @@
+/**
+ * Wraps OpenSCAD code in a generated module, then projects that module from
+ * above. Library imports stay global because OpenSCAD does not allow use/include
+ * directives inside module bodies.
+ * @param code The OpenSCAD source code to project for DXF export
+ * @returns OpenSCAD code wrapped in a top-down projection
+ */
+export function createDXFProjectionCode(code: string): string {
+  const { imports, body } = extractTopLevelLibraryImports(code);
+  const importBlock = imports.join('\n');
+  const sourceModule = `module __cadam_dxf_source__() {\n${body.trim()}\n}`;
+  const projection = 'projection(cut = false) __cadam_dxf_source__();';
+
+  return [importBlock, sourceModule, projection].filter(Boolean).join('\n\n');
+}
+
+/**
+ * OpenSCAD currently emits LWPOLYLINE entities while declaring an older
+ * AC1006 DXF version. Convert those contours to plain LINE entities, which
+ * CAD importers tend to handle more consistently.
+ * @param dxf Raw DXF text emitted by OpenSCAD
+ * @returns DXF text normalized for broader CAD importer compatibility
+ */
+export function normalizeOpenSCADDxf(dxf: string): string {
+  const pairs = toDxfPairs(dxf);
+  const output: DxfPair[] = [];
+
+  for (let index = 0; index < pairs.length; index += 1) {
+    const pair = pairs[index];
+
+    if (pair.code === '9' && pair.value === '$ACADVER') {
+      output.push(pair);
+      if (pairs[index + 1]?.code === '1') {
+        output.push({ code: '1', value: 'AC1009' });
+        index += 1;
+      }
+      continue;
+    }
+
+    if (pair.code === '0' && pair.value === 'LWPOLYLINE') {
+      const converted = convertLightweightPolylineToLines(pairs, index);
+      output.push(...converted.pairs);
+      index = converted.nextIndex - 1;
+      continue;
+    }
+
+    output.push(pair);
+  }
+
+  return fromDxfPairs(output);
+}
+
+type DxfPair = {
+  code: string;
+  value: string;
+};
+
+/**
+ * Parses DXF text into code/value pairs.
+ * @param dxf DXF text to parse
+ * @returns DXF group-code pairs
+ */
+function toDxfPairs(dxf: string): DxfPair[] {
+  const lines = dxf.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+  const pairs: DxfPair[] = [];
+
+  for (let index = 0; index < lines.length - 1; index += 2) {
+    pairs.push({
+      code: lines[index].trim(),
+      value: lines[index + 1].trim(),
+    });
+  }
+
+  return pairs;
+}
+
+/**
+ * Serializes DXF code/value pairs back to DXF text.
+ * @param pairs DXF group-code pairs to serialize
+ * @returns DXF text with a trailing newline
+ */
+function fromDxfPairs(pairs: DxfPair[]): string {
+  return `${pairs.map(({ code, value }) => `${code}\n${value}`).join('\n')}\n`;
+}
+
+/**
+ * Converts one LWPOLYLINE entity into a set of LINE entities.
+ * @param pairs Full DXF pair list
+ * @param startIndex Index of the LWPOLYLINE entity marker
+ * @returns Converted pairs and the index where the next entity starts
+ */
+function convertLightweightPolylineToLines(
+  pairs: DxfPair[],
+  startIndex: number,
+): { pairs: DxfPair[]; nextIndex: number } {
+  let layer = '0';
+  let closed = false;
+  let pendingX: string | null = null;
+  const vertices: Array<{ x: string; y: string }> = [];
+  let nextIndex = pairs.length;
+
+  for (let index = startIndex + 1; index < pairs.length; index += 1) {
+    const pair = pairs[index];
+
+    if (pair.code === '0') {
+      nextIndex = index;
+      break;
+    }
+
+    if (pair.code === '8') layer = pair.value;
+    if (pair.code === '70') closed = (Number(pair.value) & 1) === 1;
+    if (pair.code === '10') pendingX = pair.value;
+    if (pair.code === '20' && pendingX !== null) {
+      vertices.push({ x: pendingX, y: pair.value });
+      pendingX = null;
+    }
+  }
+
+  const converted: DxfPair[] = [];
+  const segmentCount = closed ? vertices.length : vertices.length - 1;
+
+  for (let index = 0; index < segmentCount; index += 1) {
+    const start = vertices[index];
+    const end = vertices[(index + 1) % vertices.length];
+
+    converted.push(
+      { code: '0', value: 'LINE' },
+      { code: '8', value: layer },
+      { code: '10', value: start.x },
+      { code: '20', value: start.y },
+      { code: '30', value: '0.0' },
+      { code: '11', value: end.x },
+      { code: '21', value: end.y },
+      { code: '31', value: '0.0' },
+    );
+  }
+
+  return { pairs: converted, nextIndex };
+}
+
+/**
+ * Separates top-level OpenSCAD library directives from projectable body code.
+ * Uses a line-aligned comment-stripped scan so import detection ignores `use<>`
+ * tokens that appear inside line or block comments while preserving the original
+ * source verbatim in the returned body.
+ * @param source OpenSCAD source code
+ * @returns Global imports and the remaining source body
+ */
+function extractTopLevelLibraryImports(source: string): {
+  imports: string[];
+  body: string;
+} {
+  const normalizedSource = source.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const sourceLines = normalizedSource.split('\n');
+  const scanLines = normalizedSource
+    .replace(/\/\*[\s\S]*?\*\//g, (comment) => comment.replace(/[^\n]/g, ''))
+    .replace(/\/\/[^\n]*/g, '')
+    .split('\n');
+
+  const importRegex = /^[ \t]*(?:use|include)\s*<[^>]+>\s*;?\s*$/;
+  const imports: string[] = [];
+  const body: string[] = [];
+
+  for (let index = 0; index < sourceLines.length; index += 1) {
+    if (importRegex.test(scanLines[index])) {
+      imports.push(sourceLines[index].trim());
+    } else {
+      body.push(sourceLines[index]);
+    }
+  }
+
+  return { imports, body: body.join('\n') };
+}

--- a/src/views/ParametricView.tsx
+++ b/src/views/ParametricView.tsx
@@ -17,6 +17,7 @@ import { ChevronsRight } from 'lucide-react';
 import { TreeNode } from '@shared/Tree';
 import { ParametricPreviewSection } from '@/components/viewer/ParametricPreviewSection';
 import { ParametricPreviewDialog } from '@/components/viewer/ParametricPreviewDialog';
+import { DxfExporter } from '@/utils/downloadUtils';
 
 // Panel size constants
 const PANEL_SIZES = {
@@ -74,6 +75,7 @@ export default function ParametricView({
   const [isParametersPanelCollapsed, setIsParametersPanelCollapsed] =
     useState(false);
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
+  const [dxfExporter, setDxfExporter] = useState<DxfExporter | null>(null);
   const chatPanelRef = useRef<ImperativePanelHandle>(null);
   const parameterPanelRef = useRef<ImperativePanelHandle>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
@@ -201,6 +203,12 @@ export default function ParametricView({
     }
   }, []);
 
+  const handleDxfExportChange = useCallback((exporter: DxfExporter | null) => {
+    // The state value is itself a function, so we use the lazy-set form;
+    // a bare setDxfExporter(exporter) would invoke it as a state updater.
+    setDxfExporter(() => exporter);
+  }, []);
+
   return (
     <div
       className="flex h-full w-full overflow-hidden bg-[#292828]"
@@ -220,9 +228,11 @@ export default function ParametricView({
           />
           <ParametricPreviewDialog
             onOutputChange={setCurrentOutput}
+            onDxfExportChange={handleDxfExportChange}
             fixError={!limitReached ? fixError : undefined}
             onSubmit={changeParameters}
             currentOutput={currentOutput}
+            dxfExporter={dxfExporter}
           />
         </div>
       ) : (
@@ -297,6 +307,7 @@ export default function ParametricView({
             <ParametricPreviewSection
               isLoading={isLoading}
               onOutputChange={setCurrentOutput}
+              onDxfExportChange={handleDxfExportChange}
               color={color}
               fixError={!limitReached ? fixError : undefined}
             />
@@ -363,6 +374,7 @@ export default function ParametricView({
                   }
                   onSubmit={changeParameters}
                   currentOutput={currentOutput}
+                  dxfExporter={dxfExporter}
                 />
               </div>
             )}

--- a/src/worker/openSCAD.ts
+++ b/src/worker/openSCAD.ts
@@ -18,6 +18,12 @@ const fontsConf = `<?xml version="1.0" encoding="UTF-8"?>
 // Credit
 // https://github.com/seasick/openscad-web-gui/blob/main/src/worker/openSCAD.ts
 
+// OpenSCAD CLI --export-format values, keyed by the fileType the worker receives.
+const EXPORT_FORMAT_FLAGS: Record<string, string> = {
+  stl: 'binstl',
+  dxf: 'dxf',
+};
+
 let defaultFont: ArrayBuffer;
 
 class OpenSCADWrapper {
@@ -126,7 +132,9 @@ class OpenSCADWrapper {
       return `-D${name}=${value}`;
     });
 
-    parameters.push('--export-format=binstl');
+    const exportFormat = EXPORT_FORMAT_FLAGS[data.fileType] ?? 'binstl';
+
+    parameters.push(`--export-format=${exportFormat}`);
     parameters.push(`--enable=manifold`);
     parameters.push(`--enable=fast-csg`);
     parameters.push(`--enable=lazy-union`);


### PR DESCRIPTION
## Summary

- Adds **.DXF** as a third format in the parametric download menu, alongside .STL and .SCAD.
- DXF is generated on-demand: clicking the format triggers a fresh OpenSCAD compile that wraps the user's code in a top-down `projection(cut = false)` and emits a 2D outline.
- The wrapper hoists `use<>` and `include<>` directives to top level so library imports (BOSL2, MCAD) auto-loaded by the worker keep resolving inside the projection.
- Normalizes OpenSCAD's `LWPOLYLINE` entities to plain `LINE` and downgrades the `$ACADVER` header from `AC1006` to `AC1009` for broader CAD-importer compatibility (Onshape, Inkscape, LibreCAD).

Closes #60

## Demo

### New `.DXF` entry in the parametric download menu

<img width="1919" height="1286" alt="Screenshot 2026-04-28 003206" src="https://github.com/user-attachments/assets/45021b34-4299-42d4-8878-dfb31baef371" />

The format selector now lists `.DXF — 2D Projection to the (x,y) plane` alongside `.STL` and `.SCAD`. Selecting DXF updates the main download button label.

### 3D text → DXF → Onshape

<img width="1919" height="1439" alt="Animation" src="https://github.com/user-attachments/assets/6e908f87-fc76-4f18-89c2-f55eb20d4041" />

### `use<BOSL2/std.scad>` artifact → DXF → Onshape

<img width="1918" height="1438" alt="Animation2" src="https://github.com/user-attachments/assets/66564564-48e9-4271-a16c-9b56bfbfb280" />

Both `.dxf` files open directly in Onshape with line entities preserved.

## Test plan

- [x] BOSL2-using artifact (`use<BOSL2/std.scad>`) — DXF download succeeds, projection geometry matches the 3D source in Onshape.
- [x] 3D text artifact — DXF outlines render as line entities in Onshape.
- [x] Spinner UX: the download button's `Download` icon swaps to a spinning `Loader2` during export; button disabled while exporting; file arrives on completion.
- [x] Existing `.STL` and `.SCAD` downloads continue to work unchanged.
- [x] Error path: failing projection (e.g. a non-projectable 3D-only model) surfaces the destructive toast and clears the loading state.
- [x] Mobile bottom sheet (`ParameterSheetContent`) renders the same flow.

## Notes / out of scope

- `ParameterSection` and `ParameterSheetContent` are ~80% duplicates (desktop pane vs. mobile sheet). They were updated in parallel for this PR to keep formats aligned, but they should be consolidated into a single responsive component in a follow-up — out of scope here.
- A pre-existing `react-hooks/exhaustive-deps` warning in the `useOpenSCAD.ts` cleanup block (introduced in an earlier color-rendering PR) was *not* addressed here; deferred to a focused lint-cleanup PR.

## Prior work

A previous direction toward 2D export lives in [`feature/2d-export-dxf-svg`](https://github.com/Adam-CAD/CADAM/tree/feature/2d-export-dxf-svg) (zachdive), which explored a wider scope: DXF and SVG, with both top-view and cross-section projection modes, using a separate temporary worker.

This PR ships a focused subset — DXF only, top-view only — reusing the existing OpenSCAD worker via a new `exportScad` hook. Happy to expand to SVG and cross-section in a follow-up PR if maintainers prefer the wider feature surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new export path through the OpenSCAD worker and introduces DXF post-processing, which could affect download behavior and worker interactions across formats.
> 
> **Overview**
> **Adds `.DXF` as a third parametric download format** alongside `.STL` and `.SCAD` (desktop `ParameterSection` and mobile `ParameterSheetContent`), including a spinner/disabled state during export and destructive toast on failure.
> 
> **Implements on-demand DXF generation** by wiring an `onDxfExportChange` callback from `OpenSCADPreview` up to `ParametricView`, exposing a `DxfExporter` function that recompiles via a new `useOpenSCAD().exportScad()` worker request.
> 
> **Introduces DXF-specific processing** with `createDXFProjectionCode()` (wrap + `projection(cut=false)` while hoisting top-level `use/include`) and `normalizeOpenSCADDxf()` (ACAD version tweak and `LWPOLYLINE`→`LINE` conversion), plus worker support for `--export-format=dxf`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfb70d1dbc0251cceca29cf46c3d164cc81a1cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds .DXF export to the parametric download menu alongside .STL and .SCAD. DXF is generated on click by projecting the model to the XY plane for better CAD import compatibility. Closes #60.

- **New Features**
  - Added “.DXF — 2D Projection to the (x,y) plane” option with a loading spinner; available on desktop and mobile.
  - DXF is compiled on-demand via the existing OpenSCAD worker using a top-down `projection(cut = false)`; `use<>`/`include<>` are hoisted to keep libraries working.
  - Normalizes OpenSCAD DXF: converts `LWPOLYLINE` to `LINE` and sets `$ACADVER` to `AC1009` for smoother imports (Onshape, Inkscape, LibreCAD).
  - Introduced `exportScad` in `useOpenSCAD`, wired a `dxfExporter` through preview and parameter panels, and added `downloadDXFFile`; existing `.STL`/`.SCAD` downloads are unchanged.

<sup>Written for commit cfb70d1dbc0251cceca29cf46c3d164cc81a1cf2. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/127?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

