### PR TITLE
Swap Kimi for Gemini Flash

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -264,11 +264,11 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'moonshotai/kimi-k2.6',
-    name: 'Kimi K2.6',
+    id: 'google/gemini-3.5-flash',
+    name: 'Gemini 3.5 Flash',
     description:
-      'Moonshot multimodal model with configurable reasoning, vision, and native tool use',
-    provider: 'MoonshotAI',
+      'High-efficiency Google multimodal model with fast coding and reasoning',
+    provider: 'Google',
     supportsTools: true,
     supportsThinking: true,
     supportsVision: true,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Swapped `moonshotai/kimi-k2.6` (Kimi K2.6) for `google/gemini-3.5-flash` (Gemini 3.5 Flash) in `PARAMETRIC_MODELS`. Keeps tools, thinking, and vision support, and updates the id, name, description, and provider to Google for a faster multimodal option.

<sup>Written for commit ff25a52c6d204cc9ab92c2bba51d1a7623403459. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/160?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

