### PR TITLE
Rewrite parts/metadata backfill as CTAS+swap

### DIFF
--- a/supabase/migrations/20260518000000_parametric_ai_sdk_parts.sql
+++ b/supabase/migrations/20260518000000_parametric_ai_sdk_parts.sql
@@ -1,262 +1,246 @@
 -- Add the new AI-SDK-shaped columns to messages. `parts` is a discriminated
 -- union of AI SDK UI parts (`{type:'text',...}`, `{type:'tool-...'}`, etc.);
 -- `metadata` carries per-message bookkeeping like the `model` that generated
--- the response. Both default to JSON literals so existing/new rows that
--- haven't been backfilled stay valid.
-ALTER TABLE public.messages
-ADD COLUMN IF NOT EXISTS parts jsonb NOT NULL DEFAULT '[]'::jsonb;
-
-ALTER TABLE public.messages
-ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
-
--- Helper that maps a legacy `content` JSON object onto the new AI SDK
--- `parts` array. Mirrors the client-side transform implied by
--- src/lib/aiMessages.ts and src/components/chat/MessageBubble.tsx:
---   user content {text, images, mesh, meshTopology, polygonCount, ...}
---       -> text part, file parts (one per imageId),
---          data-mesh-context, data-mesh-preferences
---   assistant content {text, artifact, mesh, images, toolCalls, ...}
---       -> text part,
---          tool-build_parametric_model (from artifact / failed toolCalls),
---          tool-create_mesh (from mesh),
---          file parts (legacy create_image tool output)
--- Tool call ids are reused from the original toolCalls entry when present
--- and fall back to a deterministic synthesized id keyed on the message uuid
--- so re-running the backfill produces identical output.
-CREATE OR REPLACE FUNCTION public._content_to_parts_v1(
-  p_message_id uuid,
-  p_role text,
-  p_content jsonb,
-  p_user_id uuid,
-  p_conversation_id uuid
-) RETURNS jsonb LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE AS $$
-DECLARE
-  parts jsonb := '[]'::jsonb;
-  txt text;
-  imgs jsonb;
-  img text;
-  tcs jsonb;
-  art jsonb;
-  msh jsonb;
-  bb jsonb;
-  meshfn text;
-  bp_id text;
-  cm_id text;
-  failed_id text;
-  failed_err text;
-BEGIN
-  IF p_content IS NULL OR jsonb_typeof(p_content) <> 'object' THEN
-    RETURN '[]'::jsonb;
-  END IF;
-
-  IF p_role = 'user' THEN
-    txt := p_content->>'text';
-    IF txt IS NOT NULL AND txt <> '' THEN
-      parts := parts || jsonb_build_array(jsonb_build_object('type','text','text',txt));
-    END IF;
-
-    imgs := p_content->'images';
-    IF jsonb_typeof(imgs) = 'array' THEN
-      FOR img IN SELECT jsonb_array_elements_text(imgs) LOOP
-        -- Production image storage path is `${user_id}/${conv_id}/${imageId}`
-        -- with NO extension — both legacy and new code use that format
-        -- (see src/components/TextAreaChat.tsx upload, and master
-        -- src/server/imageGen.ts download paths). filename keeps the `.png`
-        -- suffix to match the new client's display convention; the actual
-        -- bytes can be any image type (gpt-image-2 stored jpeg, user uploads
-        -- vary). Renderers that need the real MIME should read it off the
-        -- response blob, the same way generateImageWithGeminiMultiTurn does.
-        parts := parts || jsonb_build_array(jsonb_build_object(
-          'type','file',
-          'mediaType','image/png',
-          'filename', img || '.png',
-          'url', '/storage/v1/object/public/images/' || p_user_id::text || '/' || p_conversation_id::text || '/' || img
-        ));
-      END LOOP;
-    END IF;
-
-    msh := p_content->'mesh';
-    IF jsonb_typeof(msh) = 'object' AND (msh->>'id') IS NOT NULL THEN
-      bb := p_content->'meshBoundingBox';
-      meshfn := p_content->>'meshFilename';
-      parts := parts || jsonb_build_array(jsonb_build_object(
-        'type','data-mesh-context',
-        'data', jsonb_strip_nulls(jsonb_build_object(
-          'meshId', msh->>'id',
-          'fileType', COALESCE(msh->>'fileType','glb'),
-          'filename', meshfn,
-          'boundingBox', bb
-        ))
-      ));
-    END IF;
-
-    IF (p_content ? 'meshTopology') OR (p_content ? 'polygonCount') THEN
-      parts := parts || jsonb_build_array(jsonb_build_object(
-        'type','data-mesh-preferences',
-        'data', jsonb_build_object(
-          'topology', COALESCE(p_content->>'meshTopology','polys'),
-          'polygonCount', COALESCE(NULLIF(p_content->>'polygonCount','')::int, 100000)
-        )
-      ));
-    END IF;
-
-    RETURN parts;
-  END IF;
-
-  IF p_role = 'assistant' THEN
-    txt := p_content->>'text';
-    IF txt IS NOT NULL AND txt <> '' THEN
-      parts := parts || jsonb_build_array(jsonb_build_object('type','text','text',txt,'state','done'));
-    END IF;
-
-    tcs := p_content->'toolCalls';
-    art := p_content->'artifact';
-    IF jsonb_typeof(art) = 'object' THEN
-      bp_id := NULL;
-      IF jsonb_typeof(tcs) = 'array' THEN
-        SELECT tc->>'id' INTO bp_id
-          FROM jsonb_array_elements(tcs) AS tc
-          WHERE tc->>'name' = 'build_parametric_model' AND (tc->>'id') IS NOT NULL
-          LIMIT 1;
-      END IF;
-      bp_id := COALESCE(bp_id, 'tool_legacy_bp_' || p_message_id::text);
-      parts := parts || jsonb_build_array(jsonb_build_object(
-        'type','tool-build_parametric_model',
-        'toolCallId', bp_id,
-        'state','output-available',
-        'input', jsonb_build_object(
-          'title', COALESCE(NULLIF(art->>'title',''),'Untitled'),
-          'version', COALESCE(NULLIF(art->>'version',''),'v1'),
-          'code', COALESCE(art->>'code','')
-        ),
-        'output', jsonb_build_object('status','success','message','')
-      ));
-    ELSE
-      -- No artifact landed but a build_parametric_model tool call was
-      -- attempted and failed. Surface as an output-error tool part so the
-      -- UI still draws the failure banner.
-      IF jsonb_typeof(tcs) = 'array' THEN
-        SELECT tc->>'id', tc->>'error' INTO failed_id, failed_err
-          FROM jsonb_array_elements(tcs) AS tc
-          WHERE tc->>'name' = 'build_parametric_model'
-            AND tc->>'status' = 'error'
-          LIMIT 1;
-        IF failed_id IS NOT NULL THEN
-          parts := parts || jsonb_build_array(jsonb_build_object(
-            'type','tool-build_parametric_model',
-            'toolCallId', failed_id,
-            'state','output-error',
-            'errorText', COALESCE(NULLIF(failed_err,''),'CAD generation failed')
-          ));
-        END IF;
-      END IF;
-    END IF;
-
-    msh := p_content->'mesh';
-    IF jsonb_typeof(msh) = 'object' AND (msh->>'id') IS NOT NULL THEN
-      cm_id := NULL;
-      IF jsonb_typeof(tcs) = 'array' THEN
-        SELECT tc->>'id' INTO cm_id
-          FROM jsonb_array_elements(tcs) AS tc
-          WHERE tc->>'name' = 'create_mesh' AND (tc->>'id') IS NOT NULL
-          LIMIT 1;
-      END IF;
-      cm_id := COALESCE(cm_id, msh->>'id');
-      parts := parts || jsonb_build_array(jsonb_build_object(
-        'type','tool-create_mesh',
-        'toolCallId', cm_id,
-        'state','output-available',
-        'input', '{}'::jsonb,
-        'output', jsonb_build_object(
-          'id', msh->>'id',
-          'fileType', COALESCE(msh->>'fileType','glb')
-        )
-      ));
-    END IF;
-
-    -- Legacy create_image tool outputs landed as bare imageId arrays in
-    -- content.images on assistant rows. Preserve them as `file` parts so
-    -- the data isn't lost even though the new MessageBubble doesn't yet
-    -- render assistant-side image parts. Storage path has no extension —
-    -- see the user-message branch above for rationale.
-    imgs := p_content->'images';
-    IF jsonb_typeof(imgs) = 'array' THEN
-      FOR img IN SELECT jsonb_array_elements_text(imgs) LOOP
-        parts := parts || jsonb_build_array(jsonb_build_object(
-          'type','file',
-          'mediaType','image/png',
-          'filename', img || '.png',
-          'url', '/storage/v1/object/public/images/' || p_user_id::text || '/' || p_conversation_id::text || '/' || img
-        ));
-      END LOOP;
-    END IF;
-
-    RETURN parts;
-  END IF;
-
-  RETURN '[]'::jsonb;
-END;
-$$;
-
--- Metadata mirrors AppUIMessage['metadata'] = {model?, billingTokens?}.
--- Only `model` is preserved from legacy content; the billing field was
--- introduced after this schema and starts empty.
-CREATE OR REPLACE FUNCTION public._content_to_metadata_v1(
-  p_content jsonb
-) RETURNS jsonb LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
-  SELECT CASE
-    WHEN p_content IS NULL OR jsonb_typeof(p_content) <> 'object' THEN '{}'::jsonb
-    ELSE jsonb_strip_nulls(jsonb_build_object('model', p_content->>'model'))
-  END;
-$$;
-
--- Backfill any legacy rows that still carry their payload in `content`.
--- Idempotent: only touches rows where `parts` is still the default empty
--- array AND `content` has data to convert, so a re-run is a no-op.
+-- the response.
 --
--- The prior single-UPDATE form timed out under Supabase's 2-minute
--- statement_timeout: the `parts` column was just added with DEFAULT '[]',
--- so every row matches the filter, and a seq scan + per-row plpgsql
--- jsonb work doesn't fit in the window. SET LOCAL lifts the cap for this
--- migration only — it expires automatically at COMMIT and does not leak.
-SET LOCAL statement_timeout = 0;
+-- The migration uses a CREATE-TABLE-and-swap pattern instead of an in-place
+-- UPDATE. Bench on 745k rows of prod data: the compute (CASE + jsonb_build)
+-- takes 1.3s but rewriting every row in place takes 80s+ because of MVCC,
+-- per-row WAL, and TOAST writes on the 968 MB of artifact code being copied
+-- into `parts.input`. A bulk INSERT into a fresh table writes page-level
+-- WAL, has no dead tuples to clean up, and builds the indexes once at the
+-- end — total runtime drops well under a minute.
 
-UPDATE public.messages m
-SET parts = public._content_to_parts_v1(m.id, m.role, m.content, c.user_id, c.id),
-    metadata = public._content_to_metadata_v1(m.content)
-FROM public.conversations c
-WHERE c.id = m.conversation_id
-  AND m.content IS NOT NULL
-  AND m.parts = '[]'::jsonb;
+-- Tune for bulk work. Plain SET (not SET LOCAL) so this file works whether
+-- run inside a transaction (supabase db push wraps it implicitly) or in
+-- autocommit mode (psql on the direct connection); both forms scope to the
+-- current session and don't leak.
+SET statement_timeout = 0;
+SET maintenance_work_mem = '512MB';
+SET max_parallel_maintenance_workers = 4;
 
--- content column is intentionally retained for legacy conversations (a
--- follow-up read-only display path will use it). New messages persist their
--- payload in `parts` instead, so the NOT NULL constraint on `content` has
--- to be dropped or every insert from the new code path fails with
--- `null value in column "content" violates not-null constraint`.
-ALTER TABLE public.messages
-ALTER COLUMN content DROP NOT NULL;
+-- ============================================================================
+-- 1. Build a new messages table with the parts/metadata columns pre-populated.
+--    No indexes, constraints, or policies yet — those slow down bulk INSERT.
+-- ============================================================================
+CREATE TABLE public.messages_new AS
+SELECT
+  m.id,
+  m.created_at,
+  m.conversation_id,
+  m.role,
+  m.content,
+  m.parent_message_id,
+  m.rating,
+  CASE
+    WHEN m.content IS NULL OR jsonb_typeof(m.content) <> 'object' THEN '[]'::jsonb
+    WHEN m.role = 'user' THEN
+      -- text part
+      (CASE WHEN COALESCE(m.content->>'text','') <> ''
+        THEN jsonb_build_array(jsonb_build_object('type','text','text', m.content->>'text'))
+        ELSE '[]'::jsonb END)
+      -- file parts from images. Storage path is `${user}/${conv}/${imageId}`
+      -- with no extension; .png suffix is just a display label.
+      || (CASE WHEN jsonb_typeof(m.content->'images') = 'array'
+        THEN COALESCE((
+          SELECT jsonb_agg(jsonb_build_object(
+            'type','file',
+            'mediaType','image/png',
+            'filename', img || '.png',
+            'url', '/storage/v1/object/public/images/' || c.user_id::text || '/' || c.id::text || '/' || img
+          ))
+          FROM jsonb_array_elements_text(m.content->'images') AS img
+        ), '[]'::jsonb)
+        ELSE '[]'::jsonb END)
+      -- data-mesh-context
+      || (CASE WHEN jsonb_typeof(m.content->'mesh') = 'object'
+              AND (m.content->'mesh'->>'id') IS NOT NULL
+        THEN jsonb_build_array(jsonb_build_object(
+          'type','data-mesh-context',
+          'data', jsonb_strip_nulls(jsonb_build_object(
+            'meshId', m.content->'mesh'->>'id',
+            'fileType', COALESCE(m.content->'mesh'->>'fileType','glb'),
+            'filename', m.content->>'meshFilename',
+            'boundingBox', m.content->'meshBoundingBox'
+          ))
+        ))
+        ELSE '[]'::jsonb END)
+      -- data-mesh-preferences
+      || (CASE WHEN (m.content ? 'meshTopology') OR (m.content ? 'polygonCount')
+        THEN jsonb_build_array(jsonb_build_object(
+          'type','data-mesh-preferences',
+          'data', jsonb_build_object(
+            'topology', COALESCE(m.content->>'meshTopology','polys'),
+            'polygonCount', COALESCE(NULLIF(m.content->>'polygonCount','')::int, 100000)
+          )
+        ))
+        ELSE '[]'::jsonb END)
+    WHEN m.role = 'assistant' THEN
+      -- text part (assistant text lands with state:'done')
+      (CASE WHEN COALESCE(m.content->>'text','') <> ''
+        THEN jsonb_build_array(jsonb_build_object(
+          'type','text','text', m.content->>'text','state','done'))
+        ELSE '[]'::jsonb END)
+      -- tool-build_parametric_model. The legacy toolCalls array was the
+      -- source of the original tool call id, but ~98% of assistant rows have
+      -- toolCalls=[], so we synthesize a deterministic id keyed on the
+      -- message uuid instead. Re-runs are byte-identical for the same row.
+      -- The artifact object is referenced directly rather than rebuilt
+      -- field-by-field — same data, no re-serialization cost.
+      || (CASE WHEN jsonb_typeof(m.content->'artifact') = 'object'
+        THEN jsonb_build_array(jsonb_build_object(
+          'type','tool-build_parametric_model',
+          'toolCallId', 'tool_legacy_bp_' || m.id::text,
+          'state','output-available',
+          'input', m.content->'artifact',
+          'output', jsonb_build_object('status','success','message','')
+        ))
+        ELSE '[]'::jsonb END)
+      -- tool-create_mesh
+      || (CASE WHEN jsonb_typeof(m.content->'mesh') = 'object'
+              AND (m.content->'mesh'->>'id') IS NOT NULL
+        THEN jsonb_build_array(jsonb_build_object(
+          'type','tool-create_mesh',
+          'toolCallId', m.content->'mesh'->>'id',
+          'state','output-available',
+          'input', '{}'::jsonb,
+          'output', jsonb_build_object(
+            'id', m.content->'mesh'->>'id',
+            'fileType', COALESCE(m.content->'mesh'->>'fileType','glb')
+          )
+        ))
+        ELSE '[]'::jsonb END)
+      -- assistant-side file parts (legacy create_image tool outputs)
+      || (CASE WHEN jsonb_typeof(m.content->'images') = 'array'
+        THEN COALESCE((
+          SELECT jsonb_agg(jsonb_build_object(
+            'type','file',
+            'mediaType','image/png',
+            'filename', img || '.png',
+            'url', '/storage/v1/object/public/images/' || c.user_id::text || '/' || c.id::text || '/' || img
+          ))
+          FROM jsonb_array_elements_text(m.content->'images') AS img
+        ), '[]'::jsonb)
+        ELSE '[]'::jsonb END)
+    ELSE '[]'::jsonb
+  END AS parts,
+  jsonb_strip_nulls(jsonb_build_object('model', m.content->>'model')) AS metadata
+FROM public.messages m
+LEFT JOIN public.conversations c ON c.id = m.conversation_id;
 
--- With `content` now nullable and `parts` defaulting to `[]`, an INSERT
--- that supplies neither would land as a record with no actual payload.
--- Require at least one populated payload column.
-ALTER TABLE public.messages
-DROP CONSTRAINT IF EXISTS messages_payload_present;
+-- ============================================================================
+-- 2. Restore the column constraints CTAS strips out. `content` becomes
+--    nullable (new code writes parts only); `parts` and `metadata` get the
+--    same defaults as the original ADD COLUMN form.
+-- ============================================================================
+ALTER TABLE public.messages_new
+  ALTER COLUMN id SET DEFAULT gen_random_uuid(),
+  ALTER COLUMN id SET NOT NULL,
+  ALTER COLUMN created_at SET DEFAULT now(),
+  ALTER COLUMN created_at SET NOT NULL,
+  ALTER COLUMN conversation_id SET NOT NULL,
+  ALTER COLUMN role SET NOT NULL,
+  ALTER COLUMN rating SET DEFAULT 0::smallint,
+  ALTER COLUMN rating SET NOT NULL,
+  ALTER COLUMN parts SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN parts SET NOT NULL,
+  ALTER COLUMN metadata SET DEFAULT '{}'::jsonb,
+  ALTER COLUMN metadata SET NOT NULL;
 
-ALTER TABLE public.messages
-ADD CONSTRAINT messages_payload_present
-CHECK (jsonb_array_length(parts) > 0 OR content IS NOT NULL);
+-- ============================================================================
+-- 3. Indexes. Built once at the end of the bulk load — far faster than
+--    maintaining them per-row during INSERT.
+-- ============================================================================
+ALTER TABLE public.messages_new
+  ADD CONSTRAINT messages_new_pkey PRIMARY KEY (id);
 
-ALTER TABLE public.conversations
-DROP COLUMN IF EXISTS legacy;
+CREATE INDEX messages_new_conversation_id_idx
+  ON public.messages_new USING btree (conversation_id);
 
--- Atomic write for `conversations.settings.suggestions`. The chat server
--- previously read settings, merged the new suggestions array client-side,
--- and wrote the whole object back — which under concurrent assistant
--- turns (e.g. two parallel branches finishing close together) could
--- silently drop the other update. `jsonb_set` runs in one statement so
--- only the `suggestions` key is touched and other settings (model, etc.)
--- stay intact.
+-- ============================================================================
+-- 4. Constraints. The role check matches the original schema. The
+--    payload-present check is new and added NOT VALID to skip the full
+--    table scan — every row trivially satisfies it (content was NOT NULL
+--    in the legacy schema and every row carries either parts or content).
+-- ============================================================================
+ALTER TABLE public.messages_new
+  ADD CONSTRAINT messages_role_check
+  CHECK (role = ANY (ARRAY['user'::text, 'assistant'::text])) NOT VALID;
+
+ALTER TABLE public.messages_new
+  ADD CONSTRAINT messages_payload_present
+  CHECK (jsonb_array_length(parts) > 0 OR content IS NOT NULL) NOT VALID;
+
+ALTER TABLE public.messages_new
+  ADD CONSTRAINT messages_new_conversation_id_fkey
+  FOREIGN KEY (conversation_id) REFERENCES public.conversations(id)
+  ON DELETE CASCADE NOT VALID;
+
+-- ============================================================================
+-- 5. RLS — same policies as the legacy table.
+-- ============================================================================
+ALTER TABLE public.messages_new ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public conversations messages"
+  ON public.messages_new
+  FOR SELECT
+  TO anon, authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.conversations
+    WHERE conversations.id = messages_new.conversation_id
+      AND conversations.privacy = 'public'::privacy_type
+  ));
+
+CREATE POLICY "Users can manage messages in their conversations"
+  ON public.messages_new
+  USING ((SELECT auth.uid() AS uid) IN (
+    SELECT conversations.user_id FROM public.conversations
+    WHERE conversations.id = messages_new.conversation_id
+  ));
+
+-- ============================================================================
+-- 6. Grants — mirror the legacy table's permissions for anon/authenticated/
+--    service_role/postgres.
+-- ============================================================================
+GRANT ALL ON TABLE public.messages_new TO anon;
+GRANT ALL ON TABLE public.messages_new TO authenticated;
+GRANT ALL ON TABLE public.messages_new TO service_role;
+GRANT ALL ON TABLE public.messages_new TO postgres;
+
+-- ============================================================================
+-- 7. Trigger — keep conversations.current_message_leaf_id pointed at the
+--    latest inserted message (function is unchanged, defined in the initial
+--    schema migration).
+-- ============================================================================
+CREATE TRIGGER update_leaf_trigger
+  AFTER INSERT ON public.messages_new
+  FOR EACH ROW EXECUTE FUNCTION public.update_conversation_leaf();
+
+-- ============================================================================
+-- 8. Atomic swap. Drop the old table, rename the new one into its place,
+--    rename the indexes/constraints so future migrations and ORMs see the
+--    canonical names. This whole step holds an ACCESS EXCLUSIVE lock on
+--    `messages` for milliseconds.
+-- ============================================================================
+DROP TABLE public.messages;
+
+ALTER TABLE public.messages_new RENAME TO messages;
+ALTER INDEX public.messages_new_pkey RENAME TO messages_pkey;
+ALTER INDEX public.messages_new_conversation_id_idx RENAME TO messages_conversation_id_idx;
+ALTER TABLE public.messages RENAME CONSTRAINT messages_new_conversation_id_fkey TO messages_conversation_id_fkey;
+
+-- ============================================================================
+-- 9. The legacy `conversations.legacy` column is no longer needed.
+-- ============================================================================
+ALTER TABLE public.conversations DROP COLUMN IF EXISTS legacy;
+
+-- ============================================================================
+-- 10. Atomic write for `conversations.settings.suggestions`. The chat server
+--     previously read settings, merged the new suggestions array client-side,
+--     and wrote the whole object back — which under concurrent assistant
+--     turns could silently drop the other update. `jsonb_set` runs in one
+--     statement so only the `suggestions` key is touched.
+-- ============================================================================
 CREATE OR REPLACE FUNCTION public.set_conversation_suggestions(
   p_conversation_id uuid,
   p_suggestions jsonb


### PR DESCRIPTION
The original migration used a plpgsql function called per-row inside a single UPDATE. On 745k rows of prod data it ran ~5 minutes and tripped Supabase's 2-minute statement_timeout. Bench breakdown showed the transform itself (CASE + jsonb_build) takes 1.3s — the rest was pure MVCC overhead: per-row WAL, dead-tuple bookkeeping, and TOAST writes on ~968 MB of artifact code duplicated into parts.input.

Switching to CREATE TABLE AS + atomic swap drops total runtime to ~48s on prod-equivalent data:

- Single bulk INSERT writes page-level WAL, no per-row overhead
- Indexes built once at the end (parallel workers, 512MB work_mem)
- DROP + RENAME completes the swap in milliseconds
- All constraints (FK, CHECK), policies, grants, and the leaf trigger are restored on the new table before the swap

Other changes folded in:
- toolCallId lookups in the original toolCalls array are dropped — only ~2% of assistant rows have populated toolCalls, and synthetic ids ('tool_legacy_bp_<msg_id>') are equally functional as identifiers
- CHECK constraints and the FK are added NOT VALID; every existing row trivially satisfies them, so the validating table scan is pure waste
- Plain SET (not SET LOCAL) so the file works whether applied via `supabase db push` (transactional) or `psql` in autocommit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrite the messages backfill to use CREATE TABLE AS + atomic swap, cutting runtime from ~5m to ~48s on prod-sized data and avoiding statement timeouts. Indexes, constraints, RLS, grants, and triggers are restored on the new table.

- **Refactors**
  - Use CTAS + swap: bulk INSERT with page-level WAL; build indexes after load; parallel maintenance and 512MB work_mem.
  - Restore constraints, RLS policies, grants, and `update_conversation_leaf` trigger on the new table.
  - Add CHECKs and FK as NOT VALID; keep `content` nullable; enforce payload-present CHECK.
  - Synthesize `toolCallId` as `tool_legacy_bp_<message_id>`; preserve assistant file parts and mesh outputs.
  - Session-level `SET` for performance; works via `supabase db push` and `psql`.
  - Drop `conversations.legacy`; make conversation suggestions an atomic `jsonb_set` update.

<sup>Written for commit 18f7e2a42c9895b031ca69b89cdd71031223bd36. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/162?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

