### PR TITLE
fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
         "globals": "^15.9.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.1.5",
+        "nitro": "^3.0.260429-beta",
         "postcss": "^8.4.47",
         "prettier": "^3.5.2",
         "prettier-plugin-tailwindcss": "^0.6.11",
@@ -5687,6 +5688,16 @@
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "license": "MIT"
     },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -5746,6 +5757,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crossws": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.5.tgz",
+      "integrity": "sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
       }
     },
     "node_modules/css-select": {
@@ -6607,6 +6633,34 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-runner": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/env-runner/-/env-runner-0.1.7.tgz",
+      "integrity": "sha512-i7h96jxETJYhXy5grgHNJ9xNzCzWIn9Ck/VkkYgOlE4gOqknsLX3CmlVb5LmwNex8sOoLFVZLz+TIw/+b5rktA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crossws": "^0.4.4",
+        "exsolve": "^1.0.8",
+        "httpxy": "^0.5.0",
+        "srvx": "^0.11.13"
+      },
+      "bin": {
+        "env-runner": "dist/cli.mjs"
+      },
+      "peerDependencies": {
+        "@netlify/runtime": "^4",
+        "miniflare": "^4.20260317.3"
+      },
+      "peerDependenciesMeta": {
+        "@netlify/runtime": {
+          "optional": true
+        },
+        "miniflare": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -7374,6 +7428,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/h3": {
+      "version": "2.0.1-rc.22",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.22.tgz",
+      "integrity": "sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rou3": "^0.8.1",
+        "srvx": "^0.11.15"
+      },
+      "bin": {
+        "h3": "bin/h3.mjs"
+      },
+      "engines": {
+        "node": ">=20.11.1"
+      },
+      "peerDependencies": {
+        "crossws": "^0.4.1"
+      },
+      "peerDependenciesMeta": {
+        "crossws": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/h3-v2": {
       "name": "h3",
       "version": "2.0.1-rc.20",
@@ -7689,6 +7768,13 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/hookable": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -7752,6 +7838,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/httpxy": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.2.tgz",
+      "integrity": "sha512-C5OM92bmywDDdKTuYCGejdNFAb/zy0LX4srimOudYko847HvoWL2Eeik9odh9friPKu/JrlWv4z/amrJoxq2Cg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -10084,6 +10177,216 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/nf3": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/nf3/-/nf3-0.3.17.tgz",
+      "integrity": "sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nitro": {
+      "version": "3.0.260429-beta",
+      "resolved": "https://registry.npmjs.org/nitro/-/nitro-3.0.260429-beta.tgz",
+      "integrity": "sha512-KweLVCUN5X9v9g+4yxAyRcz3FcOlnjmt9FyrAIWDxJETJmNT7I0JV0clgsONjo2nI0U5gwedXYA3RaNtF5XWzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.4.2",
+        "crossws": "^0.4.5",
+        "db0": "^0.3.4",
+        "env-runner": "^0.1.7",
+        "h3": "^2.0.1-rc.20",
+        "hookable": "^6.1.1",
+        "nf3": "^0.3.16",
+        "ocache": "^0.1.4",
+        "ofetch": "^2.0.0-alpha.3",
+        "ohash": "^2.0.11",
+        "rolldown": "^1.0.0-rc.17",
+        "srvx": "^0.11.15",
+        "unenv": "^2.0.0-rc.24",
+        "unstorage": "^2.0.0-alpha.7"
+      },
+      "bin": {
+        "nitro": "dist/cli/index.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@vercel/queue": "^0.1.6",
+        "dotenv": "*",
+        "giget": "*",
+        "jiti": "^2.6.1",
+        "rollup": "^4.60.2",
+        "vite": "^7 || ^8",
+        "xml2js": "^0.6.2",
+        "zephyr-agent": "^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@vercel/queue": {
+          "optional": true
+        },
+        "dotenv": {
+          "optional": true
+        },
+        "giget": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "xml2js": {
+          "optional": true
+        },
+        "zephyr-agent": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nitro/node_modules/db0": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
+      "integrity": "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@electric-sql/pglite": "*",
+        "@libsql/client": "*",
+        "better-sqlite3": "*",
+        "drizzle-orm": "*",
+        "mysql2": "*",
+        "sqlite3": "*"
+      },
+      "peerDependenciesMeta": {
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "drizzle-orm": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nitro/node_modules/unstorage": {
+      "version": "2.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-2.0.0-alpha.7.tgz",
+      "integrity": "sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.11.0",
+        "@azure/cosmos": "^4.9.1",
+        "@azure/data-tables": "^13.3.2",
+        "@azure/identity": "^4.13.0",
+        "@azure/keyvault-secrets": "^4.10.0",
+        "@azure/storage-blob": "^12.31.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.13.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.36.2",
+        "@vercel/blob": ">=0.27.3",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1.0.1",
+        "aws4fetch": "^1.0.20",
+        "chokidar": "^4 || ^5",
+        "db0": ">=0.3.4",
+        "idb-keyval": "^6.2.2",
+        "ioredis": "^5.9.3",
+        "lru-cache": "^11.2.6",
+        "mongodb": "^6 || ^7",
+        "ofetch": "*",
+        "uploadthing": "^7.7.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "chokidar": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "lru-cache": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "ofetch": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -10187,6 +10490,30 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/ocache": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ocache/-/ocache-0.1.4.tgz",
+      "integrity": "sha512-e7geNdWjxSnvsSgvLuPvgKgu7ubM10ZmTPOgpr7mz2BXYtvjMKTiLhjFi/gWU8chkuP6hNkZBsa9LzOusyaqkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ohash": "^2.0.11"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/omggif": {
       "version": "1.0.10",
@@ -12609,6 +12936,16 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "globals": "^15.9.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.5",
+    "nitro": "^3.0.260429-beta",
     "postcss": "^8.4.47",
     "prettier": "^3.5.2",
     "prettier-plugin-tailwindcss": "^0.6.11",

--- a/src/components/chat/ChatSession.tsx
+++ b/src/components/chat/ChatSession.tsx
@@ -227,7 +227,17 @@ export function ChatSession({
             existing.type === 'tool-build_parametric_model' &&
             existing.toolCallId === toolCall.toolCallId
           ) {
-            return replacement;
+            // Carry forward `callProviderMetadata` from the model-emitted
+            // tool-call (Gemini 3 stashes its `thoughtSignature` there).
+            // Without it the next server-side turn echoes the functionCall
+            // back to Gemini without a signature and Gemini rejects the
+            // request with "Function call is missing a thought_signature".
+            return existing.callProviderMetadata
+              ? {
+                  ...replacement,
+                  callProviderMetadata: existing.callProviderMetadata,
+                }
+              : replacement;
           }
           if (
             (existing.type === 'reasoning' || existing.type === 'text') &&

--- a/supabase/migrations/20260518000000_parametric_ai_sdk_parts.sql
+++ b/supabase/migrations/20260518000000_parametric_ai_sdk_parts.sql
@@ -213,6 +213,14 @@ $$;
 -- Backfill any legacy rows that still carry their payload in `content`.
 -- Idempotent: only touches rows where `parts` is still the default empty
 -- array AND `content` has data to convert, so a re-run is a no-op.
+--
+-- The prior single-UPDATE form timed out under Supabase's 2-minute
+-- statement_timeout: the `parts` column was just added with DEFAULT '[]',
+-- so every row matches the filter, and a seq scan + per-row plpgsql
+-- jsonb work doesn't fit in the window. SET LOCAL lifts the cap for this
+-- migration only — it expires automatically at COMMIT and does not leak.
+SET LOCAL statement_timeout = 0;
+
 UPDATE public.messages m
 SET parts = public._content_to_parts_v1(m.id, m.role, m.content, c.user_id, c.id),
     metadata = public._content_to_metadata_v1(m.content)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import { tanstackStart } from '@tanstack/react-start/plugin/vite';
+import { nitro } from 'nitro/vite';
 import fs from 'node:fs';
 import path from 'path';
 import react from '@vitejs/plugin-react';
@@ -51,6 +52,10 @@ export default defineConfig({
         enabled: true,
         maskPath: normalizedAppBase,
       },
+    }),
+    nitro({
+      baseURL: normalizedAppBase,
+      inlineDynamicImports: true,
     }),
     react(),
     sentryVitePlugin({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes Vercel builds and chat tool-calls. Integrates `nitro` for bundling, preserves Gemini metadata to avoid errors, and makes the parts backfill migration reliable.

- **Bug Fixes**
  - Chat: Keep `callProviderMetadata` when replacing `tool-build_parametric_model` calls so Gemini 3 retains `thoughtSignature` and avoids “Function call is missing a thought_signature”.
  - DB: Set `SET LOCAL statement_timeout = 0` in the parts backfill to prevent Supabase’s 2-minute timeout.

- **Dependencies**
  - Added `nitro` and the `nitro/vite` plugin (with `baseURL` and `inlineDynamicImports`) to improve Vercel bundling.

<sup>Written for commit e2b9e4ab475ea8b56b0f839b7dd4680bb97c4b31. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/161?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

