### PR TITLE
feat(parametric): swap Grok 4.3 for Kimi K2.6

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -264,13 +264,13 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'x-ai/grok-4.3',
-    name: 'Grok 4.3',
+    id: 'moonshotai/kimi-k2.6',
+    name: 'Kimi K2.6',
     description:
-      'xAI reasoning model with always-on thinking and vision, suited for agentic workflows',
-    provider: 'xAI',
+      'Moonshot multimodal model with configurable reasoning, vision, and native tool use',
+    provider: 'MoonshotAI',
     supportsTools: true,
-    supportsThinking: false,
+    supportsThinking: true,
     supportsVision: true,
   },
 ];


### PR DESCRIPTION
## Summary
- Replace `x-ai/grok-4.3` with `moonshotai/kimi-k2.6` in the parametric model picker.
- Capability flags: `supportsTools: true`, `supportsThinking: true` (Kimi exposes a configurable `reasoning` / `reasoning_effort` parameter, unlike Grok 4.3's always-on reasoning), `supportsVision: true`.
- No edge-function changes needed: Kimi accepts image input (skip `TEXT_ONLY_MODELS`) and all 14 OpenRouter providers serving the model support tools (skip `REQUIRES_TOOL_CAPABLE_PROVIDER`).

## Why
Grok 4.3's always-on reasoning starved the parametric code-gen content stream. Reasoning tokens land in `delta.reasoning`, but `parametric-chat`'s code-gen reader only accumulates `delta.content` (intentional — internal reasoning shouldn't leak into the artifact). Result: `rawCode` finished empty, the tool call flipped to `error`, and users saw the agent preamble + tool invocation but no generated OpenSCAD. Kimi K2.6's reasoning is configurable, so output streams to `delta.content` as expected.

## Test plan
- [ ] Pick "Kimi K2.6" in the parametric model picker and send a build prompt; confirm OpenSCAD code streams into the artifact panel.
- [ ] Send a prompt with an image attachment; confirm the image is forwarded (not stripped) and influences the output.
- [ ] Trigger a tool call and confirm it resolves to an artifact (not flipped to `error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)