### PR TITLE
feat(parametric): add design tree viewer

### DIFF
--- a/shared/designTree.ts
+++ b/shared/designTree.ts
@@ -1,0 +1,177 @@
+import { DesignNode, DesignNodeKind } from './types.ts';
+
+type RawDesignNode = {
+  id?: unknown;
+  kind?: unknown;
+  name?: unknown;
+  parentId?: unknown;
+  children?: unknown;
+  params?: unknown;
+  parameterNames?: unknown;
+  visible?: unknown;
+  locked?: unknown;
+  color?: unknown;
+};
+
+const DESIGN_NODE_PREFIX = '@cadam-node';
+const DESIGN_NODE_KINDS = new Set<DesignNodeKind>([
+  'assembly',
+  'part',
+  'operation',
+  'sketch',
+  'parameter-group',
+  'import',
+]);
+
+export function parseDesignTree(code: string): DesignNode[] {
+  const lines = code.split(/\r?\n/);
+  const lineStarts = getLineStarts(code);
+  const nodes: DesignNode[] = [];
+  const seenIds = new Set<string>();
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    const prefixIndex = line.indexOf(DESIGN_NODE_PREFIX);
+    if (prefixIndex === -1) continue;
+
+    const payload = line.slice(prefixIndex + DESIGN_NODE_PREFIX.length).trim();
+    if (!payload.startsWith('{')) continue;
+
+    const raw = parseRawNode(payload);
+    if (!raw) continue;
+
+    const node = normalizeNode(raw);
+    if (!node || seenIds.has(node.id)) continue;
+
+    const range = findAnnotatedRange(lines, lineStarts, index);
+    nodes.push({ ...node, codeRange: range });
+    seenIds.add(node.id);
+  }
+
+  const validIds = new Set(nodes.map((node) => node.id));
+  return nodes.map((node) => ({
+    ...node,
+    parentId:
+      node.parentId && validIds.has(node.parentId) ? node.parentId : undefined,
+    children: node.children?.filter((id) => validIds.has(id)),
+  }));
+}
+
+function parseRawNode(payload: string): RawDesignNode | null {
+  try {
+    return JSON.parse(payload) as RawDesignNode;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeNode(raw: RawDesignNode): DesignNode | null {
+  if (typeof raw.id !== 'string' || !raw.id.trim()) return null;
+  if (
+    typeof raw.kind !== 'string' ||
+    !DESIGN_NODE_KINDS.has(raw.kind as DesignNodeKind)
+  ) {
+    return null;
+  }
+
+  const id = raw.id.trim();
+  const name =
+    typeof raw.name === 'string' && raw.name.trim() ? raw.name.trim() : id;
+  const rawParams = Array.isArray(raw.parameterNames)
+    ? raw.parameterNames
+    : raw.params;
+
+  return {
+    id,
+    kind: raw.kind as DesignNodeKind,
+    name,
+    parentId: stringValue(raw.parentId),
+    children: stringArray(raw.children),
+    parameterNames: stringArray(rawParams),
+    visible: booleanValue(raw.visible),
+    locked: booleanValue(raw.locked),
+    color: stringValue(raw.color),
+  };
+}
+
+function stringValue(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function booleanValue(value: unknown) {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function stringArray(value: unknown) {
+  if (!Array.isArray(value)) return undefined;
+  const values = value.filter(
+    (item): item is string =>
+      typeof item === 'string' && item.trim().length > 0,
+  );
+  return values.length > 0 ? values.map((item) => item.trim()) : undefined;
+}
+
+function getLineStarts(code: string) {
+  const starts = [0];
+  for (let index = 0; index < code.length; index++) {
+    if (code[index] === '\n') starts.push(index + 1);
+  }
+  return starts;
+}
+
+function findAnnotatedRange(
+  lines: string[],
+  lineStarts: number[],
+  annotationLineIndex: number,
+) {
+  const startLine = findNextMeaningfulLine(lines, annotationLineIndex + 1);
+  if (startLine === -1) {
+    return {
+      start: lineStarts[annotationLineIndex],
+      end: lineStarts[annotationLineIndex] + lines[annotationLineIndex].length,
+    };
+  }
+
+  const endLine = findRangeEndLine(lines, startLine);
+  return {
+    start: lineStarts[startLine],
+    end: lineStarts[endLine] + lines[endLine].length,
+  };
+}
+
+function findNextMeaningfulLine(lines: string[], startLine: number) {
+  for (let index = startLine; index < lines.length; index++) {
+    const trimmed = lines[index].trim();
+    if (!trimmed || trimmed.startsWith('//')) continue;
+    return index;
+  }
+  return -1;
+}
+
+function findRangeEndLine(lines: string[], startLine: number) {
+  let depth = 0;
+  let sawBrace = false;
+
+  for (let index = startLine; index < lines.length; index++) {
+    const line = stripLineComment(lines[index]);
+
+    for (const char of line) {
+      if (char === '{') {
+        depth++;
+        sawBrace = true;
+      } else if (char === '}') {
+        depth = Math.max(0, depth - 1);
+      }
+    }
+
+    if (sawBrace && depth === 0) return index;
+    if (!sawBrace && line.includes(';')) return index;
+  }
+
+  return startLine;
+}
+
+function stripLineComment(line: string) {
+  const commentIndex = line.indexOf('//');
+  return commentIndex === -1 ? line : line.slice(0, commentIndex);
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -70,7 +70,29 @@ export type ParametricArtifact = {
   version: string;
   code: string;
   parameters: Parameter[];
+  designTree?: DesignNode[];
   suggestions?: string[];
+};
+
+export type DesignNodeKind =
+  | 'assembly'
+  | 'part'
+  | 'operation'
+  | 'sketch'
+  | 'parameter-group'
+  | 'import';
+
+export type DesignNode = {
+  id: string;
+  kind: DesignNodeKind;
+  name: string;
+  parentId?: string;
+  children?: string[];
+  parameterNames?: string[];
+  codeRange?: { start: number; end: number };
+  visible?: boolean;
+  locked?: boolean;
+  color?: string;
 };
 
 export type ParameterOption = { value: string | number; label: string };

--- a/src/components/design-tree/DesignTreePanel.tsx
+++ b/src/components/design-tree/DesignTreePanel.tsx
@@ -1,0 +1,173 @@
+import { DesignNode, Parameter } from '@shared/types';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import {
+  Box,
+  Boxes,
+  Braces,
+  Cuboid,
+  Eye,
+  FileInput,
+  Lock,
+  PenTool,
+} from 'lucide-react';
+
+interface DesignTreePanelProps {
+  nodes: DesignNode[];
+  selectedNodeId?: string;
+  parameters: Parameter[];
+  onSelectNode: (nodeId: string | undefined) => void;
+}
+
+const kindIcons = {
+  assembly: Boxes,
+  part: Cuboid,
+  operation: Braces,
+  sketch: PenTool,
+  'parameter-group': Box,
+  import: FileInput,
+} as const;
+
+export function DesignTreePanel({
+  nodes,
+  selectedNodeId,
+  parameters,
+  onSelectNode,
+}: DesignTreePanelProps) {
+  const nodeRows = buildTreeRows(nodes);
+  const selectedNode = nodes.find((node) => node.id === selectedNodeId);
+  const parameterCount = selectedNode?.parameterNames?.filter((name) =>
+    parameters.some((param) => param.name === name),
+  ).length;
+
+  if (nodes.length === 0) {
+    return (
+      <div className="flex min-h-[220px] flex-col items-center justify-center rounded-md border border-dashed border-adam-neutral-700 p-5 text-center">
+        <Boxes className="mb-3 h-5 w-5 text-adam-neutral-400" />
+        <p className="text-sm font-medium text-adam-text-primary">
+          No design tree yet
+        </p>
+        <p className="mt-1 text-xs leading-5 text-adam-neutral-400">
+          Add @cadam-node JSON comments above modules, operations, or assemblies
+          to make model structure editable here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-xs font-semibold text-adam-text-primary">
+            Design Tree
+          </span>
+          <Badge className="rounded-full bg-adam-neutral-800 px-2 py-0 text-[10px] text-adam-neutral-300">
+            {nodes.length}
+          </Badge>
+        </div>
+        <Button
+          variant="ghost"
+          className="h-7 rounded-md px-2 text-xs text-adam-neutral-300 hover:bg-adam-neutral-800 hover:text-adam-text-primary"
+          onClick={() => onSelectNode(undefined)}
+          disabled={!selectedNodeId}
+        >
+          Clear
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        {nodeRows.map(({ node, depth }) => {
+          const Icon = kindIcons[node.kind];
+          const selected = node.id === selectedNodeId;
+
+          return (
+            <button
+              key={node.id}
+              type="button"
+              className={cn(
+                'flex h-9 w-full items-center gap-2 rounded-md px-2 text-left transition-colors',
+                selected
+                  ? 'bg-adam-blue/20 text-adam-text-primary ring-1 ring-adam-blue/40'
+                  : 'text-adam-neutral-300 hover:bg-adam-neutral-800 hover:text-adam-text-primary',
+              )}
+              style={{ paddingLeft: `${8 + depth * 16}px` }}
+              onClick={() => onSelectNode(node.id)}
+            >
+              <Icon className="h-3.5 w-3.5 flex-shrink-0" />
+              <span className="min-w-0 flex-1 truncate text-xs font-medium">
+                {node.name}
+              </span>
+              {node.locked && <Lock className="h-3 w-3 flex-shrink-0" />}
+              {node.visible === false && (
+                <Eye className="h-3 w-3 flex-shrink-0 opacity-50" />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {selectedNode && (
+        <div className="rounded-md border border-adam-neutral-700 bg-adam-neutral-900/40 p-3">
+          <div className="flex items-center justify-between gap-2">
+            <p className="min-w-0 truncate text-xs font-semibold text-adam-text-primary">
+              {selectedNode.name}
+            </p>
+            <Badge className="rounded-full bg-adam-neutral-800 px-2 py-0 text-[10px] text-adam-neutral-300">
+              {selectedNode.kind}
+            </Badge>
+          </div>
+          <p className="mt-2 text-xs text-adam-neutral-400">
+            {parameterCount
+              ? `${parameterCount} linked parameter${parameterCount === 1 ? '' : 's'}`
+              : 'No linked parameters'}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function buildTreeRows(nodes: DesignNode[]) {
+  const childrenByParent = new Map<string | undefined, DesignNode[]>();
+  const explicitChildIds = new Set<string>();
+
+  for (const node of nodes) {
+    if (node.children) {
+      for (const childId of node.children) explicitChildIds.add(childId);
+    }
+    const siblings = childrenByParent.get(node.parentId) ?? [];
+    siblings.push(node);
+    childrenByParent.set(node.parentId, siblings);
+  }
+
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const roots = nodes.filter(
+    (node) => !node.parentId && !explicitChildIds.has(node.id),
+  );
+  const rows: { node: DesignNode; depth: number }[] = [];
+  const visited = new Set<string>();
+
+  const visit = (node: DesignNode, depth: number) => {
+    if (visited.has(node.id)) return;
+    visited.add(node.id);
+    rows.push({ node, depth });
+
+    const childNodes =
+      node.children?.map((id) => byId.get(id)).filter(isDesignNode) ??
+      childrenByParent.get(node.id) ??
+      [];
+
+    for (const child of childNodes) visit(child, depth + 1);
+  };
+
+  for (const root of roots) visit(root, 0);
+  for (const node of nodes) visit(node, 0);
+
+  return rows;
+}
+
+function isDesignNode(node: DesignNode | undefined): node is DesignNode {
+  return !!node;
+}

--- a/src/components/design-tree/DesignTreeViewerDrawer.tsx
+++ b/src/components/design-tree/DesignTreeViewerDrawer.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { Boxes, X } from 'lucide-react';
+import { DesignNode, Parameter } from '@shared/types';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { DesignTreePanel } from '@/components/design-tree/DesignTreePanel';
+
+interface DesignTreeViewerDrawerProps {
+  nodes: DesignNode[];
+  selectedNodeId?: string;
+  parameters: Parameter[];
+  onSelectNode: (nodeId: string | undefined) => void;
+}
+
+export function DesignTreeViewerDrawer({
+  nodes,
+  selectedNodeId,
+  parameters,
+  onSelectNode,
+}: DesignTreeViewerDrawerProps) {
+  const [open, setOpen] = useState(false);
+
+  if (!open) {
+    return (
+      <Button
+        type="button"
+        aria-label="Open design tree"
+        variant="ghost"
+        className="absolute left-3 top-3 z-20 h-9 rounded-md border border-adam-neutral-700/70 bg-adam-neutral-900/80 px-2 text-adam-text-primary shadow-lg backdrop-blur-md hover:bg-adam-neutral-800 hover:text-adam-text-primary"
+        onClick={() => setOpen(true)}
+      >
+        <Boxes className="h-4 w-4" />
+        <Badge className="ml-2 rounded-full bg-adam-blue px-1.5 py-0 text-[10px] text-white">
+          {nodes.length}
+        </Badge>
+      </Button>
+    );
+  }
+
+  return (
+    <div className="absolute left-3 top-3 z-20 flex max-h-[calc(100%-1.5rem)] w-[min(280px,calc(100%-1.5rem))] flex-col overflow-hidden rounded-lg border border-adam-neutral-700/80 bg-adam-bg-secondary-dark/95 shadow-2xl backdrop-blur-md">
+      <div className="flex h-11 flex-shrink-0 items-center justify-between gap-3 border-b border-adam-neutral-700 px-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <Boxes className="h-4 w-4 flex-shrink-0 text-adam-neutral-300" />
+          <span className="truncate text-sm font-semibold text-adam-text-primary">
+            Design Tree
+          </span>
+          <Badge className="rounded-full bg-adam-neutral-800 px-2 py-0 text-[10px] text-adam-neutral-300">
+            {nodes.length}
+          </Badge>
+        </div>
+        <Button
+          type="button"
+          aria-label="Close design tree"
+          variant="ghost"
+          className="h-7 w-7 flex-shrink-0 rounded-md p-0 text-adam-neutral-300 hover:bg-adam-neutral-800 hover:text-adam-text-primary"
+          onClick={() => setOpen(false)}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+      <ScrollArea className="min-h-0 flex-1 p-3">
+        <DesignTreePanel
+          nodes={nodes}
+          selectedNodeId={selectedNodeId}
+          parameters={parameters}
+          onSelectNode={onSelectNode}
+        />
+      </ScrollArea>
+    </div>
+  );
+}

--- a/src/components/parameter/ParameterSection.tsx
+++ b/src/components/parameter/ParameterSection.tsx
@@ -8,7 +8,7 @@ import {
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Message, Parameter } from '@shared/types';
+import { DesignNode, Message, Parameter } from '@shared/types';
 import {
   Tooltip,
   TooltipContent,
@@ -27,6 +27,7 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import { ParameterInput } from '@/components/parameter/ParameterInput';
+import { DesignTreePanel } from '@/components/design-tree/DesignTreePanel';
 import {
   validateParameterValue,
   isColorParameter,
@@ -39,12 +40,16 @@ import {
   DxfExporter,
 } from '@/utils/downloadUtils';
 import { useToast } from '@/hooks/use-toast';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 interface ParameterSectionProps {
   parameters: Parameter[];
   onSubmit: (message: Message | null, parameters: Parameter[]) => void;
   currentOutput?: Blob;
   dxfExporter?: DxfExporter | null;
+  designTree: DesignNode[];
+  selectedDesignNodeId?: string;
+  onSelectDesignNode: (nodeId: string | undefined) => void;
 }
 
 type DownloadFormat = 'stl' | 'scad' | 'dxf';
@@ -54,11 +59,24 @@ export function ParameterSection({
   onSubmit,
   currentOutput,
   dxfExporter,
+  designTree,
+  selectedDesignNodeId,
+  onSelectDesignNode,
 }: ParameterSectionProps) {
   const { currentMessage } = useCurrentMessage();
   const { toast } = useToast();
   const [selectedFormat, setSelectedFormat] = useState<DownloadFormat>('stl');
   const [isExporting, setIsExporting] = useState(false);
+  const selectedDesignNode = useMemo(
+    () => designTree.find((node) => node.id === selectedDesignNodeId),
+    [designTree, selectedDesignNodeId],
+  );
+
+  const visibleParameters = useMemo(() => {
+    if (!selectedDesignNode?.parameterNames?.length) return parameters;
+    const selectedNames = new Set(selectedDesignNode.parameterNames);
+    return parameters.filter((param) => selectedNames.has(param.name));
+  }, [parameters, selectedDesignNode]);
 
   // Split params into the main list (non-color, shown by default) and a
   // collapsible Colors group below it. Keeps the dimensions the user
@@ -66,12 +84,12 @@ export function ParameterSection({
   const { mainParameters, colorParameters } = useMemo(() => {
     const main: Parameter[] = [];
     const color: Parameter[] = [];
-    for (const p of parameters) {
+    for (const p of visibleParameters) {
       if (isColorParameter(p)) color.push(p);
       else main.push(p);
     }
     return { mainParameters: main, colorParameters: color };
-  }, [parameters]);
+  }, [visibleParameters]);
   const [colorsOpen, setColorsOpen] = useState(true);
   const [dimensionsOpen, setDimensionsOpen] = useState(true);
 
@@ -207,79 +225,125 @@ export function ParameterSection({
         </TooltipProvider>
       </div>
       <div className="flex h-[calc(100%-3.5rem)] flex-col justify-between overflow-hidden">
-        <ScrollArea className="flex-1 px-6 py-6">
-          <div className="flex flex-col gap-3">
-            {mainParameters.length > 0 && (
-              <Collapsible
-                open={dimensionsOpen}
-                onOpenChange={setDimensionsOpen}
-              >
-                <CollapsibleTrigger
-                  aria-label={`${dimensionsOpen ? 'Collapse' : 'Expand'} dimension parameters`}
-                  className="group flex w-full items-center justify-between gap-2 rounded-md py-1 text-xs font-semibold text-adam-text-primary transition-colors focus:outline-none"
-                >
-                  <span className="flex items-center gap-2">
-                    Dimensions
-                    <span className="text-[10px] text-adam-neutral-400">
-                      {mainParameters.length}
-                    </span>
-                  </span>
-                  <ChevronDown
-                    className={`h-3.5 w-3.5 text-adam-neutral-400 transition-all duration-200 group-hover:text-adam-text-primary ${
-                      dimensionsOpen ? 'rotate-180' : ''
-                    }`}
-                  />
-                </CollapsibleTrigger>
-                <CollapsibleContent className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
-                  <div className="mt-3 flex flex-col gap-3">
-                    {mainParameters.map((param) => (
-                      <ParameterInput
-                        key={param.name}
-                        param={param}
-                        handleCommit={handleCommit}
-                      />
-                    ))}
-                  </div>
-                </CollapsibleContent>
-              </Collapsible>
-            )}
-            {colorParameters.length > 0 && (
-              <Collapsible
-                open={colorsOpen}
-                onOpenChange={setColorsOpen}
-                className="mt-3 border-t border-adam-neutral-700/60 pt-3"
-              >
-                <CollapsibleTrigger
-                  aria-label={`${colorsOpen ? 'Collapse' : 'Expand'} color parameters`}
-                  className="group flex w-full items-center justify-between gap-2 rounded-md py-1 text-xs font-semibold text-adam-text-primary transition-colors focus:outline-none"
-                >
-                  <span className="flex items-center gap-2">
-                    Colors
-                    <span className="text-[10px] text-adam-neutral-400">
-                      {colorParameters.length}
-                    </span>
-                  </span>
-                  <ChevronDown
-                    className={`h-3.5 w-3.5 text-adam-neutral-400 transition-all duration-200 group-hover:text-adam-text-primary ${
-                      colorsOpen ? 'rotate-180' : ''
-                    }`}
-                  />
-                </CollapsibleTrigger>
-                <CollapsibleContent className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
-                  <div className="mt-3 flex flex-col gap-3">
-                    {colorParameters.map((param) => (
-                      <ParameterInput
-                        key={param.name}
-                        param={param}
-                        handleCommit={handleCommit}
-                      />
-                    ))}
-                  </div>
-                </CollapsibleContent>
-              </Collapsible>
-            )}
+        <Tabs
+          defaultValue="parameters"
+          className="flex min-h-0 flex-1 flex-col"
+        >
+          <div className="border-b border-adam-neutral-700/60 px-6 py-3">
+            <TabsList className="grid h-8 w-full grid-cols-2 rounded-md bg-adam-neutral-800 p-0.5">
+              <TabsTrigger className="h-7 rounded" value="parameters">
+                Parameters
+              </TabsTrigger>
+              <TabsTrigger className="h-7 rounded" value="tree">
+                Tree
+              </TabsTrigger>
+            </TabsList>
           </div>
-        </ScrollArea>
+          <TabsContent value="parameters" className="mt-0 min-h-0 flex-1">
+            <ScrollArea className="h-full px-6 py-6">
+              <div className="flex flex-col gap-3">
+                {selectedDesignNode && (
+                  <div className="flex items-center justify-between gap-2 rounded-md border border-adam-blue/30 bg-adam-blue/10 px-3 py-2">
+                    <span className="min-w-0 truncate text-xs text-adam-text-primary">
+                      {selectedDesignNode.name}
+                    </span>
+                    <Button
+                      variant="ghost"
+                      className="h-6 rounded px-2 text-xs text-adam-neutral-300 hover:bg-adam-neutral-800 hover:text-adam-text-primary"
+                      onClick={() => onSelectDesignNode(undefined)}
+                    >
+                      Clear
+                    </Button>
+                  </div>
+                )}
+                {mainParameters.length > 0 && (
+                  <Collapsible
+                    open={dimensionsOpen}
+                    onOpenChange={setDimensionsOpen}
+                  >
+                    <CollapsibleTrigger
+                      aria-label={`${dimensionsOpen ? 'Collapse' : 'Expand'} dimension parameters`}
+                      className="group flex w-full items-center justify-between gap-2 rounded-md py-1 text-xs font-semibold text-adam-text-primary transition-colors focus:outline-none"
+                    >
+                      <span className="flex items-center gap-2">
+                        Dimensions
+                        <span className="text-[10px] text-adam-neutral-400">
+                          {mainParameters.length}
+                        </span>
+                      </span>
+                      <ChevronDown
+                        className={`h-3.5 w-3.5 text-adam-neutral-400 transition-all duration-200 group-hover:text-adam-text-primary ${
+                          dimensionsOpen ? 'rotate-180' : ''
+                        }`}
+                      />
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
+                      <div className="mt-3 flex flex-col gap-3">
+                        {mainParameters.map((param) => (
+                          <ParameterInput
+                            key={param.name}
+                            param={param}
+                            handleCommit={handleCommit}
+                          />
+                        ))}
+                      </div>
+                    </CollapsibleContent>
+                  </Collapsible>
+                )}
+                {colorParameters.length > 0 && (
+                  <Collapsible
+                    open={colorsOpen}
+                    onOpenChange={setColorsOpen}
+                    className="mt-3 border-t border-adam-neutral-700/60 pt-3"
+                  >
+                    <CollapsibleTrigger
+                      aria-label={`${colorsOpen ? 'Collapse' : 'Expand'} color parameters`}
+                      className="group flex w-full items-center justify-between gap-2 rounded-md py-1 text-xs font-semibold text-adam-text-primary transition-colors focus:outline-none"
+                    >
+                      <span className="flex items-center gap-2">
+                        Colors
+                        <span className="text-[10px] text-adam-neutral-400">
+                          {colorParameters.length}
+                        </span>
+                      </span>
+                      <ChevronDown
+                        className={`h-3.5 w-3.5 text-adam-neutral-400 transition-all duration-200 group-hover:text-adam-text-primary ${
+                          colorsOpen ? 'rotate-180' : ''
+                        }`}
+                      />
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
+                      <div className="mt-3 flex flex-col gap-3">
+                        {colorParameters.map((param) => (
+                          <ParameterInput
+                            key={param.name}
+                            param={param}
+                            handleCommit={handleCommit}
+                          />
+                        ))}
+                      </div>
+                    </CollapsibleContent>
+                  </Collapsible>
+                )}
+                {visibleParameters.length === 0 && (
+                  <p className="rounded-md border border-dashed border-adam-neutral-700 p-4 text-center text-xs text-adam-neutral-400">
+                    This design node has no linked parameters.
+                  </p>
+                )}
+              </div>
+            </ScrollArea>
+          </TabsContent>
+          <TabsContent value="tree" className="mt-0 min-h-0 flex-1">
+            <ScrollArea className="h-full px-6 py-6">
+              <DesignTreePanel
+                nodes={designTree}
+                selectedNodeId={selectedDesignNodeId}
+                parameters={parameters}
+                onSelectNode={onSelectDesignNode}
+              />
+            </ScrollArea>
+          </TabsContent>
+        </Tabs>
         <div className="flex flex-col gap-4 border-t border-adam-neutral-700 px-6 py-6">
           <div className="flex">
             <Button

--- a/src/components/parameter/ParameterSheetContent.tsx
+++ b/src/components/parameter/ParameterSheetContent.tsx
@@ -1,8 +1,8 @@
 import { Download, ChevronUp, Loader2 } from 'lucide-react';
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Message, Parameter } from '@shared/types';
+import { DesignNode, Message, Parameter } from '@shared/types';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -25,6 +25,9 @@ interface ParameterSheetContentProps {
   onSubmit: (message: Message | null, parameters: Parameter[]) => void;
   currentOutput?: Blob;
   dxfExporter?: DxfExporter | null;
+  designTree: DesignNode[];
+  selectedDesignNodeId?: string;
+  onSelectDesignNode: (nodeId: string | undefined) => void;
 }
 
 type DownloadFormat = 'stl' | 'scad' | 'dxf';
@@ -34,11 +37,25 @@ export function ParameterSheetContent({
   onSubmit,
   currentOutput,
   dxfExporter,
+  designTree,
+  selectedDesignNodeId,
+  onSelectDesignNode,
 }: ParameterSheetContentProps) {
   const { currentMessage } = useCurrentMessage();
   const { toast } = useToast();
   const [selectedFormat, setSelectedFormat] = useState<DownloadFormat>('stl');
   const [isExporting, setIsExporting] = useState(false);
+
+  const selectedDesignNode = useMemo(
+    () => designTree.find((node) => node.id === selectedDesignNodeId),
+    [designTree, selectedDesignNodeId],
+  );
+
+  const visibleParameters = useMemo(() => {
+    if (!selectedDesignNode?.parameterNames?.length) return parameters;
+    const selectedNames = new Set(selectedDesignNode.parameterNames);
+    return parameters.filter((param) => selectedNames.has(param.name));
+  }, [parameters, selectedDesignNode]);
 
   // Debounce timer for compilation
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -146,13 +163,32 @@ export function ParameterSheetContent({
     <>
       <ScrollArea className="h-full w-full px-4">
         <div className="flex flex-col gap-6 pb-4 pt-2">
-          {parameters.map((param) => (
+          {selectedDesignNode && (
+            <div className="flex items-center justify-between gap-2 rounded-md border border-adam-blue/30 bg-adam-blue/10 px-3 py-2">
+              <span className="min-w-0 truncate text-xs text-adam-text-primary">
+                {selectedDesignNode.name}
+              </span>
+              <Button
+                variant="ghost"
+                className="h-6 rounded px-2 text-xs text-adam-neutral-300 hover:bg-adam-neutral-800 hover:text-adam-text-primary"
+                onClick={() => onSelectDesignNode(undefined)}
+              >
+                Clear
+              </Button>
+            </div>
+          )}
+          {visibleParameters.map((param) => (
             <ParameterInput
               key={param.name}
               param={param}
               handleCommit={handleCommit}
             />
           ))}
+          {visibleParameters.length === 0 && (
+            <p className="rounded-md border border-dashed border-adam-neutral-700 p-4 text-center text-xs text-adam-neutral-400">
+              This design node has no linked parameters.
+            </p>
+          )}
         </div>
       </ScrollArea>
       <div className="flex w-full flex-col gap-4 p-4">

--- a/src/components/viewer/OpenSCADViewer.tsx
+++ b/src/components/viewer/OpenSCADViewer.tsx
@@ -18,6 +18,8 @@ import { cn } from '@/lib/utils';
 import { MeshFilesContext } from '@/contexts/MeshFilesContext';
 import { createDXFProjectionCode } from '@/utils/dxfUtils';
 import { DxfExporter } from '@/utils/downloadUtils';
+import { DesignTreeViewerDrawer } from '@/components/design-tree/DesignTreeViewerDrawer';
+import { DesignNode, Parameter } from '@shared/types';
 
 // Extract import() filenames from OpenSCAD code
 function extractImportFilenames(code: string): string[] {
@@ -51,6 +53,10 @@ interface OpenSCADPreviewProps {
   fixError?: (error: OpenSCADError) => void;
   isMobile?: boolean;
   backgroundColor?: string;
+  designTree: DesignNode[];
+  selectedDesignNodeId?: string;
+  parameters: Parameter[];
+  onSelectDesignNode: (nodeId: string | undefined) => void;
 }
 
 export function OpenSCADPreview({
@@ -61,6 +67,10 @@ export function OpenSCADPreview({
   fixError,
   isMobile,
   backgroundColor,
+  designTree,
+  selectedDesignNodeId,
+  parameters,
+  onSelectDesignNode,
 }: OpenSCADPreviewProps) {
   const {
     compileScad,
@@ -326,8 +336,14 @@ export function OpenSCADPreview({
   }, []);
 
   return (
-    <div className="h-full w-full bg-adam-neutral-700/50 shadow-lg backdrop-blur-sm transition-all duration-300 ease-in-out">
+    <div className="relative h-full w-full overflow-hidden bg-adam-neutral-700/50 shadow-lg backdrop-blur-sm transition-all duration-300 ease-in-out">
       <div className="h-full w-full">
+        <DesignTreeViewerDrawer
+          nodes={designTree}
+          selectedNodeId={selectedDesignNodeId}
+          parameters={parameters}
+          onSelectNode={onSelectDesignNode}
+        />
         {geometry || coloredGroup ? (
           <div className="h-full w-full">
             <ThreeScene

--- a/src/components/viewer/ParametricPreviewDialog.tsx
+++ b/src/components/viewer/ParametricPreviewDialog.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/sheet';
 import { useEffect, useState, useRef } from 'react';
 import { ParameterSheetContent } from '@/components/parameter/ParameterSheetContent';
-import { Message, Parameter } from '@shared/types';
+import { DesignNode, Message, Parameter } from '@shared/types';
 import * as SheetPrimitive from '@radix-ui/react-dialog';
 import { cn } from '@/lib/utils';
 import { Separator } from '@/components/ui/separator';
@@ -30,6 +30,9 @@ interface ParametricPreviewDialogProps {
   onOutputChange?: (output: Blob | undefined) => void;
   onDxfExportChange?: (exporter: DxfExporter | null) => void;
   fixError?: (error: OpenSCADError) => void;
+  designTree: DesignNode[];
+  selectedDesignNodeId?: string;
+  onSelectDesignNode: (nodeId: string | undefined) => void;
 }
 
 export function ParametricPreviewDialog({
@@ -39,6 +42,9 @@ export function ParametricPreviewDialog({
   onOutputChange,
   onDxfExportChange,
   fixError,
+  designTree,
+  selectedDesignNodeId,
+  onSelectDesignNode,
 }: ParametricPreviewDialogProps) {
   const { currentMessage, setCurrentMessage } = useCurrentMessage();
   const [open, setOpen] = useState(true);
@@ -167,6 +173,12 @@ export function ParametricPreviewDialog({
                       fixError={fixError}
                       isMobile={true}
                       backgroundColor="#212121"
+                      designTree={designTree}
+                      selectedDesignNodeId={selectedDesignNodeId}
+                      parameters={
+                        currentMessage.content.artifact.parameters ?? []
+                      }
+                      onSelectDesignNode={onSelectDesignNode}
                     />
                   </div>
                 </div>
@@ -178,6 +190,9 @@ export function ParametricPreviewDialog({
                   onSubmit={onSubmit}
                   currentOutput={currentOutput}
                   dxfExporter={dxfExporter}
+                  designTree={designTree}
+                  selectedDesignNodeId={selectedDesignNodeId}
+                  onSelectDesignNode={onSelectDesignNode}
                 />
               </div>
             </SheetPrimitive.Content>

--- a/src/components/viewer/ParametricPreviewSection.tsx
+++ b/src/components/viewer/ParametricPreviewSection.tsx
@@ -4,6 +4,7 @@ import Loader from '@/components/viewer/Loader';
 import { OpenSCADPreview } from './OpenSCADViewer';
 import OpenSCADError from '@/lib/OpenSCADError';
 import { DxfExporter } from '@/utils/downloadUtils';
+import { DesignNode } from '@shared/types';
 
 interface ParametricPreviewSectionProps {
   isLoading: boolean;
@@ -12,6 +13,9 @@ interface ParametricPreviewSectionProps {
   onDxfExportChange?: (exporter: DxfExporter | null) => void;
   fixError?: (error: OpenSCADError) => void;
   isMobile?: boolean;
+  designTree: DesignNode[];
+  selectedDesignNodeId?: string;
+  onSelectDesignNode: (nodeId: string | undefined) => void;
 }
 
 export function ParametricPreviewSection({
@@ -21,6 +25,9 @@ export function ParametricPreviewSection({
   onDxfExportChange,
   fixError,
   isMobile,
+  designTree,
+  selectedDesignNodeId,
+  onSelectDesignNode,
 }: ParametricPreviewSectionProps) {
   const { currentMessage: message } = useCurrentMessage();
 
@@ -44,6 +51,10 @@ export function ParametricPreviewSection({
               onOutputChange={onOutputChange}
               onDxfExportChange={onDxfExportChange}
               fixError={fixError}
+              designTree={designTree}
+              selectedDesignNodeId={selectedDesignNodeId}
+              parameters={message.content.artifact.parameters ?? []}
+              onSelectDesignNode={onSelectDesignNode}
             />
           )}
         </div>

--- a/src/views/ParametricEditorView.tsx
+++ b/src/views/ParametricEditorView.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/services/messageService';
 import { useAuth } from '@/contexts/AuthContext';
 import Tree from '@shared/Tree';
+import { parseDesignTree } from '@shared/designTree';
 import { useRequestCancellation } from '@/hooks/useRequestCancellation';
 import posthog from 'posthog-js';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
@@ -135,6 +136,7 @@ export function ParametricEditorView() {
           version: message.content.artifact?.version ?? '',
           code: newCode,
           parameters: updatedParameters,
+          designTree: parseDesignTree(newCode),
           suggestions: message.content.artifact?.suggestions ?? [],
         },
       };

--- a/src/views/ParametricView.tsx
+++ b/src/views/ParametricView.tsx
@@ -1,6 +1,6 @@
 import { ChatSection } from '@/components/chat/ChatSection';
 import { ParameterSection } from '@/components/parameter/ParameterSection';
-import { Content, Message, Model, Parameter } from '@shared/types';
+import { Content, DesignNode, Message, Model, Parameter } from '@shared/types';
 import OpenSCADError from '@/lib/OpenSCADError';
 import { cn } from '@/lib/utils';
 import { useRef, useState, useMemo, useCallback, useLayoutEffect } from 'react';
@@ -18,6 +18,7 @@ import { TreeNode } from '@shared/Tree';
 import { ParametricPreviewSection } from '@/components/viewer/ParametricPreviewSection';
 import { ParametricPreviewDialog } from '@/components/viewer/ParametricPreviewDialog';
 import { DxfExporter } from '@/utils/downloadUtils';
+import { parseDesignTree } from '@shared/designTree';
 
 // Panel size constants
 const PANEL_SIZES = {
@@ -76,6 +77,9 @@ export default function ParametricView({
     useState(false);
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
   const [dxfExporter, setDxfExporter] = useState<DxfExporter | null>(null);
+  const [selectedDesignNodeId, setSelectedDesignNodeId] = useState<
+    string | undefined
+  >();
   const chatPanelRef = useRef<ImperativePanelHandle>(null);
   const parameterPanelRef = useRef<ImperativePanelHandle>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
@@ -152,6 +156,22 @@ export default function ParametricView({
     () => !!currentMessage?.content.artifact,
     [currentMessage],
   );
+
+  const designTree = useMemo<DesignNode[]>(() => {
+    const artifact = currentMessage?.content.artifact;
+    if (!artifact?.code) return [];
+    if (artifact.designTree?.length) return artifact.designTree;
+    return parseDesignTree(artifact.code);
+  }, [currentMessage?.content.artifact]);
+
+  useLayoutEffect(() => {
+    if (
+      selectedDesignNodeId &&
+      !designTree.some((node) => node.id === selectedDesignNodeId)
+    ) {
+      setSelectedDesignNodeId(undefined);
+    }
+  }, [designTree, selectedDesignNodeId]);
 
   // `react-resizable-panels` only honors `defaultSize` at initial mount, and
   // the PanelGroup's `autoSaveId` can restore a persisted size of 0 from a
@@ -233,6 +253,9 @@ export default function ParametricView({
             onSubmit={changeParameters}
             currentOutput={currentOutput}
             dxfExporter={dxfExporter}
+            designTree={designTree}
+            selectedDesignNodeId={selectedDesignNodeId}
+            onSelectDesignNode={setSelectedDesignNodeId}
           />
         </div>
       ) : (
@@ -310,6 +333,9 @@ export default function ParametricView({
               onDxfExportChange={handleDxfExportChange}
               color={color}
               fixError={!limitReached ? fixError : undefined}
+              designTree={designTree}
+              selectedDesignNodeId={selectedDesignNodeId}
+              onSelectDesignNode={setSelectedDesignNodeId}
             />
           </Panel>
           {/*
@@ -375,6 +401,9 @@ export default function ParametricView({
                   onSubmit={changeParameters}
                   currentOutput={currentOutput}
                   dxfExporter={dxfExporter}
+                  designTree={designTree}
+                  selectedDesignNodeId={selectedDesignNodeId}
+                  onSelectDesignNode={setSelectedDesignNodeId}
                 />
               </div>
             )}

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -9,6 +9,7 @@ import {
 } from '@shared/types.ts';
 import { getAnonSupabaseClient } from '../_shared/supabaseClient.ts';
 import Tree from '@shared/Tree.ts';
+import { parseDesignTree } from '@shared/designTree.ts';
 import parseParameters from '../_shared/parseParameter.ts';
 import { formatUserMessage } from '../_shared/messageUtils.ts';
 import { corsHeaders } from '../_shared/cors.ts';
@@ -393,13 +394,17 @@ const tools = [
 // Strict prompt for producing only OpenSCAD (no suggestion requirement)
 const STRICT_CODE_PROMPT = `You are Adam, an AI CAD editor that creates and modifies OpenSCAD models. You assist users by chatting with them and making changes to their CAD in real-time. You understand that users can see a live preview of the model in a viewport on the right side of the screen while you make changes.
 
-When a user sends a message, you will reply with a response that contains only the most expert code for OpenSCAD according to a given prompt. Make sure that the syntax of the code is correct and that all parts are connected as a 3D printable object. Always write code with changeable parameters. Use full descriptive snake_case variable names (e.g. \`wheel_radius\`, \`pelican_seat_offset\`) — never abbreviate to single letters or short tokens (\`w_r\`, \`p_seat\`). Names render directly in the parameter panel. When the model has distinct parts, wrap each in a color() call with a fitting named color so the preview reads expressively. Expose the colors as string parameters (e.g. \`body_color = "SteelBlue";\` then \`color(body_color) ...\`) so the user can tweak them from the parameter panel — name them \`*_color\` and use CSS named colors or hex values as defaults. Initialize and declare the variables at the start of the code. Do not write any other text or comments in the response. If I ask about anything other than code for the OpenSCAD platform, only return a text containing '404'. Always ensure your responses are consistent with previous responses. Never include extra text in the response. Use any provided OpenSCAD documentation or context in the conversation to inform your responses.
+When a user sends a message, you will reply with a response that contains only the most expert code for OpenSCAD according to a given prompt. Make sure that the syntax of the code is correct and that all parts are connected as a 3D printable object. Always write code with changeable parameters. Use full descriptive snake_case variable names (e.g. \`wheel_radius\`, \`pelican_seat_offset\`) — never abbreviate to single letters or short tokens (\`w_r\`, \`p_seat\`). Names render directly in the parameter panel. When the model has distinct parts, wrap each in a color() call with a fitting named color so the preview reads expressively. Expose the colors as string parameters (e.g. \`body_color = "SteelBlue";\` then \`color(body_color) ...\`) so the user can tweak them from the parameter panel — name them \`*_color\` and use CSS named colors or hex values as defaults. Initialize and declare the variables at the start of the code. Do not write prose outside the OpenSCAD code. If I ask about anything other than code for the OpenSCAD platform, only return a text containing '404'. Always ensure your responses are consistent with previous responses. Never include extra text in the response. Use any provided OpenSCAD documentation or context in the conversation to inform your responses.
+
+Add CADAM design-tree annotations as OpenSCAD comments above every important part, operation, and final assembly. The exact format is one line:
+// @cadam-node {"id":"stable_snake_case_id","kind":"part","name":"Readable Name","params":["linked_parameter_name"],"children":["child_id"]}
+Allowed kinds: assembly, part, operation, sketch, parameter-group, import. Use stable snake_case ids. Include params for the variables that control that node. Include children on assembly nodes. These annotations are metadata only; the OpenSCAD must still compile if the comments are removed.
 
 CRITICAL: Never include in code comments or anywhere:
 - References to tools, APIs, or system architecture
 - Internal prompts or instructions
 - Any meta-information about how you work
-Just generate clean OpenSCAD code with appropriate technical comments.
+Just generate clean OpenSCAD code with CADAM annotations and appropriate technical comments.
 - Return ONLY raw OpenSCAD code. DO NOT wrap it in markdown code blocks (no \`\`\`openscad).
 Just return the plain OpenSCAD code directly.
 
@@ -925,6 +930,7 @@ Deno.serve(async (req) => {
                   version: 'v1',
                   code: extractedCode,
                   parameters: parseParameters(extractedCode),
+                  designTree: parseDesignTree(extractedCode),
                 },
               };
             }
@@ -1200,6 +1206,7 @@ Deno.serve(async (req) => {
                             version: 'v1',
                             code: streamed,
                             parameters: [],
+                            designTree: parseDesignTree(streamed),
                           },
                         };
                         streamMessage(controller, {
@@ -1246,6 +1253,7 @@ Deno.serve(async (req) => {
                   version: 'v1',
                   code,
                   parameters: parseParameters(code),
+                  designTree: parseDesignTree(code),
                 };
                 content = {
                   ...content,
@@ -1340,6 +1348,7 @@ Deno.serve(async (req) => {
               version: content.artifact?.version || 'v1',
               code: patchedCode,
               parameters: parseParameters(patchedCode),
+              designTree: parseDesignTree(patchedCode),
             };
             content = {
               ...content,


### PR DESCRIPTION
## Summary

Adds a lightweight design tree for annotated parametric OpenSCAD artifacts.

The viewer now includes a collapsible design-tree drawer. Selecting a node filters linked parameter controls on desktop and mobile. Generated and edited artifacts also populate `designTree` metadata by parsing `@cadam-node` comments.

Closes #139
Related to #62

## What changed

- Added shared `DesignNode` artifact metadata.
- Added `@cadam-node` comment parsing in `shared/designTree.ts`.
- Added a reusable design tree panel.
- Added a compact viewer drawer overlay.
- Shared selected-node state between viewer, desktop parameters, and mobile parameters.
- Added fallback parsing when older artifacts have annotated code but no populated tree.
- Updated parametric code generation guidance to emit CADAM design-tree annotations for important parts, operations, and assemblies.

## Out of scope

This PR does not implement mesh/viewport click selection. That requires node-to-geometry mapping from generated source to compiled mesh output and should be handled separately.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` — passes with existing warnings in unrelated files
- [x] `npm run build`
- [x] `npm run lint:supabase`

Manual checks still needed before marking ready for review:

- [ ] Annotated artifact shows viewer tree button with count.
- [ ] Opening drawer shows nested tree rows.
- [ ] Selecting a node filters desktop parameter controls.
- [ ] Clearing selection restores all parameters.
- [ ] Unannotated artifact opens drawer empty state.
- [ ] Mobile preview drawer opens and node selection filters mobile controls.
- [ ] Existing rendering, orbit controls, download controls, and compile loading overlay continue to work.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a design tree viewer for annotated OpenSCAD models. Selecting a node filters parameters, and artifacts now include `designTree` metadata parsed from `@cadam-node` comments.

- **New Features**
  - Parse `@cadam-node` comments into `DesignNode`s in `@shared/designTree` and attach `designTree` to artifacts.
  - Viewer gets a compact drawer with node count; selection is shared with desktop and mobile parameter panels.
  - Parameter panels add a Tree view and filter controls by the selected node; Clear restores all parameters.
  - Fallback parsing when older artifacts have annotations but no `designTree`.
  - Updated code-gen prompt to emit CADAM design-tree annotations for parts, operations, and assemblies.

<sup>Written for commit 4b3fbdc947d46ab09a161af2f400c789a71b3f0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

