### PR TITLE
Catch missed billing copy: trial dialog + Fusion mention

### DIFF
--- a/src/components/auth/TrialDialog.tsx
+++ b/src/components/auth/TrialDialog.tsx
@@ -80,7 +80,7 @@ export function TrialDialog({
           <li className="flex items-center gap-2">
             <Check className="h-4 w-4 text-adam-neutral-100" />
             <span className="text-adam-neutral-100">
-              5,000 tokens per month
+              10,000 tokens per month
             </span>
           </li>
           <li className="flex items-center gap-2">

--- a/src/config/plan-features.ts
+++ b/src/config/plan-features.ts
@@ -18,7 +18,7 @@ export const PLAN_FEATURES: Record<PlanLevel, PlanCopy> = {
     description: 'For regular use',
     features: [
       'All AI features',
-      'Tokens shared between CADAM and the Onshape extension',
+      'Tokens shared across CADAM, Onshape, and Fusion',
     ],
   },
   pro: {
@@ -26,7 +26,7 @@ export const PLAN_FEATURES: Record<PlanLevel, PlanCopy> = {
     features: [
       'All AI features',
       'Priority support',
-      'Tokens shared between CADAM and the Onshape extension',
+      'Tokens shared across CADAM, Onshape, and Fusion',
     ],
   },
 };


### PR DESCRIPTION
## Summary
Follow-up to [#135](https://github.com/Adam-CAD/CADAM/pull/135). Two spots I missed in the first sweep:

1. **`src/components/auth/TrialDialog.tsx`** (the 7-day Adam Pro trial dialog): hardcoded \`\"5,000 tokens per month\"\` → \`\"10,000 tokens per month\"\`. This is what shows when a user clicks \"Start your Free Trial\" — was telling them the OLD pro amount.
2. **`src/config/plan-features.ts`**: standard + pro bullets \`\"Tokens shared between CADAM and the Onshape extension\"\` → \`\"Tokens shared across CADAM, Onshape, and Fusion\"\`. This `PLAN_FEATURES` object powers the bullets on `/cadam/subscription`.

## Verified clean (no edit needed)
- `CreditsButton.tsx` \"Daily free credits\" — label only, value comes from `formatFull(freeTokens)` (dynamic)
- `SettingsView.tsx` \"Daily free tokens\" — same, value from `freeTokens.toLocaleString()` (dynamic)
- `SubscriptionView.tsx` — renders `Subscriptions.tsx` + `plan-features.ts`, both already updated

## Test plan
- [ ] Open `/cadam/subscription` — bullets read \"Tokens shared across CADAM, Onshape, and Fusion\"
- [ ] Trigger the trial dialog (sign-in flow for free users) — should say \"10,000 tokens per month\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missed billing copy so users see the correct Pro limits and platform coverage. The trial dialog now shows 10,000 tokens per month, and subscription features say tokens are shared across CADAM, Onshape, and Fusion.

<sup>Written for commit ceae846f82cf752a299f476a951012c03dcc60e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

