### PR TITLE
fix(parametric): generate proper threaded geometry for screws/bolts

### DIFF
--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -403,6 +403,21 @@ Just generate clean OpenSCAD code with appropriate technical comments.
 - Return ONLY raw OpenSCAD code. DO NOT wrap it in markdown code blocks (no \`\`\`openscad).
 Just return the plain OpenSCAD code directly.
 
+# Threaded Fasteners (CRITICAL)
+For ANY screw, bolt, nut, threaded rod, or threaded hole, you MUST use the BOSL2 library — built-in primitives like \`cylinder()\` cannot represent helical threads, so a hand-rolled screw renders as a smooth cylinder or a blank gap where the thread should be. The BOSL2 library is preloaded in the runtime under \`/libraries/BOSL2/\`; the literal token \`BOSL2\` must appear in the code (via \`include\`) for the runtime to load it.
+
+Required pattern:
+1. Always start the file with \`include <BOSL2/std.scad>\` plus the relevant module file:
+   - \`include <BOSL2/screws.scad>\` for headed screws/bolts and matching tapped holes (\`screw()\`, \`screw_hole()\`, \`nut()\`).
+   - \`include <BOSL2/threading.scad>\` for plain threaded rod / studding / custom thread profiles (\`threaded_rod()\`, \`threaded_nut()\`, \`trapezoidal_threaded_rod()\`).
+2. Generate threaded geometry with the library modules — never with bare \`cylinder()\` or \`linear_extrude()\`. Examples:
+   - Bolt: \`screw("M6x1", head="hex", length=bolt_length, thread=true)\`
+   - Threaded rod: \`threaded_rod(d=rod_diameter, l=rod_length, pitch=rod_pitch)\`
+   - Tapped hole: subtract \`screw_hole("M6", length=plate_thickness, thread=true)\` inside a \`difference()\`.
+3. Set \`$fn = 64;\` (or higher; 96–128 for large diameters) at the top of the file. Threads with low \`$fn\` collapse into invisible slivers — this is the most common cause of "blank space" in the thread region.
+4. Expose dimensions (diameter, length, pitch) as snake_case parameters so the user can tweak them. Use the BOSL2 spec string ("M6x1", "#8-32") for the size whenever possible — it picks a standard pitch automatically.
+5. Do not redefine your own \`thread()\` / \`screw()\` modules — always call BOSL2's.
+
 # STL Import (CRITICAL)
 When the user uploads a 3D model (STL file) and you are told to use import():
 1. YOU MUST USE import("filename.stl") to include their original model - DO NOT recreate it
@@ -452,7 +467,21 @@ module torus(r1, r2) {
     rotate_extrude()
     translate([r1, 0, 0])
     circle(r=r2);
-}`;
+}
+
+User: "an M8 hex bolt 30mm long"
+Assistant:
+include <BOSL2/std.scad>
+include <BOSL2/screws.scad>
+
+// Bolt parameters
+bolt_spec = "M8x1.25";
+bolt_length = 30;
+bolt_color = "Silver";
+$fn = 96;
+
+color(bolt_color)
+screw(bolt_spec, head="hex", length=bolt_length, thread=true);`;
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {

--- a/supabase/functions/parametric-chat/index.ts
+++ b/supabase/functions/parametric-chat/index.ts
@@ -411,9 +411,10 @@ Required pattern:
    - \`include <BOSL2/screws.scad>\` for headed screws/bolts and matching tapped holes (\`screw()\`, \`screw_hole()\`, \`nut()\`).
    - \`include <BOSL2/threading.scad>\` for plain threaded rod / studding / custom thread profiles (\`threaded_rod()\`, \`threaded_nut()\`, \`trapezoidal_threaded_rod()\`).
 2. Generate threaded geometry with the library modules — never with bare \`cylinder()\` or \`linear_extrude()\`. Examples:
-   - Bolt: \`screw("M6x1", head="hex", length=bolt_length, thread=true)\`
+   - Bolt: \`screw("M6x1", head="hex", length=bolt_length)\`
    - Threaded rod: \`threaded_rod(d=rod_diameter, l=rod_length, pitch=rod_pitch)\`
-   - Tapped hole: subtract \`screw_hole("M6", length=plate_thickness, thread=true)\` inside a \`difference()\`.
+   - Tapped hole: subtract \`screw_hole("M6", length=plate_thickness)\` inside a \`difference()\`.
+   - Do not pass a boolean \`thread\` argument; BOSL2's \`thread\` option is a pitch/type override. Use the spec string for standard pitch and \`thread_len\` only when partial threading is needed.
 3. Set \`$fn = 64;\` (or higher; 96–128 for large diameters) at the top of the file. Threads with low \`$fn\` collapse into invisible slivers — this is the most common cause of "blank space" in the thread region.
 4. Expose dimensions (diameter, length, pitch) as snake_case parameters so the user can tweak them. Use the BOSL2 spec string ("M6x1", "#8-32") for the size whenever possible — it picks a standard pitch automatically.
 5. Do not redefine your own \`thread()\` / \`screw()\` modules — always call BOSL2's.
@@ -481,7 +482,7 @@ bolt_color = "Silver";
 $fn = 96;
 
 color(bolt_color)
-screw(bolt_spec, head="hex", length=bolt_length, thread=true);`;
+screw(bolt_spec, head="hex", length=bolt_length);`;
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {


### PR DESCRIPTION
## Summary

Closes #42.

When the model generated a screw or bolt, the threaded region rendered as smooth cylinder or blank space, and the same gap shipped through to the STL export. Root cause: the LLM was hand-rolling threads with bare \`cylinder()\` / \`linear_extrude()\`, neither of which can represent helical thread geometry in OpenSCAD. At the default low \`\$fn\`, the thread profile collapses into invisible slivers.

## Fix

Adds explicit guidance + one worked example to the parametric-chat system prompt directing the model to use **BOSL2** for any threaded fastener:

- \`include <BOSL2/std.scad>\` + the relevant module file (\`screws.scad\` for headed fasteners, \`threading.scad\` for plain threaded rod)
- Generate threaded geometry with \`screw()\`, \`screw_hole()\`, \`threaded_rod()\`, \`nut()\`, etc. — never bare primitives
- Set \`\$fn = 64\` (96–128 for larger diameters) so threads actually resolve
- Expose diameter / length / pitch as snake_case parameters
- Use the BOSL2 spec string (\`\"M6x1\"\`, \`\"#8-32\"\`) so pitch is auto-picked

BOSL2 is already preloaded in the runtime (referenced from the README as a built-in library), so no library plumbing change is needed — only the prompt.

## Test plan

- Manual: run \"M8 hex bolt 30mm long\" through the parametric chat — should now produce a model with visible helical threads (no blank gap), exportable to STL.
- Spot-check existing requests for nuts and threaded rods.

Suggested test prompts:
- \`an M6 hex bolt 25mm with matching nut\`
- \`a threaded rod 8mm diameter 100mm long, 1.25mm pitch\`
- \`a plate with four M3 tapped holes\`

## Notes

This is a pure prompt change; no runtime, library, or schema changes. The change is in \`supabase/functions/parametric-chat/index.ts\` only.

Authored by Eve (Zach's AI agent) on behalf of Adam.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing/blank threads by requiring `BOSL2` for all screws, bolts, nuts, threaded rods, and tapped holes, and removing boolean thread overrides so models and STL exports render correct helical threads (fixes #42).

- **Bug Fixes**
  - Enforce `BOSL2` includes and modules (`std.scad`, `screws.scad`, `threading.scad`); call `screw()`, `screw_hole()`, `threaded_rod()`, `nut()`.
  - Remove boolean thread flags; use size strings like "M6x1" or "#8-32" and `thread_len` only for partial threads.
  - Forbid bare `cylinder()`/`linear_extrude()`; set `$fn >= 64` (96–128 for larger diameters).
  - Add a minimal M8 hex bolt example.

<sup>Written for commit 5458cd3b96a2eea0645043da76c2515ee9d07357. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

