### PR TITLE
feat(parametric): swap Owl Alpha for Grok 4.3

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -264,14 +264,14 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'openrouter/owl-alpha',
-    name: 'Owl Alpha',
+    id: 'x-ai/grok-4.3',
+    name: 'Grok 4.3',
     description:
-      'High-performance agentic model with native tool use and long-context support',
-    provider: 'OpenRouter',
+      'xAI reasoning model with always-on thinking and vision, suited for agentic workflows',
+    provider: 'xAI',
     supportsTools: true,
     supportsThinking: false,
-    supportsVision: false,
+    supportsVision: true,
   },
 ];
 

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -31,16 +31,14 @@ const OPENROUTER_API_KEY = Deno.env.get('OPENROUTER_API_KEY') ?? '';
 // doesn't need this constraint. Keep this list scoped — adding a model that
 // doesn't actually have mixed-provider tool support just narrows routing for
 // no reason.
-const REQUIRES_TOOL_CAPABLE_PROVIDER = new Set<string>([
-  'openrouter/owl-alpha',
-]);
+const REQUIRES_TOOL_CAPABLE_PROVIDER = new Set<string>([]);
 
 // Models whose OpenRouter input modality is text-only. We strip image blocks
 // from these requests because OpenRouter rejects image content for text-only
 // models and the whole turn fails. Authoritative server-side — must mirror
 // `supportsVision: false` entries in PARAMETRIC_MODELS (src/lib/utils.ts) but
 // is not derived from the client to avoid stale-client/direct-API bypass.
-const TEXT_ONLY_MODELS = new Set<string>(['openrouter/owl-alpha']);
+const TEXT_ONLY_MODELS = new Set<string>([]);
 
 // Helper to stream updated assistant message rows.
 // Silently noop if the controller is already closed (e.g. the client


### PR DESCRIPTION
## Summary
- Replace `openrouter/owl-alpha` with `x-ai/grok-4.3` in the parametric model picker.
- Mirror the swap in the `parametric-chat` edge function: drop from `TEXT_ONLY_MODELS` (Grok 4.3 accepts image input) and from `REQUIRES_TOOL_CAPABLE_PROVIDER` (Grok is single-provider on OpenRouter, so the routing constraint is unnecessary).
- Keep `supportsThinking: false` — Grok 4.3's reasoning is always-on with no configurable parameter, same rationale as the prior Owl Alpha entry.

## Test plan
- [ ] Pick "Grok 4.3" in the parametric model picker and confirm it streams a response.
- [ ] Send a message with an image attachment and confirm the image is forwarded (not stripped).
- [ ] Trigger a tool-calling turn and confirm tools fire end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)