### PR TITLE
Update billing copy for new free-tier daily allowance

### DIFF
--- a/src/components/Subscriptions.tsx
+++ b/src/components/Subscriptions.tsx
@@ -102,7 +102,7 @@ function buildTier(
 }
 
 function creditsLines(tier: SubscriptionTier): string[] {
-  const daily = '50 free credits per day';
+  const daily = '200 free credits per day';
   if (tier.level === 'free') return [daily];
   const amount = tier.tokenAmount?.toLocaleString() ?? '';
   return [daily, `${amount} credits per month`];

--- a/src/components/UpgradeModal.tsx
+++ b/src/components/UpgradeModal.tsx
@@ -50,7 +50,7 @@ function findMonthly(
 }
 
 function creditsBadge(level: PlanLevel, product: BillingProduct | undefined) {
-  if (level === 'free') return '50 / day';
+  if (level === 'free') return '200 / day';
   const amount = product?.tokenAmount ?? 0;
   return `${amount.toLocaleString()} / mo`;
 }


### PR DESCRIPTION
## Summary
Pairs with [adam-billing#9](https://github.com/Adam-CAD/adam-billing/pull/9) and [adam-billing#10](https://github.com/Adam-CAD/adam-billing/pull/10), which doubled standard/pro plan grants and bumped free-tier daily from 50 → 200.

- `src/components/UpgradeModal.tsx`: \`'50 / day'\` → \`'200 / day'\`
- `src/components/Subscriptions.tsx`: \`'50 free credits per day'\` → \`'200 free credits per day'\`

Plan token amounts (Standard 4k/mo, Pro 10k/mo) on these views are already dynamic — they read \`tokenAmount\` from the products API, so no copy change needed for those.

## Notes
- The dead `get_subscription_token_limit()` PG function in migration `20260303204633_token_payments.sql` still has the old 1000/5000 values. **Not changing it** — that migration is immutable history, and the function was dropped in `20260429225347_drop_local_billing_schema.sql` when CADAM moved to centralized adam-billing. No live code path hits it.

## Test plan
- [ ] Open UpgradeModal — free tier badge should say "200 / day"
- [ ] Open Subscriptions page — free tier card should say "200 free credits per day"
- [ ] Confirm Standard / Pro cards still show their dynamic per-month amounts (4,000 / 10,000) once the adam-billing seed:products step has run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated billing copy to show 200 free credits/day for the Free plan in UpgradeModal and Subscriptions, aligning with the new allowance in `adam-billing`. Monthly amounts for Standard/Pro remain dynamic from the products API; no change needed.

<sup>Written for commit dd9f379ce60da068883cbcf159d9143b7b08b436. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

