### PR TITLE
Stop MeshImagePreview from rendering its own "3D Object" label

### DIFF
--- a/src/components/viewer/MeshImagePreview.tsx
+++ b/src/components/viewer/MeshImagePreview.tsx
@@ -1,9 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
-import { Box, Frown, HeartCrack } from 'lucide-react';
+import { Frown, HeartCrack } from 'lucide-react';
 
 import { generatePreview } from '@/utils/meshUtils';
 import { useMeshData } from '@/hooks/useMeshData';
 
+/**
+ * Pure visual: renders the mesh thumbnail (or an icon-only placeholder for
+ * loading/missing/failure states). Status text and titles are owned by the
+ * parent component (MeshToolBlock surfaces them in its header;
+ * MeshContextChip surfaces filename + filetype next to the thumbnail).
+ * Don't reintroduce a "3D Object" label here — it duplicated MeshToolBlock's
+ * own title and rendered twice in the message bubble.
+ */
 export function MeshImagePreview({ meshId }: { meshId: string }) {
   const {
     data: { data: meshData, isLoading: isMeshDataLoading },
@@ -26,51 +34,29 @@ export function MeshImagePreview({ meshId }: { meshId: string }) {
 
   if (!isMeshDataLoading && !meshData) {
     return (
-      <div className="flex h-10 w-full items-center justify-between rounded-lg bg-adam-neutral-950 px-3">
-        <div className="flex h-full items-center justify-center gap-2">
-          <Box className="h-4 w-4 text-white" />
-          <span className="font-base text-sm text-white">
-            3D Object Data not found
-          </span>
-        </div>
-        <Frown className="h-4 w-4 text-white" />
+      <div className="flex aspect-square w-full items-center justify-center rounded-lg bg-adam-neutral-950">
+        <Frown className="h-6 w-6 text-white" />
       </div>
     );
   }
 
   if (meshData?.status === 'failure') {
     return (
-      <div className="flex h-10 w-full items-center justify-between rounded-lg bg-adam-neutral-950 px-3">
-        <div className="flex h-full items-center justify-center gap-2">
-          <Box className="h-4 w-4 text-white" />
-          <span className="font-base text-sm text-white">
-            3D Object failed to generate
-          </span>
-        </div>
-        <HeartCrack className="h-4 w-4 text-white" />
+      <div className="flex aspect-square w-full items-center justify-center rounded-lg bg-adam-neutral-950">
+        <HeartCrack className="h-6 w-6 text-white" />
       </div>
     );
   }
 
   return (
-    <div className="overflow-hidden rounded-lg">
-      <div
-        className={`relative aspect-square w-full bg-adam-neutral-950 ${
-          meshPreview ? '' : 'animate-pulse'
-        }`}
-      >
-        {meshPreview ? (
-          <img
-            src={meshPreview}
-            alt=""
-            className="h-full w-full object-cover"
-          />
-        ) : null}
-      </div>
-      <div className="flex h-10 w-full items-center gap-2 bg-black/80 px-3">
-        <Box className="h-4 w-4 text-white" />
-        <span className="font-base text-sm text-white">3D Object</span>
-      </div>
+    <div
+      className={`relative aspect-square w-full overflow-hidden rounded-lg bg-adam-neutral-950 ${
+        meshPreview ? '' : 'animate-pulse'
+      }`}
+    >
+      {meshPreview ? (
+        <img src={meshPreview} alt="" className="h-full w-full object-cover" />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `MeshImagePreview` rendered a `Box` icon + "3D Object" footer that duplicated `MeshToolBlock`'s own title — assistant message bubbles showed "3D Object" twice for every successful mesh
- The duplicate was invisible inside `MeshContextChip` only because its 48×48 `overflow-hidden` wrapper clipped the footer off; it was clearly visible in `MeshToolBlock`'s preview body
- Strip all status text from `MeshImagePreview`; let the parent (`MeshToolBlock` header / `MeshContextChip` chip text) own the labels. Missing-data and failure states keep their semantic icon (`Frown` / `HeartCrack`) but lose the redundant text

## Test plan
- [ ] Open a conversation where the assistant successfully generated a mesh — preview shows once, "3D Object" header label appears once
- [ ] Open a conversation where a user uploaded a mesh — `MeshContextChip` shows the filename + filetype next to the 48×48 thumbnail, layout unchanged
- [ ] Open a conversation with a failed mesh generation — `MeshToolBlock` header shows "Mesh generation failed"; preview body shows the `HeartCrack` icon without redundant text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "3D Object" footer from `MeshImagePreview` to stop duplicate titles and let the parent own labels. Assistant messages no longer show "3D Object" twice; `MeshContextChip` layout stays the same.

- **Bug Fixes**
  - Removed footer label and `Box` icon; titles/status now come from the parent (`MeshToolBlock` / `MeshContextChip`).
  - Missing data or failure render icon-only (`Frown` / `HeartCrack`) with no text.
  - Loading uses an animate-pulse thumbnail placeholder; success shows the image only.

<sup>Written for commit 668c53201f09317cebe1c79355f9676b8c0286c1. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/163?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

