### PR TITLE
Zach/double credits copy

### DIFF
--- a/src/components/Subscriptions.tsx
+++ b/src/components/Subscriptions.tsx
@@ -102,7 +102,7 @@ function buildTier(
 }
 
 function creditsLines(tier: SubscriptionTier): string[] {
-  const daily = '50 free credits per day';
+  const daily = '200 free credits per day';
   if (tier.level === 'free') return [daily];
   const amount = tier.tokenAmount?.toLocaleString() ?? '';
   return [daily, `${amount} credits per month`];

--- a/src/components/UpgradeModal.tsx
+++ b/src/components/UpgradeModal.tsx
@@ -50,7 +50,7 @@ function findMonthly(
 }
 
 function creditsBadge(level: PlanLevel, product: BillingProduct | undefined) {
-  if (level === 'free') return '50 / day';
+  if (level === 'free') return '200 / day';
   const amount = product?.tokenAmount ?? 0;
   return `${amount.toLocaleString()} / mo`;
 }

--- a/src/components/auth/TrialDialog.tsx
+++ b/src/components/auth/TrialDialog.tsx
@@ -80,7 +80,7 @@ export function TrialDialog({
           <li className="flex items-center gap-2">
             <Check className="h-4 w-4 text-adam-neutral-100" />
             <span className="text-adam-neutral-100">
-              5,000 tokens per month
+              10,000 tokens per month
             </span>
           </li>
           <li className="flex items-center gap-2">

--- a/src/config/plan-features.ts
+++ b/src/config/plan-features.ts
@@ -18,7 +18,7 @@ export const PLAN_FEATURES: Record<PlanLevel, PlanCopy> = {
     description: 'For regular use',
     features: [
       'All AI features',
-      'Tokens shared between CADAM and the Onshape extension',
+      'Tokens shared across CADAM, Onshape, and Fusion',
     ],
   },
   pro: {
@@ -26,7 +26,7 @@ export const PLAN_FEATURES: Record<PlanLevel, PlanCopy> = {
     features: [
       'All AI features',
       'Priority support',
-      'Tokens shared between CADAM and the Onshape extension',
+      'Tokens shared across CADAM, Onshape, and Fusion',
     ],
   },
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update billing and plan copy to match new token limits and product coverage. Free tier shows 200 free credits/day, trial shows 10,000 tokens/month, and shared tokens now list CADAM, Onshape, and Fusion.

<sup>Written for commit 8435470e568a145ba23c887e8a2ab01a376de110. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

