### PR TITLE
chore: housekeeping pass (lint, types, dead code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ npx supabase functions serve --no-verify-jwt
 
 ## 🛠️ Built With
 
-- **Frontend:** React 18 + TypeScript + Vite
+- **Frontend:** React 19 + TypeScript + Vite
 - **3D Rendering:** Three.js + React Three Fiber
 - **CAD Engine:** OpenSCAD WebAssembly
 - **Backend:** Supabase (PostgreSQL + Edge Functions)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite-react-typescript-starter",
+  "name": "cadam",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc -b --noEmit",
     "lint:supabase": "deno lint supabase",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "preview": "vite preview",
     "prepare": "husky"
   },

--- a/src/components/ParametricEditor.tsx
+++ b/src/components/ParametricEditor.tsx
@@ -1,4 +1,0 @@
-// This component now delegates to the ParametricEditorView which handles
-// all business logic (mutations, message handling) and renders ParametricView
-// for the UI layout. This re-export maintains backwards compatibility.
-export { ParametricEditorView as ParametricEditor } from '@/views/ParametricEditorView';

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -403,12 +403,7 @@ function DesktopSidebar({ isSidebarOpen, setIsSidebarOpen }: SidebarProps) {
   );
 }
 
-function MobileSidebar({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  isSidebarOpen,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  setIsSidebarOpen,
-}: SidebarProps) {
+function MobileSidebar(_props: SidebarProps) {
   const [open, setOpen] = useState(false);
 
   return (

--- a/src/views/ResetPasswordView.tsx
+++ b/src/views/ResetPasswordView.tsx
@@ -25,8 +25,7 @@ export function ResetPasswordView() {
         title: 'Success',
         description: 'Password reset instructions have been sent to your email',
       });
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (error) {
+    } catch {
       toast({
         title: 'Error',
         description: 'Failed to send reset instructions',


### PR DESCRIPTION
## Summary

A small no-behavior-change cleanup pass. Each commit is independent and self-explanatory; trivial to revert any of them individually.

### Changes

- **`chore: drop redundant eslint-disable directives`** — `src/components/Sidebar.tsx` and `src/views/ResetPasswordView.tsx`. The lint config already ignores `_`-prefixed args, and ES2019 lets us drop the catch binding entirely. The disables were no-ops.
- **`chore: remove dead ParametricEditor re-export shim`** — `src/components/ParametricEditor.tsx` was a 4-line re-export of `ParametricEditorView` that nothing in the repo imports. Its own comment said it existed for backwards compatibility, but this is a private webapp.
- **`docs: fix outdated React 18 reference in README`** — Built With section said React 18; package.json and the README badge both already say React 19.1.
- **`chore: rename package from default vite scaffold name to cadam`** — `package.json` name was still `vite-react-typescript-starter`. It surfaces in npm logs / lockfile comments.
- **`chore: add format:check script`** — mirrors the existing `format` script with `--check` so CI / pre-merge hooks can verify formatting without writing.

### Validation

- `npm run typecheck` — clean.
- `npm run lint` — `0 errors, 12 warnings` (same baseline as `master`; remaining warnings are `react-refresh/only-export-components` on shadcn/ui files and `react-hooks/exhaustive-deps` ref-cleanup notes that need behavioral judgment to fix — out of scope for this pass).
- `npm run format:check` — clean.
- `npm run build` — could not verify in this sandbox (4 GB cgroup OOMs vite during transform of the 3,800-module graph, before any of these changes are reached). The `tsc -b` portion that runs first does pass, and none of the diffs touch import graphs or build config, so build risk is low. Please run locally to confirm.

### Out of scope (deliberately untouched)

- `supabase/functions/**` — per repo guidance.
- shadcn/ui `react-refresh` warnings — would mean splitting upstream-style files.
- The two `react-hooks/exhaustive-deps` ref-cleanup warnings in `useOpenSCAD.ts` / `VisualCard.tsx` — needs runtime reasoning.
- No new dependencies, no reformat, no architectural changes.

No user-visible behavior changes.

## Test plan

- [ ] `npm install`
- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run build` (full vite build — could not run in sandbox; main concern this PR can't self-verify)
- [ ] Smoke test app locally to confirm the package rename / removed shim cause no import resolution surprises

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Housekeeping pass to remove dead code, clean up lint directives, and tighten project metadata. Removed unused `ParametricEditor` re-export, dropped redundant eslint disables (simplified catch binding), renamed package to `cadam`, added `format:check` for `prettier`, and updated README to React 19. No runtime behavior changes.

<sup>Written for commit 353e27a0e427c8f15bb6052ebdb0b0de4a41c931. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

