### PR TITLE
Add max tier

### DIFF
--- a/src/components/Subscriptions.tsx
+++ b/src/components/Subscriptions.tsx
@@ -40,7 +40,7 @@ type SubscriptionTier = {
   popular: boolean;
 };
 
-const DISPLAY_ORDER: PlanLevel[] = ['free', 'pro', 'standard'];
+const DISPLAY_ORDER: PlanLevel[] = ['free', 'standard', 'pro', 'max'];
 
 function formatPrice(cents: number): string {
   const dollars = cents / 100;
@@ -143,7 +143,7 @@ export function Subscriptions() {
   };
 
   const renderTiers = (tiers: SubscriptionTier[]) => (
-    <div className="flex flex-col items-center gap-4 px-4 md:flex-row md:items-stretch md:justify-center md:px-8">
+    <div className="mx-auto grid max-w-[340px] grid-cols-1 justify-items-center gap-4 px-4 sm:max-w-[640px] sm:grid-cols-2 md:px-8 xl:max-w-none xl:grid-cols-4">
       {tiers.map((tier) => (
         <SubscriptionCard
           key={tier.level}
@@ -161,7 +161,7 @@ export function Subscriptions() {
   return (
     <div className="min-h-screen w-full bg-adam-bg-secondary-dark">
       <div className="flex min-h-screen w-full flex-col items-center justify-center py-12">
-        <div className="w-full max-w-5xl">
+        <div className="w-full max-w-6xl">
           <div className="mb-8 px-8 text-center">
             <h1 className="mb-2 font-kumbh-sans text-3xl font-light text-white">
               Choose a plan that works for you

--- a/src/components/UpgradeModal.tsx
+++ b/src/components/UpgradeModal.tsx
@@ -94,7 +94,7 @@ export function UpgradeModal({ open, onOpenChange }: UpgradeModalProps) {
           </DialogDescription>
         </DialogHeader>
 
-        <div className="mt-2 grid grid-cols-1 gap-3 md:grid-cols-3">
+        <div className="mt-2 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
           {PLAN_ORDER.map((level) => {
             const product =
               level === 'free' ? undefined : findMonthly(products, level);

--- a/src/components/chat/AssistantMessage.tsx
+++ b/src/components/chat/AssistantMessage.tsx
@@ -669,7 +669,7 @@ function MeshLimitReachedMessage() {
     );
   }
 
-  if (level === 'pro') {
+  if (level === 'pro' || level === 'max') {
     return (
       <span>
         You have reached the limit of 1500 generations per month. Let us know if

--- a/src/config/plan-features.ts
+++ b/src/config/plan-features.ts
@@ -2,7 +2,7 @@
 // from the billing service (/v1/products), but the bullets below are a
 // product decision that doesn't belong in the billing catalog.
 
-export type PlanLevel = 'free' | 'standard' | 'pro';
+export type PlanLevel = 'free' | 'standard' | 'pro' | 'max';
 
 type PlanCopy = {
   description: string;
@@ -18,7 +18,7 @@ export const PLAN_FEATURES: Record<PlanLevel, PlanCopy> = {
     description: 'For regular use',
     features: [
       'All AI features',
-      'Tokens shared between CADAM and the Onshape extension',
+      'Tokens shared across CADAM, Onshape, and Fusion',
     ],
   },
   pro: {
@@ -26,7 +26,15 @@ export const PLAN_FEATURES: Record<PlanLevel, PlanCopy> = {
     features: [
       'All AI features',
       'Priority support',
-      'Tokens shared between CADAM and the Onshape extension',
+      'Tokens shared across CADAM, Onshape, and Fusion',
+    ],
+  },
+  max: {
+    description: 'For teams and heavy workloads',
+    features: [
+      'All AI features',
+      'Priority support',
+      'Tokens shared across CADAM, Onshape, and Fusion',
     ],
   },
 };
@@ -35,6 +43,7 @@ export const PLAN_DISPLAY_NAMES: Record<PlanLevel, string> = {
   free: 'Free',
   standard: 'Standard',
   pro: 'Pro',
+  max: 'Max',
 };
 
-export const PLAN_ORDER: PlanLevel[] = ['free', 'standard', 'pro'];
+export const PLAN_ORDER: PlanLevel[] = ['free', 'standard', 'pro', 'max'];

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react';
 import { Session, User } from '@supabase/supabase-js';
 
-export type SubscriptionLevel = 'standard' | 'pro';
+export type SubscriptionLevel = 'standard' | 'pro' | 'max';
 export type PlanLevel = SubscriptionLevel | 'free';
 
 export type BillingStatus = {

--- a/src/hooks/useBillingProducts.ts
+++ b/src/hooks/useBillingProducts.ts
@@ -1,7 +1,7 @@
 import { supabase } from '@/lib/supabase';
 import { useQuery } from '@tanstack/react-query';
 
-export type SubscriptionLevel = 'standard' | 'pro';
+export type SubscriptionLevel = 'standard' | 'pro' | 'max';
 
 export type BillingProduct = {
   id: string;

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -17,6 +17,7 @@ import * as Sentry from '@sentry/react';
 import { useProfile, useUpdateProfile } from '@/services/profileService';
 import { AvatarUpdateDialog } from '@/components/auth/AvatarUpdateDialog';
 import { useTokenPacks } from '@/hooks/useTokenPacks';
+import { PLAN_DISPLAY_NAMES } from '@/config/plan-features';
 
 function formatPeriodEnd(iso: string | null | undefined): string | null {
   if (!iso) return null;
@@ -136,12 +137,7 @@ export default function SettingsView() {
       },
     });
 
-  const tierLabel =
-    level === 'free'
-      ? 'Adam Free'
-      : level === 'standard'
-        ? 'Adam Standard'
-        : 'Adam Pro';
+  const tierLabel = `Adam ${PLAN_DISPLAY_NAMES[level]}`;
 
   const tierAccent =
     level === 'free'
@@ -294,7 +290,9 @@ export default function SettingsView() {
                       tierAccent,
                     )}
                   >
-                    {level === 'pro' && <Sparkles className="h-3 w-3" />}
+                    {(level === 'pro' || level === 'max') && (
+                      <Sparkles className="h-3 w-3" />
+                    )}
                     {tierLabel}
                   </span>
                   {periodEnd && (

--- a/supabase/functions/_shared/billingClient.ts
+++ b/supabase/functions/_shared/billingClient.ts
@@ -2,7 +2,7 @@
 // onshape-extension/src/lib/billing/client.ts so CADAM and onshape behave
 // identically against the same endpoints.
 
-export type SubscriptionLevel = 'standard' | 'pro';
+export type SubscriptionLevel = 'standard' | 'pro' | 'max';
 
 export type BillingStatus = {
   user: {
@@ -115,7 +115,10 @@ const devRefund = (tokens: number): RefundResult => ({
   totalBalance: DEV_TOKENS.total,
 });
 
-const devProducts: { subscriptions: BillingProduct[]; packs: BillingProduct[] } = {
+const devProducts: {
+  subscriptions: BillingProduct[];
+  packs: BillingProduct[];
+} = {
   subscriptions: [
     {
       id: 'dev_standard_monthly',
@@ -123,9 +126,9 @@ const devProducts: { subscriptions: BillingProduct[]; packs: BillingProduct[] } 
       stripePriceId: 'price_dev_standard_monthly',
       productType: 'subscription',
       subscriptionLevel: 'standard',
-      tokenAmount: 500_000,
+      tokenAmount: 4_000,
       name: 'Standard',
-      priceCents: 1900,
+      priceCents: 2000,
       interval: 'month',
       active: true,
     },
@@ -135,9 +138,21 @@ const devProducts: { subscriptions: BillingProduct[]; packs: BillingProduct[] } 
       stripePriceId: 'price_dev_pro_monthly',
       productType: 'subscription',
       subscriptionLevel: 'pro',
-      tokenAmount: 2_000_000,
+      tokenAmount: 10_000,
       name: 'Pro',
-      priceCents: 4900,
+      priceCents: 4000,
+      interval: 'month',
+      active: true,
+    },
+    {
+      id: 'dev_max_monthly',
+      stripeProductId: 'prod_dev_max',
+      stripePriceId: 'price_dev_max_monthly',
+      productType: 'subscription',
+      subscriptionLevel: 'max',
+      tokenAmount: 50_000,
+      name: 'Max',
+      priceCents: 20000,
       interval: 'month',
       active: true,
     },
@@ -257,10 +272,16 @@ export const billing = {
   },
 
   consume: (email: string, body: ConsumeBody) => {
-    if (isBypassed()) return Promise.resolve<ConsumeResult>(devConsume(body.tokens));
-    return call<ConsumeResult>('POST', `/v1/users/${enc(email)}/consume`, body, {
-      allowStatus: [422],
-    });
+    if (isBypassed())
+      return Promise.resolve<ConsumeResult>(devConsume(body.tokens));
+    return call<ConsumeResult>(
+      'POST',
+      `/v1/users/${enc(email)}/consume`,
+      body,
+      {
+        allowStatus: [422],
+      },
+    );
   },
 
   refund: (email: string, body: RefundBody) => {
@@ -270,12 +291,20 @@ export const billing = {
 
   createCheckout: (email: string, body: CheckoutBody) => {
     if (isBypassed()) return Promise.reject(devCheckoutError());
-    return call<{ url: string }>('POST', `/v1/users/${enc(email)}/checkout`, body);
+    return call<{ url: string }>(
+      'POST',
+      `/v1/users/${enc(email)}/checkout`,
+      body,
+    );
   },
 
   createPortal: (email: string, body: { returnUrl: string }) => {
     if (isBypassed()) return Promise.reject(devCheckoutError());
-    return call<{ url: string }>('POST', `/v1/users/${enc(email)}/portal`, body);
+    return call<{ url: string }>(
+      'POST',
+      `/v1/users/${enc(email)}/portal`,
+      body,
+    );
   },
 
   cancelSubscription: (email: string, body: CancelSubscriptionBody = {}) => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new Max subscription tier and wires it through plans, billing, and UI. Pricing and upgrade views now show four tiers with updated copy and dev billing products.

- **New Features**
  - Added `max` to `PlanLevel`/`SubscriptionLevel`, `PLAN_DISPLAY_NAMES`, and `PLAN_ORDER` (display order: free → standard → pro → max).
  - Updated `PLAN_FEATURES` copy and expanded “tokens shared” to include CADAM, Onshape, and Fusion.
  - Pricing/upgrade UI now uses a 4-column layout at xl, shows all tiers, and increases container width; settings label now derives from `PLAN_DISPLAY_NAMES`; sparkle badge shown for `pro` and `max`.
  - Assistant messages treat `max` like `pro` for monthly generation limit messaging.
  - Dev billing catalog: added monthly `max` product (50,000 tokens, $200.00), adjusted dev `standard` (4,000 tokens, $20.00) and `pro` (10,000 tokens, $40.00).

<sup>Written for commit 8fe75b675c159fd66f574f590e3d74fcb7299da1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

