### PR TITLE
feat(prompt-view): add Fusion extension pill

### DIFF
--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -274,7 +274,7 @@ export function PromptView() {
                 )}
               </div>
               {!isLoading && user && !limitReached && !lowPrompts && (
-                <div className="flex justify-center">
+                <div className="flex flex-wrap justify-center gap-2">
                   <a
                     href="https://cad.onshape.com/appstore/apps/Design%20&%20Documentation/690a8dc864e816c112aa66a0"
                     target="_blank"
@@ -295,6 +295,30 @@ export function PromptView() {
                       Try our{' '}
                       <span className="font-medium text-adam-blue">
                         Onshape extension
+                      </span>
+                    </span>
+                    <ArrowUpRight className="h-3.5 w-3.5 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+                  </a>
+                  <a
+                    href="https://fusion.adam.new/install"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => {
+                      try {
+                        posthog.capture('fusion_banner_click', {
+                          location: 'prompt_view',
+                        });
+                      } catch {
+                        // Analytics failures (e.g. blocked by ad-blocker)
+                        // must never block the link's navigation.
+                      }
+                    }}
+                    className="group inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm text-adam-text-secondary transition-colors hover:border-adam-blue/40 hover:bg-adam-blue/10 hover:text-adam-text-primary"
+                  >
+                    <span>
+                      Try our{' '}
+                      <span className="font-medium text-adam-blue">
+                        Fusion extension
                       </span>
                     </span>
                     <ArrowUpRight className="h-3.5 w-3.5 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -19,6 +19,19 @@ import * as Sentry from '@sentry/react';
 import { useSendContentMutation } from '@/services/messageService';
 import { useProfile } from '@/services/profileService';
 
+const EXTENSION_PILLS = [
+  {
+    href: 'https://cad.onshape.com/appstore/apps/Design%20&%20Documentation/690a8dc864e816c112aa66a0',
+    event: 'onshape_banner_click',
+    label: 'Onshape extension',
+  },
+  {
+    href: 'https://fusion.adam.new/install',
+    event: 'fusion_banner_click',
+    label: 'Fusion extension',
+  },
+] as const;
+
 export function PromptView() {
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -275,54 +288,31 @@ export function PromptView() {
               </div>
               {!isLoading && user && !limitReached && !lowPrompts && (
                 <div className="flex flex-wrap justify-center gap-2">
-                  <a
-                    href="https://cad.onshape.com/appstore/apps/Design%20&%20Documentation/690a8dc864e816c112aa66a0"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={() => {
-                      try {
-                        posthog.capture('onshape_banner_click', {
-                          location: 'prompt_view',
-                        });
-                      } catch {
-                        // Analytics failures (e.g. blocked by ad-blocker)
-                        // must never block the link's navigation.
-                      }
-                    }}
-                    className="group inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm text-adam-text-secondary transition-colors hover:border-adam-blue/40 hover:bg-adam-blue/10 hover:text-adam-text-primary"
-                  >
-                    <span>
-                      Try our{' '}
-                      <span className="font-medium text-adam-blue">
-                        Onshape extension
+                  {EXTENSION_PILLS.map(({ href, event, label }) => (
+                    <a
+                      key={event}
+                      href={href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={() => {
+                        try {
+                          posthog.capture(event, { location: 'prompt_view' });
+                        } catch {
+                          // Analytics failures (e.g. blocked by ad-blocker)
+                          // must never block the link's navigation.
+                        }
+                      }}
+                      className="group inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm text-adam-text-secondary transition-colors hover:border-adam-blue/40 hover:bg-adam-blue/10 hover:text-adam-text-primary"
+                    >
+                      <span>
+                        Try our{' '}
+                        <span className="font-medium text-adam-blue">
+                          {label}
+                        </span>
                       </span>
-                    </span>
-                    <ArrowUpRight className="h-3.5 w-3.5 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
-                  </a>
-                  <a
-                    href="https://fusion.adam.new/install"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={() => {
-                      try {
-                        posthog.capture('fusion_banner_click', {
-                          location: 'prompt_view',
-                        });
-                      } catch {
-                        // Analytics failures (e.g. blocked by ad-blocker)
-                        // must never block the link's navigation.
-                      }
-                    }}
-                    className="group inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm text-adam-text-secondary transition-colors hover:border-adam-blue/40 hover:bg-adam-blue/10 hover:text-adam-text-primary"
-                  >
-                    <span>
-                      Try our{' '}
-                      <span className="font-medium text-adam-blue">
-                        Fusion extension
-                      </span>
-                    </span>
-                    <ArrowUpRight className="h-3.5 w-3.5 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
-                  </a>
+                      <ArrowUpRight className="h-3.5 w-3.5 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+                    </a>
+                  ))}
                 </div>
               )}
               {!user && (


### PR DESCRIPTION
## Summary
- Add a Fusion extension pill next to the existing Onshape pill in the prompt view, linking to https://fusion.adam.new/install
- Track clicks with a `fusion_banner_click` PostHog event mirroring the existing Onshape analytics
- Wrap the pills in `flex-wrap gap-2` so they sit side-by-side and reflow on narrow screens

## Test plan
- [ ] Visit the prompt view as a signed-in user with prompts remaining and confirm both pills render side-by-side
- [ ] Click the Fusion pill and confirm it opens https://fusion.adam.new/install in a new tab
- [ ] Verify `fusion_banner_click` fires in PostHog
- [ ] Resize the viewport narrow and confirm the pills wrap cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Fusion extension pill next to the Onshape pill in the prompt view to drive installs and track engagement. Pills sit side-by-side and wrap cleanly on small screens.

- **New Features**
  - Added Fusion pill linking to https://fusion.adam.new/install (opens in a new tab) and tracking `fusion_banner_click` with location `prompt_view` (non-blocking).
  - Updated layout to `flex-wrap gap-2` so pills sit side-by-side and wrap on narrow screens.

- **Refactors**
  - Moved Onshape and Fusion pills to a config-driven `EXTENSION_PILLS` map to remove duplicate JSX and make future additions a one-line change.

<sup>Written for commit c4a468b1f3db221cd2c2bd7ec2113947827577e8. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/134?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

