### PR TITLE
feat: add CADAM product designer workflow

### DIFF
--- a/README_PRISMA_CADAM.md
+++ b/README_PRISMA_CADAM.md
@@ -1,0 +1,93 @@
+# CADAM instalado para PRISMA
+
+Repositorio instalado:
+`/home/juanpighelfi/Documents/Disenos 3D/PRISMA/07_CADAM`
+
+Repo original:
+`https://github.com/Adam-CAD/CADAM`
+
+Estado verificado:
+
+- `npm ci`: OK
+- `npx supabase start`: OK
+- `npm run typecheck`: OK
+- `npm run build`: OK
+- servidor dev probado en navegador: OK
+
+URL local:
+`http://127.0.0.1:3000/cadam/`
+
+Comandos para levantarlo:
+
+```bash
+cd "/home/juanpighelfi/Documents/Disenos 3D/PRISMA/07_CADAM"
+npx supabase start
+npm run dev -- --host 127.0.0.1
+```
+
+Notas importantes:
+
+1. CADAM es una web app Text-to-CAD basada en React/TanStack/Vite + Supabase + OpenSCAD WASM.
+2. Para generación real desde la UI necesita al menos una clave de proveedor IA en `.env.local`, por ejemplo:
+   - `ANTHROPIC_API_KEY`
+   - `OPENROUTER_API_KEY`
+   - `OPENAI_API_KEY`
+   - `GOOGLE_API_KEY`
+3. Dejé `.env.local` configurado con Supabase local y placeholders vacíos para las claves IA.
+4. El login/registro local aparece activo; la caja de generación queda deshabilitada hasta iniciar sesión.
+5. Para PRISMA, CADAM debe usarse como generador/asistente CAD para base, inserto y encastre. La pantalla se mantiene fija salvo la zona estricta de encastre.
+
+Regla PRISMA vigente:
+
+- La pantalla no se rediseña.
+- Sólo se modifica el sistema de encastre/interfaz pantalla-base y, si hace falta, la base/inserto técnico.
+- Validar después con OpenSCAD/build123d/CAD, QA de malla, Bambu slicing y render/corte técnico.
+
+## Capa CADAM product designer inspirada en Zoo/KCL
+
+Se agregó una capa v1 para que CADAM no actúe sólo como generador one-shot de OpenSCAD, sino como asistente de diseño de producto paramétrico para piezas imprimibles.
+
+Archivos principales:
+
+- `shared/cadamProductDesigner.ts`: módulo puro con extracción de brief, candidatos, scoring, resumen de trace Zoo/KCL y readiness Gemini/Vertex opcional.
+- `src/server/aiChat.ts`: el system prompt paramétrico incorpora `PRODUCT_DESIGNER_PROMPT_EXTENSION`; el modo creative no se toca.
+- `src/server/productDesignPlan.ts`: handler offline para planificar producto sin llamar proveedores IA.
+- `src/routes/api/product-design-plan.ts`: endpoint POST `/api/product-design-plan` registrado por TanStack Router.
+- `scripts/test-cadam-product-designer.mjs`: prueba manual Node sin Vitest/tsx.
+
+Uso del endpoint de planificación:
+
+```bash
+curl -sS http://127.0.0.1:3000/cadam/api/product-design-plan \
+  -H 'content-type: application/json' \
+  -d '{"prompt":"lámpara FDM en dos piezas: exterior PLA premium, interior PETG barato, click fit y cavidades de yeso para lastre"}'
+```
+
+La respuesta incluye:
+
+- `brief`: tipo de producto, materiales, fabricación, requisitos de ensamble, cavidades, restricciones, defaults inferidos y riesgos/unknowns.
+- `candidates`: estrategias rankeadas como robust baseline, print-optimized, material-efficient, premium shell, modular/repairable y una arquitectura específica para lámparas con ballast/insert.
+- `traceSummary` si se envía `traceMarkdown` en el body.
+- `gemini`: sólo indica disponibilidad de Gemini/Vertex; no expone secretos y no llama al proveedor.
+
+Inspiración tomada sólo del trace visible Zoo/KCL:
+
+- activación explícita de capacidades/skills;
+- lectura de selección y archivos antes de editar;
+- búsqueda de conocimiento/samples;
+- validación incremental;
+- consideración de volumen, superficie, centro de masa, snap/click fits, cavidades de lastre, split PLA/PETG y robustez mecánica.
+
+Gemini/Vertex es opcional:
+
+- El módulo sólo devuelve readiness (`available`, `missing`, `model`, `location`).
+- No requiere credenciales para los tests ni para el flujo base.
+- Si se configura Vertex, usar variables de entorno compatibles con el proyecto (`GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, ADC/API key según corresponda). No guardar credenciales en docs ni commits.
+
+Comandos de verificación:
+
+```bash
+node --experimental-strip-types scripts/test-cadam-product-designer.mjs
+npm run typecheck
+npm run build
+```

--- a/docs/CADAM_PRODUCT_DESIGNER.md
+++ b/docs/CADAM_PRODUCT_DESIGNER.md
@@ -1,0 +1,155 @@
+# CADAM Product Designer
+
+This document describes a general CADAM improvement layer for text-to-CAD product work. It is not tied to any single lamp, client project, or model family.
+
+## Purpose
+
+CADAM should act less like a one-shot CAD code generator and more like a product-design assistant:
+
+1. read the user's product request;
+2. extract a structured brief;
+3. propose several mechanically different candidate strategies;
+4. rank them by printability, robustness, manufacturability, tolerances, assembly, parametricity, and aesthetics;
+5. turn the selected candidate into an enriched OpenSCAD prompt;
+6. later validate generated CAD with geometry/export/slicing feedback.
+
+## Source of inspiration: Zoo/KCL visible trace
+
+The reference file analyzed for this work is:
+
+`/home/juanpighelfi/Documents/CADAM+/zookeeper-trace .md`
+
+Only visible trace data was used: tool names, skill activations, UI/action labels, file reads, exports, visible KCL terms, and observable workflow steps. No hidden chain-of-thought is used, copied, inferred, or required.
+
+Observable patterns extracted from the trace include:
+
+- explicit routing into CAD/mechanical/knowledge capabilities;
+- reading current selections and project files before editing;
+- searching knowledge sources and built-in samples;
+- working with parametric source artifacts;
+- exporting current parts;
+- using validation loops and repair loops;
+- exposing or considering volume, surface area, center of mass, snap/click fits, ballast cavities, material splits, and mechanical constraints.
+
+## Implemented architecture
+
+Core module:
+
+`shared/cadamProductDesigner.ts`
+
+Responsibilities:
+
+- `extractProductBrief(prompt)`: creates a structured brief from natural language.
+- `proposeDesignCandidates(brief)`: creates multiple candidate architectures.
+- `rankDesignCandidates(candidates, brief)`: scores and sorts candidates.
+- `buildCandidateGenerationPrompt(input)`: converts a selected candidate into a generation-ready OpenSCAD prompt.
+- `summarizeZooWorkflowTrace(markdown)`: summarizes visible Zoo/KCL trace patterns.
+- `vertexGeminiReadiness(env)`: checks optional Gemini/Vertex readiness without calling the provider or exposing secrets.
+- `PRODUCT_DESIGNER_PROMPT_EXTENSION`: extends CADAM parametric chat behavior.
+
+Server endpoint:
+
+`src/server/productDesignPlan.ts`
+
+Route:
+
+`src/routes/api/product-design-plan.ts`
+
+Endpoint:
+
+`POST /cadam/api/product-design-plan`
+
+Web UI:
+
+`src/views/ProductDesignerView.tsx`
+
+Route:
+
+`/cadam/product-designer`
+
+The web page lets a user submit a product request, inspect the extracted brief, compare ranked candidate strategies, copy an enriched prompt for CAD generation, or use `Start CAD generation` to create a normal CADAM parametric conversation from the selected candidate.
+
+## API usage
+
+```bash
+curl -sS http://127.0.0.1:3000/cadam/api/product-design-plan \
+  -H 'content-type: application/json' \
+  -d '{"prompt":"soporte de pared FDM con tornillos M4, clip flexible y tolerancia ajustable"}'
+```
+
+Response shape:
+
+- `brief`: structured product brief;
+- `candidates`: ranked design candidates;
+- `generationPrompts`: candidate id to enriched OpenSCAD generation prompt;
+- `traceSummary`: only present when `traceMarkdown` is provided;
+- `gemini`: readiness status only.
+
+## Product families to support
+
+The layer should be useful for many models, including:
+
+- brackets and wall mounts;
+- electronics enclosures;
+- snap-fit cases;
+- jigs and fixtures;
+- drilling guides;
+- simple mechanisms;
+- clips and fasteners;
+- aesthetic shells over hidden inserts;
+- multipart assemblies;
+- weighted bases or stability-critical products;
+- printable adapters and repair parts.
+
+## Optional Gemini/Vertex role
+
+Gemini/Vertex is optional. The baseline must work offline with heuristics and the configured CADAM provider stack.
+
+When available, Gemini can be added later as:
+
+- visual/reference reviewer;
+- candidate proposer;
+- CAD prompt critic;
+- mechanical-risk reviewer;
+- comparison judge between generated renders and source images.
+
+The readiness helper only returns missing variable names and non-secret settings. It must never print API keys, tokens, credential JSON, connection strings, or private local paths containing secrets.
+
+## Current limitations
+
+Implemented now:
+
+- general brief extraction;
+- candidate generation and ranking;
+- enriched prompt creation;
+- visible-trace summarization;
+- endpoint;
+- web page;
+- direct `Start CAD generation` action from a selected candidate into the normal CADAM parametric chat;
+- localStorage branch persistence for selected candidate prompts;
+- parametric system-prompt extension;
+- offline tests.
+
+Still to build:
+
+- server-side branch/generation history beyond localStorage and conversation/message metadata;
+- generated CAD validation with compile/export feedback;
+- volume/bounding-box/center-of-mass analysis;
+- slicer/printability gates;
+- visual comparison loop for image references;
+- real skill/tool router beyond prompt extension and heuristics;
+- optional Gemini reviewer/proposer loop.
+
+## Verification commands
+
+```bash
+node --experimental-strip-types scripts/test-cadam-product-designer.mjs
+node --experimental-strip-types scripts/test-cadam-product-designer-v2.mjs
+node --experimental-strip-types scripts/test-cadam-product-designer-v3.mjs
+node --experimental-strip-types scripts/test-cadam-product-designer-v4.mjs
+npm run typecheck
+npm run lint
+npm run build
+```
+
+TanStack route tree note: after adding a route, start Vite once so `src/routeTree.gen.ts` is regenerated, then rerun typecheck.

--- a/docs/skills/cadam-zoo-product-designer/SKILL.md
+++ b/docs/skills/cadam-zoo-product-designer/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: cadam-zoo-product-designer
+description: Use when improving CADAM/text-to-CAD with a product-designer layer inspired by visible Zoo/KCL traces, or when using CADAM to plan printable parametric products through briefs, candidates, scoring, enriched prompts, web UI, and validation loops.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [cadam, text-to-cad, product-design, openscad, zoo-kcl]
+    related_skills: [openscad-3d-print-modeling, test-driven-development]
+---
+
+# CADAM Zoo Product Designer
+
+## Overview
+
+Use this skill for CADAM work where the goal is a stronger text-to-CAD product-design workflow rather than a one-shot code generator. The approach is inspired by visible Zoo/KCL traces: observable tool calls, skill activations, project-file reads, source CAD edits, exports, and validation affordances.
+
+Do not copy, infer, or claim hidden chain-of-thought. Use only visible trace artifacts and public UI/tool behavior.
+
+## When to Use
+
+Use when the user asks to:
+
+- improve CADAM as a CAD/product-design system;
+- build a web page or endpoint for CAD planning;
+- analyze visible Zoo/KCL traces for workflow ideas;
+- create general text-to-CAD product briefs and candidate strategies;
+- rank printable/mechanical design variants;
+- convert a selected strategy into an enriched OpenSCAD prompt;
+- keep Gemini/Vertex optional and fallback-safe.
+
+Do not use when:
+
+- the task is only to model one object directly in OpenSCAD;
+- the user wants private chain-of-thought extraction;
+- there is no CADAM/text-to-CAD integration involved.
+
+## Core Workflow
+
+1. Read the user's CADAM brief and any visible trace file they provide.
+2. Extract only observable workflow signals from traces:
+   - skill/tool names;
+   - file reads and project-state access;
+   - CAD source operations;
+   - export/validation actions;
+   - repeated mechanical terms such as snap, click, cavity, volume, tolerance, center of mass.
+3. Implement an offline, pure shared module first:
+   - `extractProductBrief()`;
+   - `proposeDesignCandidates()`;
+   - `rankDesignCandidates()`;
+   - `buildCandidateGenerationPrompt()`;
+   - `summarizeZooWorkflowTrace()`;
+   - provider readiness checks only.
+4. Extend CADAM's parametric prompt without breaking existing creative flows.
+5. Add a planning endpoint that does not require external providers.
+6. Add a web UI where the user can submit many kinds of product prompts, compare candidates, and copy or send an enriched generation prompt.
+7. Verify with tests, typecheck, lint, build, and a live endpoint call.
+
+## Product Brief Fields
+
+Track at least:
+
+- object type;
+- intended use;
+- dimensions;
+- materials;
+- manufacturing process;
+- robustness requirements;
+- assembly requirements;
+- cavities/internal volumes;
+- constraints;
+- inferred defaults;
+- unknowns;
+- aesthetic goals;
+- safety caveats.
+
+## Candidate Scoring
+
+Score candidates by:
+
+- geometric validity;
+- printability;
+- robustness;
+- manufacturability;
+- material efficiency;
+- assembly ease;
+- parametricity;
+- aesthetic fit;
+- stability;
+- tolerance risk.
+
+Use scores to guide the user, not to pretend there is certified engineering validation.
+
+## Web UI Pattern
+
+The first useful UI slice should include:
+
+- a textarea with example prompts across multiple product families;
+- an Analyze button that POSTs to `/api/product-design-plan`;
+- a brief summary panel;
+- ranked candidate cards;
+- warnings and notes;
+- a Generate CAD prompt action for each candidate;
+- a copyable enriched prompt.
+
+A later slice can send the selected candidate directly into the normal CADAM parametric chat and persist candidate branches.
+
+## Gemini/Vertex Policy
+
+Gemini is optional. The baseline must work without any Gemini credentials.
+
+Use Gemini only as a readiness-gated enhancement for:
+
+- visual review;
+- reference-image critique;
+- candidate proposal;
+- prompt critique.
+
+Never log or document secret values. If credentials appear, redact them as `[REDACTED]`.
+
+## Verification Checklist
+
+- [ ] Trace analysis is limited to visible Zoo/KCL artifacts.
+- [ ] No hidden chain-of-thought is copied or claimed.
+- [ ] Core planning logic is in a pure shared module.
+- [ ] There is a test that fails before new behavior is implemented.
+- [ ] Endpoint works without external provider calls.
+- [ ] Web UI is general and not tied to a single product.
+- [ ] Route tree is regenerated after adding TanStack routes.
+- [ ] `npm run typecheck` passes.
+- [ ] `npm run lint` has no new errors.
+- [ ] `npm run build` passes.
+- [ ] Final report distinguishes implemented features from future validation loops.
+
+## Common Pitfalls
+
+1. Overfitting examples to a single lamp or project. Keep examples varied: bracket, enclosure, jig, fixture, mechanism, adapter, multipart shell.
+2. Treating trace text as private reasoning. Only use visible UI/tool/action evidence.
+3. Calling Gemini in tests. Tests should be offline; Gemini readiness should be a data object.
+4. Hand-editing generated route trees as the primary fix. Start Vite/TanStack to regenerate when possible.
+5. Jumping directly to CAD generation. Planning, candidates, scoring, and enriched prompts make the CAD result more controllable.

--- a/scripts/test-cadam-product-designer-v2.mjs
+++ b/scripts/test-cadam-product-designer-v2.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import {
+  buildCandidateGenerationPrompt,
+  extractProductBrief,
+  proposeDesignCandidates,
+  rankDesignCandidates,
+} from '../shared/cadamProductDesigner.ts';
+
+const root = new URL('../', import.meta.url);
+
+const productPrompts = [
+  'soporte de pared FDM con tornillos M4, clip flexible y tolerancia ajustable',
+  'caja electronica para ESP32 con tapa snap fit, ventilacion y bosses para tornillos',
+  'jig de perforacion parametrico con bujes metalicos y guia de alineacion',
+];
+
+for (const prompt of productPrompts) {
+  const brief = extractProductBrief(prompt);
+  assert.notEqual(brief.objectType, 'lamp', `Should not overfit to lamps: ${prompt}`);
+  assert.equal(brief.manufacturing, 'FDM 3D printing');
+  const ranked = rankDesignCandidates(proposeDesignCandidates(brief), brief);
+  assert.ok(ranked.length >= 5, 'Should generate several product-design strategies');
+  assert.ok(ranked.some((candidate) => /robust|print|modular|fixture|enclosure|jig/i.test(`${candidate.id} ${candidate.title} ${candidate.strategy}`)));
+  const generationPrompt = buildCandidateGenerationPrompt({
+    originalPrompt: prompt,
+    brief,
+    candidate: ranked[0],
+  });
+  assert.match(generationPrompt, /Selected design candidate/i);
+  assert.match(generationPrompt, /OpenSCAD/i);
+  assert.match(generationPrompt, /Customizer/i);
+  assert.match(generationPrompt, /tolerance|clearance/i);
+}
+
+const view = await readFile(new URL('src/views/ProductDesignerView.tsx', root), 'utf8');
+assert.match(view, /CADAM Product Designer/i);
+assert.match(view, /apiJson\('product-design-plan'/s);
+assert.match(view, /Generate CAD prompt/i);
+assert.doesNotMatch(view, /PRISMA/i);
+
+const route = await readFile(new URL('src/routes/_layout/product-designer.tsx', root), 'utf8');
+assert.match(route, /createFileRoute\('\/_layout\/product-designer'\)/);
+
+const docs = await readFile(new URL('docs/CADAM_PRODUCT_DESIGNER.md', root), 'utf8');
+assert.match(docs, /general CADAM/i);
+assert.match(docs, /Zoo\/KCL visible trace/i);
+assert.match(docs, /not.*chain-of-thought|No hidden chain-of-thought/is);
+assert.match(docs, /web/i);
+assert.doesNotMatch(docs, /PRISMA/i);
+
+const skill = await readFile(new URL('docs/skills/cadam-zoo-product-designer/SKILL.md', root), 'utf8');
+assert.ok(skill.startsWith('---\n'));
+assert.match(skill, /name: cadam-zoo-product-designer/);
+assert.match(skill, /visible Zoo\/KCL traces/i);
+assert.match(skill, /Verification Checklist/i);
+
+console.log('cadam product designer v2 tests passed');

--- a/scripts/test-cadam-product-designer-v3.mjs
+++ b/scripts/test-cadam-product-designer-v3.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const view = await readFile(new URL('src/views/ProductDesignerView.tsx', root), 'utf8');
+
+assert.match(view, /Start CAD generation/i);
+assert.match(view, /createAndCacheAiChat/);
+assert.match(view, /persistUserMessage/);
+assert.match(view, /ensureInputRecords/);
+assert.match(view, /type:\s*'parametric'/);
+assert.match(view, /apiUrl\('parametric-chat'\)/);
+assert.match(view, /navigate\(\{\s*to:\s*'\/editor\/\$id'/s);
+assert.match(view, /User must be authenticated|Sign in/i);
+assert.match(view, /product_designer_candidate_id|productDesignerCandidateId/);
+
+const docs = await readFile(new URL('docs/CADAM_PRODUCT_DESIGNER.md', root), 'utf8');
+assert.match(docs, /Start CAD generation|send selected candidate/i);
+assert.match(docs, /\/cadam\/product-designer/);
+
+console.log('cadam product designer v3 tests passed');

--- a/scripts/test-cadam-product-designer-v4.mjs
+++ b/scripts/test-cadam-product-designer-v4.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const view = await readFile(new URL('src/views/ProductDesignerView.tsx', root), 'utf8');
+const docs = await readFile(new URL('docs/CADAM_PRODUCT_DESIGNER.md', root), 'utf8');
+
+assert.match(view, /CADAM_PRODUCT_DESIGNER_BRANCHES/);
+assert.match(view, /localStorage\.getItem/);
+assert.match(view, /localStorage\.setItem/);
+assert.match(view, /Save branch/i);
+assert.match(view, /Saved candidate branches/i);
+assert.match(view, /restoreSavedBranch/);
+assert.match(view, /productDesignerCandidateId/);
+assert.match(docs, /localStorage branch persistence/i);
+
+console.log('cadam product designer v4 tests passed');

--- a/scripts/test-cadam-product-designer.mjs
+++ b/scripts/test-cadam-product-designer.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import {
+  PRODUCT_DESIGNER_PROMPT_EXTENSION,
+  extractProductBrief,
+  proposeDesignCandidates,
+  rankDesignCandidates,
+  summarizeZooWorkflowTrace,
+  vertexGeminiReadiness,
+} from '../shared/cadamProductDesigner.ts';
+
+const lampPrompt = `Design a robust 3D-printable lamp. Split it into two parts: an exterior aesthetic PLA shell and an interior cheap PETG structural insert. Add a click/snap-fit system between the parts. Leave as much internal space as possible for ballast cavities that can be filled with sand or weights. Prioritize robustness, printability, and easy assembly.`;
+
+const brief = extractProductBrief(lampPrompt);
+assert.equal(brief.objectType, 'lamp');
+assert.equal(brief.manufacturing, 'FDM 3D printing');
+assert.ok(brief.materials.exterior?.includes('PLA'));
+assert.ok(brief.materials.interior?.includes('PETG'));
+assert.ok(brief.assemblyRequirements.some((item) => /snap|click/i.test(item)));
+assert.ok(brief.cavities.some((item) => /ballast/i.test(item)));
+assert.ok(brief.inferredDefaults.some((item) => /wall/i.test(item)));
+
+const candidates = proposeDesignCandidates(brief);
+assert.ok(candidates.length >= 4);
+assert.ok(new Set(candidates.map((candidate) => candidate.strategy)).size >= 4);
+assert.ok(candidates.some((candidate) => /baseline/i.test(candidate.strategy)));
+assert.ok(candidates.some((candidate) => /modular|repair/i.test(candidate.strategy)));
+
+const ranked = rankDesignCandidates([
+  {
+    ...candidates[0],
+    cadCode: 'wall_thickness = 1; cube([20,20,20]);',
+  },
+  {
+    ...candidates[1],
+    cadCode: 'wall_thickness = 3; rib_count = 8; snap_clearance = 0.35; ballast_cavity_volume = 120;',
+  },
+]);
+assert.equal(ranked[0].id, candidates[1].id);
+assert.ok(ranked[0].score.overall > ranked[1].score.overall);
+assert.ok(ranked[1].warnings.some((warning) => /wall/i.test(warning)));
+
+const trace = `🧠 Activating skill: kcl-modeling\n📖 Reading user selections...\n📂 Listing project files and attachments...\n🔍 Searching built-in samples for: twist lock lamp base snap fit clip ballast cavities assembly\n✅ Read: main.kcl\n✅ Read: shadeDisk.kcl\nSupplemental analysis Beyond geometry creation, center of mass, volume, and surface area.`;
+const summary = summarizeZooWorkflowTrace(trace);
+assert.ok(summary.observableSkillRouting.some((item) => item.includes('kcl-modeling')));
+assert.ok(summary.observableDesignStages.some((item) => /selection/i.test(item)));
+assert.ok(summary.observableMechanicalConsiderations.some((item) => /snap|ballast/i.test(item)));
+assert.ok(summary.limitations.some((item) => /visible/i.test(item)));
+
+const noEnv = vertexGeminiReadiness({});
+assert.equal(noEnv.available, false);
+assert.ok(noEnv.missing.includes('GOOGLE_CLOUD_PROJECT'));
+
+assert.ok(PRODUCT_DESIGNER_PROMPT_EXTENSION.includes('multiple design candidates'));
+assert.ok(PRODUCT_DESIGNER_PROMPT_EXTENSION.includes('mechanical'));
+
+console.log('cadam product designer tests passed');

--- a/shared/cadamProductDesigner.ts
+++ b/shared/cadamProductDesigner.ts
@@ -1,0 +1,641 @@
+export type ProductBrief = {
+  objectType: string;
+  intendedUse?: string;
+  dimensions: Record<string, number | string>;
+  materials: Record<string, string>;
+  manufacturing?: string;
+  robustnessRequirements: string[];
+  assemblyRequirements: string[];
+  cavities: string[];
+  constraints: string[];
+  inferredDefaults: string[];
+  unknowns: string[];
+  aestheticGoals: string[];
+  safetyConstraints: string[];
+};
+
+export type CandidateScore = {
+  geometricValidity: number;
+  printability: number;
+  robustness: number;
+  manufacturability: number;
+  materialEfficiency: number;
+  assemblyEase: number;
+  parametricity: number;
+  aestheticFit: number;
+  stability: number;
+  toleranceRisk: number;
+  overall: number;
+};
+
+export type DesignCandidate = {
+  id: string;
+  title: string;
+  strategy: string;
+  cadCode?: string;
+  parameters?: Record<string, unknown>;
+  score?: CandidateScore;
+  notes: string[];
+  warnings: string[];
+  failureRisks: string[];
+  parentId?: string;
+  generation: number;
+};
+
+export type ZooWorkflowSummary = {
+  observableSkillRouting: string[];
+  observableDesignStages: string[];
+  observableMechanicalConsiderations: string[];
+  observableCadGenerationPatterns: string[];
+  observableProjectStateUse: string[];
+  observableValidationOrRepair: string[];
+  cadamImprovementOpportunities: string[];
+  limitations: string[];
+};
+
+export type ProductDesignPlan = {
+  brief: ProductBrief;
+  candidates: DesignCandidate[];
+  generationPrompts?: Record<string, string>;
+  traceSummary?: ZooWorkflowSummary;
+  gemini: ReturnType<typeof vertexGeminiReadiness>;
+};
+
+export type CandidateGenerationPromptInput = {
+  originalPrompt: string;
+  brief: ProductBrief;
+  candidate: DesignCandidate;
+  extraInstructions?: string;
+};
+
+export const PRODUCT_DESIGNER_PROMPT_EXTENSION = `
+# CADAM product-designer workflow
+For practical mechanical/product CAD requests, behave as a product design partner, not a single-shot code generator.
+
+Before calling build_parametric_model, internally structure the task as:
+- product brief: object type, use, dimensions, materials, manufacturing method, robustness, assembly, cavities, tolerances, printability, aesthetic goals, unknowns, inferred defaults, and safety caveats.
+- multiple design candidates when useful: explore meaningfully different strategies such as robust baseline, print-optimized, material-efficient, premium/aesthetic, mechanically reinforced, modular/repairable, or task-specific alternatives.
+- candidate evaluation: compare geometric validity, printability, robustness, manufacturability, material efficiency, assembly ease, parametricity, aesthetic fit, stability, tolerance risk, and complexity.
+- variant evolution: when the user picks or praises a candidate, preserve that branch and generate descendants rather than restarting.
+
+Mechanical heuristics for FDM:
+- Prefer explicit top-level parameters with Customizer comments for wall thickness, clearances, rib count, boss diameters, snap clearances, ballast cavities, vents, and material-specific parts.
+- For snap/click fits, expose clearance and flexure dimensions; use PETG/nylon-like assumptions for flexing parts and warn about brittle PLA snaps.
+- For lamps, separate visible PLA shells from cheaper/stronger PETG inserts when requested, preserve large ballast cavities, route cables safely, leave heat/ventilation clearance, and label electrical safety assumptions.
+- If images are present, use them for silhouette/proportion/feature extraction and compare generated previews against them when possible.
+- Keep failures structured: if CAD cannot be made valid, explain the failure and emit the smallest repairable artifact instead of vague prose.
+`;
+
+const MM_DIMENSION = /(\d+(?:\.\d+)?)\s*(mm|cm|m)\b/gi;
+
+function unique(values: string[]): string[] {
+  return Array.from(
+    new Set(values.map((value) => value.trim()).filter(Boolean)),
+  );
+}
+
+function has(text: string, pattern: RegExp): boolean {
+  return pattern.test(text);
+}
+
+function inferObjectType(lower: string): string {
+  if (/lamp|lampara|lámpara|shade|diffuser/.test(lower)) return 'lamp';
+  if (
+    /enclosure|case|box|housing|caja|gabinete|electronics|electronica|electr[oó]nica/.test(
+      lower,
+    )
+  )
+    return 'enclosure';
+  if (
+    /jig|fixture|plantilla|drill guide|guia de perforaci[oó]n|guía de perforaci[oó]n/.test(
+      lower,
+    )
+  )
+    return 'jig/fixture';
+  if (/clip|snap|bracket|mount|soporte|fastener|wall mount|pared/.test(lower))
+    return 'connector/fixture';
+  if (
+    /gear|engranaje|pulley|polea|hinge|bisagra|mechanism|mecanismo/.test(lower)
+  )
+    return 'mechanism';
+  if (/planter|maceta/.test(lower)) return 'planter';
+  return 'physical product';
+}
+
+export function extractProductBrief(prompt: string): ProductBrief {
+  const lower = prompt.toLowerCase();
+  const dimensions: Record<string, number | string> = {};
+  let match: RegExpExecArray | null;
+  while ((match = MM_DIMENSION.exec(prompt))) {
+    dimensions[`dimension_${Object.keys(dimensions).length + 1}`] =
+      `${match[1]}${match[2]}`;
+  }
+
+  const materials: Record<string, string> = {};
+  if (has(lower, /pla/))
+    materials.exterior = 'PLA aesthetic shell or visible part';
+  if (has(lower, /petg/))
+    materials.interior = 'PETG structural insert or cheap interior part';
+  if (has(lower, /nylon|pa6|pa12/))
+    materials.flexures = 'nylon-family material for fatigue-resistant flexures';
+
+  const assemblyRequirements = unique([
+    has(lower, /snap|click|clip|pres[s-]?fit|encastre/)
+      ? 'snap/click-fit assembly with explicit clearances'
+      : '',
+    has(lower, /screw|m3|m4|bolt|tornillo/)
+      ? 'screw/fastener-compatible assembly'
+      : '',
+    has(lower, /split|separate|two parts|dos piezas|modular/)
+      ? 'separate printable parts with clear assembly order'
+      : '',
+  ]);
+
+  const cavities = unique([
+    has(lower, /ballast|lastre|sand|weights|yeso|plaster/)
+      ? 'large ballast cavities for sand/plaster/weights'
+      : '',
+    has(lower, /cavity|void|cabidad|cavidad|internal space/)
+      ? 'preserve internal voids where structurally safe'
+      : '',
+    has(lower, /cable|wire|led|e14|lamp holder|portal[aá]mparas/)
+      ? 'cable/lamp-holder routing cavity'
+      : '',
+  ]);
+
+  const robustnessRequirements = unique([
+    has(lower, /robust|strong|strength|rigid|resistente|structural/)
+      ? 'robust load paths with ribs/gussets where useful'
+      : '',
+    has(lower, /easy assembly|facil|fácil/)
+      ? 'easy hand assembly and low tool burden'
+      : '',
+    has(lower, /printability|3d.print|fdm|imprimir/)
+      ? 'FDM-printable geometry with manageable overhangs'
+      : '',
+  ]);
+
+  const constraints = unique([
+    has(lower, /as much internal space|mayor espacio|maximum internal/)
+      ? 'maximize usable internal space'
+      : '',
+    has(lower, /cheap|barato/)
+      ? 'use low-cost material where hidden or non-aesthetic'
+      : '',
+    has(lower, /aesthetic|premium|est[eé]tico/)
+      ? 'protect the visible exterior appearance'
+      : '',
+  ]);
+
+  const aestheticGoals = unique([
+    has(lower, /aesthetic|premium|est[eé]tico/)
+      ? 'clean visible shell with hidden structural mechanics'
+      : '',
+  ]);
+
+  const safetyConstraints = unique([
+    inferObjectType(lower) === 'lamp'
+      ? 'electrical/heat safety must be reviewed before real use'
+      : '',
+    has(lower, /load|hanging|weight|lastre/)
+      ? 'ballast/load-bearing assumptions are practical heuristics, not certification'
+      : '',
+  ]);
+
+  const inferredDefaults = unique([
+    'units in millimeters',
+    'default FDM wall thickness 2.4-3.2 mm unless prompt says otherwise',
+    'snap-fit clearance starts around 0.25-0.45 mm and must be tuned per printer/material',
+    'use grouped top-level OpenSCAD parameters with Customizer ranges',
+    inferObjectType(lower) === 'lamp'
+      ? 'separate heat/electrical components from printed plastic with clearance and ventilation'
+      : '',
+  ]);
+
+  const unknowns = unique([
+    Object.keys(dimensions).length === 0 ? 'exact external dimensions' : '',
+    assemblyRequirements.length === 0
+      ? 'preferred fastening/assembly method'
+      : '',
+    'printer/nozzle/material profile and tolerance calibration',
+  ]);
+
+  return {
+    objectType: inferObjectType(lower),
+    intendedUse:
+      inferObjectType(lower) === 'lamp'
+        ? 'functional/decorative lamp product'
+        : undefined,
+    dimensions,
+    materials,
+    manufacturing: has(lower, /cnc|milling|machining|fresado/)
+      ? 'CNC/machining'
+      : 'FDM 3D printing',
+    robustnessRequirements,
+    assemblyRequirements,
+    cavities,
+    constraints,
+    inferredDefaults,
+    unknowns,
+    aestheticGoals,
+    safetyConstraints,
+  };
+}
+
+function makeCandidate(
+  id: string,
+  title: string,
+  strategy: string,
+  notes: string[],
+): DesignCandidate {
+  return {
+    id,
+    title,
+    strategy,
+    notes,
+    warnings: [],
+    failureRisks: [],
+    generation: 1,
+  };
+}
+
+export function proposeDesignCandidates(
+  brief: ProductBrief,
+): DesignCandidate[] {
+  const object =
+    brief.objectType === 'physical product' ? 'product' : brief.objectType;
+  const base = [
+    makeCandidate(
+      'baseline-robust',
+      `${object} robust baseline`,
+      'baseline robust parametric design',
+      [
+        'Prioritizes simple manifold geometry, conservative walls, and easy preview/export.',
+      ],
+    ),
+    makeCandidate(
+      'print-optimized',
+      `${object} print-optimized`,
+      'print-optimized low-support design',
+      [
+        'Chooses orientations, splits, and overhang reductions that should slice reliably on FDM.',
+      ],
+    ),
+    makeCandidate(
+      'material-efficient',
+      `${object} material-efficient`,
+      'material-efficient hollow/ribbed design',
+      [
+        'Uses shells, ribs, and cavities to reduce filament while preserving stiffness.',
+      ],
+    ),
+    makeCandidate(
+      'premium-visible',
+      `${object} premium exterior`,
+      'premium/aesthetic visible-shell design',
+      [
+        'Keeps structural mechanics hidden behind a cleaner external silhouette.',
+      ],
+    ),
+    makeCandidate(
+      'modular-repairable',
+      `${object} modular repairable`,
+      'modular/repairable assembly design',
+      [
+        'Separates hidden structural inserts, visible shells, and replaceable connectors when useful.',
+      ],
+    ),
+  ];
+
+  if (brief.objectType === 'lamp') {
+    base.push(
+      makeCandidate(
+        'lamp-ballast-insert',
+        'lamp ballast insert architecture',
+        'lamp-specific PLA shell + PETG insert + ballast cavities',
+        [
+          'Explicitly models PLA outer shell, PETG inner skeleton, snap/click fit, cable path, holder clearance, vents, and ballast reservoirs.',
+        ],
+      ),
+    );
+  }
+
+  if (brief.objectType === 'enclosure') {
+    base.push(
+      makeCandidate(
+        'enclosure-serviceable-snap',
+        'serviceable electronics enclosure',
+        'two-part enclosure with snap tabs, screw bosses, vents, and cable exits',
+        [
+          'Balances snap-fit convenience with screw-boss fallback, PCB standoffs, ventilation, and labelled clearances.',
+        ],
+      ),
+    );
+  }
+
+  if (brief.objectType === 'connector/fixture') {
+    base.push(
+      makeCandidate(
+        'fixture-load-path',
+        'load-path optimized fixture',
+        'bracket/fixture with reinforced bosses, screw slots, ribs, and printable flexures',
+        [
+          'Keeps forces flowing through ribs and bosses while exposing clearance and fastener parameters.',
+        ],
+      ),
+    );
+  }
+
+  if (brief.objectType === 'jig/fixture') {
+    base.push(
+      makeCandidate(
+        'jig-accurate-guide',
+        'accurate workshop jig',
+        'datum-driven jig with bushings, registration faces, clamps, and tolerance offsets',
+        [
+          'Prioritizes repeatable datums, replaceable wear inserts, and clear alignment features over ornament.',
+        ],
+      ),
+    );
+  }
+
+  if (brief.objectType === 'mechanism') {
+    base.push(
+      makeCandidate(
+        'mechanism-clearance-prototype',
+        'clearance-first mechanism prototype',
+        'mechanism with exposed pivots, stops, service gaps, and iteration-friendly parameters',
+        [
+          'Treats friction, layer orientation, axle clearance, and sacrificial iteration features as first-class constraints.',
+        ],
+      ),
+    );
+  }
+
+  return base;
+}
+
+function scoreFromCode(
+  candidate: DesignCandidate,
+  brief: ProductBrief,
+): CandidateScore {
+  const code = (candidate.cadCode ?? '').toLowerCase();
+  const strategy = candidate.strategy.toLowerCase();
+  const mentions = (terms: RegExp) => terms.test(code) || terms.test(strategy);
+  const wallThin = /wall_?thickness\s*=\s*(0?\.\d|1(?:\.\d)?)/.test(code);
+  const hasParams = /[a-z][a-z0-9_]+\s*=/.test(code);
+  const hasModules = /module\s+[a-z0-9_]+/.test(code);
+
+  const score: CandidateScore = {
+    geometricValidity: hasModules || code.length === 0 ? 7 : 5,
+    printability:
+      6 +
+      (mentions(/print|fdm|overhang|support|orientation|wall/) ? 1 : 0) -
+      (wallThin ? 3 : 0),
+    robustness:
+      5 +
+      (mentions(/rib|gusset|boss|insert|petg|reinforce|structural/) ? 2 : 0),
+    manufacturability:
+      6 + (mentions(/clearance|tolerance|assembly|split|part/) ? 1 : 0),
+    materialEfficiency:
+      5 + (mentions(/hollow|cavity|void|rib|ballast/) ? 2 : 0),
+    assemblyEase: 5 + (mentions(/snap|click|clip|screw|pin|clearance/) ? 2 : 0),
+    parametricity: hasParams ? 8 : 4,
+    aestheticFit: 5 + (mentions(/shell|aesthetic|premium|visible/) ? 2 : 0),
+    stability: 5 + (mentions(/ballast|base|center|weight|lastre/) ? 2 : 0),
+    toleranceRisk:
+      7 -
+      (mentions(/snap|click|press/) && !mentions(/clearance|tolerance/)
+        ? 2
+        : 0),
+    overall: 0,
+  };
+
+  if (
+    brief.cavities.length > 0 &&
+    !mentions(/cavity|void|ballast|hollow|lastre/)
+  )
+    score.materialEfficiency -= 2;
+  if (
+    brief.assemblyRequirements.length > 0 &&
+    !mentions(/snap|click|clip|screw|pin|assembly|clearance/)
+  )
+    score.assemblyEase -= 2;
+
+  const entries = Object.entries(score).filter(
+    ([key]) => key !== 'overall',
+  ) as [keyof CandidateScore, number][];
+  score.overall = Number(
+    (
+      entries.reduce(
+        (sum, [, value]) => sum + Math.max(0, Math.min(10, value)),
+        0,
+      ) / entries.length
+    ).toFixed(2),
+  );
+  return score;
+}
+
+export function rankDesignCandidates(
+  candidates: DesignCandidate[],
+  brief: ProductBrief = extractProductBrief(''),
+): DesignCandidate[] {
+  return candidates
+    .map((candidate) => {
+      const score = scoreFromCode(candidate, brief);
+      const warnings = [...candidate.warnings];
+      const code = (candidate.cadCode ?? '').toLowerCase();
+      if (/wall_?thickness\s*=\s*(0?\.\d|1(?:\.\d)?)/.test(code)) {
+        warnings.push(
+          'Wall thickness appears too thin for robust FDM mechanical parts.',
+        );
+      }
+      if (/snap|click|press/.test(code) && !/clearance|tolerance/.test(code)) {
+        warnings.push(
+          'Snap/click feature lacks explicit clearance/tolerance parameters.',
+        );
+      }
+      if (
+        brief.objectType === 'lamp' &&
+        !/vent|heat|clearance|cable|holder/.test(code) &&
+        candidate.cadCode
+      ) {
+        warnings.push(
+          'Lamp design should include heat/electrical clearance and cable/holder assumptions.',
+        );
+      }
+      return { ...candidate, score, warnings };
+    })
+    .sort((a, b) => (b.score?.overall ?? 0) - (a.score?.overall ?? 0));
+}
+
+export function summarizeZooWorkflowTrace(
+  traceMarkdown: string,
+): ZooWorkflowSummary {
+  const text = traceMarkdown.replace(/\s+/g, ' ');
+  const activated = Array.from(
+    text.matchAll(/Activating skill:\s*([a-z0-9-]+)/gi),
+  ).map((match) => match[1]);
+  return {
+    observableSkillRouting: unique([
+      ...activated.map((skill) => `visible activation of ${skill}`),
+      /mechanical/i.test(text)
+        ? 'mechanical-engineering capability appears in visible routing'
+        : '',
+      /knowledge|samples/i.test(text)
+        ? 'knowledge/sample search is part of the visible workflow'
+        : '',
+    ]),
+    observableDesignStages: unique([
+      /Reading user selections/i.test(text)
+        ? 'reads current user selection/project context before editing'
+        : '',
+      /Listing project files/i.test(text)
+        ? 'lists project files and attachments'
+        : '',
+      /Read:/i.test(text)
+        ? 'reads existing CAD files before proposing changes'
+        : '',
+      /built-in samples|knowledge sources/i.test(text)
+        ? 'searches knowledge/samples for analogous CAD features'
+        : '',
+      /Export current part/i.test(text)
+        ? 'supports current-part export as a workflow endpoint'
+        : '',
+    ]),
+    observableMechanicalConsiderations: unique([
+      /snap|click|detent|clip/i.test(text)
+        ? 'snap/click/detent mechanisms are explicit design concerns'
+        : '',
+      /ballast|lastre|yeso|cavit/i.test(text)
+        ? 'ballast cavities and internal volume are explicit design concerns'
+        : '',
+      /PLA|PETG/i.test(text)
+        ? 'visible/material split between PLA and PETG is considered'
+        : '',
+      /center of mass|volume|surface area/i.test(text)
+        ? 'derived properties such as volume, surface area, and center of mass are exposed'
+        : '',
+    ]),
+    observableCadGenerationPatterns: unique([
+      /sketch|extrude|revolve|fillet|chamfer|shell|hole/i.test(text)
+        ? 'feature-based CAD operations are available in the visible interface'
+        : '',
+      /kcl/i.test(text)
+        ? 'parametric KCL files and variables are the visible source artifact'
+        : '',
+      /appearance|color/i.test(text)
+        ? 'visual material/appearance metadata is part of generated code'
+        : '',
+      /project files/i.test(text)
+        ? 'multi-file assemblies are a normal project shape'
+        : '',
+    ]),
+    observableProjectStateUse: unique([
+      /user selections/i.test(text) ? 'current selection state is read' : '',
+      /Project Files/i.test(text)
+        ? 'project file tree influences the workflow'
+        : '',
+      /attachments|image/i.test(text)
+        ? 'attachments/images are accepted as reference context'
+        : '',
+    ]),
+    observableValidationOrRepair: unique([
+      /Logs|View KCL source code|Export part/i.test(text)
+        ? 'logs/source/export affordances support validation loops'
+        : '',
+      /Supplemental analysis/i.test(text)
+        ? 'post-generation analysis is visible as a companion capability'
+        : '',
+    ]),
+    cadamImprovementOpportunities: [
+      'Add structured product brief extraction before CAD generation.',
+      'Generate and rank multiple candidate strategies instead of one immediate artifact for complex product prompts.',
+      'Surface mechanical warnings for walls, snaps, tolerances, ballast, cable paths, and heat-sensitive lamp features.',
+      'Preserve candidate families/branches so selected winners can evolve through follow-up generations.',
+      'Keep optional image/visual critique behind provider readiness checks and graceful fallbacks.',
+    ],
+    limitations: [
+      'Summary is inferred only from visible trace text and UI/action labels.',
+      'No hidden chain-of-thought, private prompts, APIs, or proprietary implementation details are used.',
+      'Trace snippets are noisy UI exports, so counts and stages are heuristic rather than authoritative telemetry.',
+    ],
+  };
+}
+
+export function buildCandidateGenerationPrompt({
+  originalPrompt,
+  brief,
+  candidate,
+  extraInstructions,
+}: CandidateGenerationPromptInput): string {
+  const score = candidate.score
+    ? `overall ${candidate.score.overall}/10`
+    : 'not scored';
+  const list = (label: string, values: string[]) =>
+    values.length > 0
+      ? `- ${label}: ${values.join('; ')}`
+      : `- ${label}: not specified; infer conservative defaults and expose them as parameters`;
+
+  return [
+    'Use CADAM parametric mode to generate editable OpenSCAD for the selected product-design candidate.',
+    '',
+    `Original user prompt: ${originalPrompt}`,
+    '',
+    'Product brief:',
+    `- object type: ${brief.objectType}`,
+    `- intended use: ${brief.intendedUse ?? 'not specified'}`,
+    `- manufacturing: ${brief.manufacturing ?? 'FDM 3D printing'}`,
+    `- dimensions: ${JSON.stringify(brief.dimensions)}`,
+    `- materials: ${JSON.stringify(brief.materials)}`,
+    list('robustness requirements', brief.robustnessRequirements),
+    list('assembly requirements', brief.assemblyRequirements),
+    list('cavities/internal volumes', brief.cavities),
+    list('constraints', brief.constraints),
+    list('aesthetic goals', brief.aestheticGoals),
+    list('safety constraints', brief.safetyConstraints),
+    list('unknowns to keep parametric', brief.unknowns),
+    '',
+    'Selected design candidate:',
+    `- id: ${candidate.id}`,
+    `- title: ${candidate.title}`,
+    `- strategy: ${candidate.strategy}`,
+    `- score: ${score}`,
+    `- notes: ${candidate.notes.join('; ') || 'none'}`,
+    `- warnings: ${candidate.warnings.join('; ') || 'none'}`,
+    '',
+    'CAD output requirements:',
+    '- Return one self-contained OpenSCAD file with a top-level PART selector and assembly preview.',
+    '- Use millimeters and grouped Customizer parameters for primary dimensions, wall thickness, tolerances, clearances, fasteners, ribs, cavities, and material-specific parts.',
+    '- Include printability notes in comments: orientation, supports, material assumptions, and clearance tuning.',
+    '- Prefer simple manifold boolean structure, named modules, and repairable subassemblies over decorative one-shot geometry.',
+    '- If a requirement is unsafe or underspecified, encode a conservative default as a parameter and explain it in comments rather than silently dropping it.',
+    extraInstructions ? `\nExtra instructions:\n${extraInstructions}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+export function vertexGeminiReadiness(
+  env: Record<string, string | undefined> = typeof process === 'undefined'
+    ? {}
+    : process.env,
+): { available: boolean; missing: string[]; model: string; location: string } {
+  const required = ['GOOGLE_CLOUD_PROJECT', 'GOOGLE_CLOUD_LOCATION'];
+  const missing = required.filter((key) => !env[key]);
+  const hasApiKeyOrAdc = Boolean(
+    env.GOOGLE_API_KEY ||
+      env.GOOGLE_APPLICATION_CREDENTIALS ||
+      env.GOOGLE_GENAI_USE_VERTEXAI,
+  );
+  if (!hasApiKeyOrAdc)
+    missing.push(
+      'GOOGLE_API_KEY or GOOGLE_APPLICATION_CREDENTIALS/GOOGLE_GENAI_USE_VERTEXAI',
+    );
+  return {
+    available: missing.length === 0,
+    missing,
+    model: env.VERTEX_GEMINI_MODEL ?? 'gemini-3.1-pro-preview',
+    location: env.GOOGLE_CLOUD_LOCATION ?? 'global',
+  };
+}

--- a/shared/chatAi.ts
+++ b/shared/chatAi.ts
@@ -102,6 +102,8 @@ export type AppUIMessage = UIMessage<
   {
     model?: Model;
     billingTokens?: number;
+    productDesignerCandidateId?: string;
+    product_designer_candidate_id?: string;
   },
   AppDataTypes,
   AppTools

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -85,6 +85,8 @@ export type ConversationSettings = {
    * `src/server/aiChat.ts`.
    */
   suggestions?: string[];
+  productDesignerCandidateId?: string;
+  product_designer_candidate_id?: string;
 } | null;
 
 export type Profile = Database['public']['Tables']['profiles']['Row'];

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -8,273 +8,291 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as UpdatePasswordRouteImport } from './routes/update-password'
-import { Route as TermsOfServiceRouteImport } from './routes/terms-of-service'
-import { Route as SignupEmailRouteImport } from './routes/signup-email'
-import { Route as SignupRouteImport } from './routes/signup'
-import { Route as SigninRouteImport } from './routes/signin'
-import { Route as ResetPasswordRouteImport } from './routes/reset-password'
-import { Route as PrivacyPolicyRouteImport } from './routes/privacy-policy'
-import { Route as ConfirmEmailRouteImport } from './routes/confirm-email'
-import { Route as LayoutRouteImport } from './routes/_layout'
-import { Route as LayoutIndexRouteImport } from './routes/_layout/index'
-import { Route as ApiTitleGeneratorRouteImport } from './routes/api/title-generator'
-import { Route as ApiPromptGeneratorRouteImport } from './routes/api/prompt-generator'
-import { Route as ApiParametricChatRouteImport } from './routes/api/parametric-chat'
-import { Route as ApiMeshRouteImport } from './routes/api/mesh'
-import { Route as ApiFalWebhookRouteImport } from './routes/api/fal-webhook'
-import { Route as ApiDeleteUserRouteImport } from './routes/api/delete-user'
-import { Route as ApiCreativeChatRouteImport } from './routes/api/creative-chat'
-import { Route as ApiBillingStatusRouteImport } from './routes/api/billing-status'
-import { Route as ApiBillingProductsRouteImport } from './routes/api/billing-products'
-import { Route as ApiBillingPortalRouteImport } from './routes/api/billing-portal'
-import { Route as ApiBillingCheckoutRouteImport } from './routes/api/billing-checkout'
-import { Route as LayoutAuthRouteImport } from './routes/_layout/_auth'
-import { Route as LayoutSplatRouteImport } from './routes/_layout/$'
-import { Route as ApiJacksonPollockSplatRouteImport } from './routes/api/jackson-pollock/$'
-import { Route as LayoutShareIdRouteImport } from './routes/_layout/share/$id'
-import { Route as LayoutAuthSubscriptionRouteImport } from './routes/_layout/_auth/subscription'
-import { Route as LayoutAuthSettingsRouteImport } from './routes/_layout/_auth/settings'
-import { Route as LayoutAuthHistoryRouteImport } from './routes/_layout/_auth/history'
-import { Route as LayoutAuthEditorIdRouteImport } from './routes/_layout/_auth/editor/$id'
+import { Route as rootRouteImport } from './routes/__root';
+import { Route as UpdatePasswordRouteImport } from './routes/update-password';
+import { Route as TermsOfServiceRouteImport } from './routes/terms-of-service';
+import { Route as SignupEmailRouteImport } from './routes/signup-email';
+import { Route as SignupRouteImport } from './routes/signup';
+import { Route as SigninRouteImport } from './routes/signin';
+import { Route as ResetPasswordRouteImport } from './routes/reset-password';
+import { Route as PrivacyPolicyRouteImport } from './routes/privacy-policy';
+import { Route as ConfirmEmailRouteImport } from './routes/confirm-email';
+import { Route as LayoutRouteImport } from './routes/_layout';
+import { Route as LayoutIndexRouteImport } from './routes/_layout/index';
+import { Route as ApiTitleGeneratorRouteImport } from './routes/api/title-generator';
+import { Route as ApiPromptGeneratorRouteImport } from './routes/api/prompt-generator';
+import { Route as ApiProductDesignPlanRouteImport } from './routes/api/product-design-plan';
+import { Route as ApiParametricChatRouteImport } from './routes/api/parametric-chat';
+import { Route as ApiMeshRouteImport } from './routes/api/mesh';
+import { Route as ApiFalWebhookRouteImport } from './routes/api/fal-webhook';
+import { Route as ApiDeleteUserRouteImport } from './routes/api/delete-user';
+import { Route as ApiCreativeChatRouteImport } from './routes/api/creative-chat';
+import { Route as ApiBillingStatusRouteImport } from './routes/api/billing-status';
+import { Route as ApiBillingProductsRouteImport } from './routes/api/billing-products';
+import { Route as ApiBillingPortalRouteImport } from './routes/api/billing-portal';
+import { Route as ApiBillingCheckoutRouteImport } from './routes/api/billing-checkout';
+import { Route as LayoutProductDesignerRouteImport } from './routes/_layout/product-designer';
+import { Route as LayoutAuthRouteImport } from './routes/_layout/_auth';
+import { Route as LayoutSplatRouteImport } from './routes/_layout/$';
+import { Route as ApiJacksonPollockSplatRouteImport } from './routes/api/jackson-pollock/$';
+import { Route as LayoutShareIdRouteImport } from './routes/_layout/share/$id';
+import { Route as LayoutAuthSubscriptionRouteImport } from './routes/_layout/_auth/subscription';
+import { Route as LayoutAuthSettingsRouteImport } from './routes/_layout/_auth/settings';
+import { Route as LayoutAuthHistoryRouteImport } from './routes/_layout/_auth/history';
+import { Route as LayoutAuthEditorIdRouteImport } from './routes/_layout/_auth/editor/$id';
 
 const UpdatePasswordRoute = UpdatePasswordRouteImport.update({
   id: '/update-password',
   path: '/update-password',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const TermsOfServiceRoute = TermsOfServiceRouteImport.update({
   id: '/terms-of-service',
   path: '/terms-of-service',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const SignupEmailRoute = SignupEmailRouteImport.update({
   id: '/signup-email',
   path: '/signup-email',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
   path: '/signup',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const SigninRoute = SigninRouteImport.update({
   id: '/signin',
   path: '/signin',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
   id: '/reset-password',
   path: '/reset-password',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const PrivacyPolicyRoute = PrivacyPolicyRouteImport.update({
   id: '/privacy-policy',
   path: '/privacy-policy',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ConfirmEmailRoute = ConfirmEmailRouteImport.update({
   id: '/confirm-email',
   path: '/confirm-email',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LayoutRoute = LayoutRouteImport.update({
   id: '/_layout',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LayoutIndexRoute = LayoutIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => LayoutRoute,
-} as any)
+} as any);
 const ApiTitleGeneratorRoute = ApiTitleGeneratorRouteImport.update({
   id: '/api/title-generator',
   path: '/api/title-generator',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiPromptGeneratorRoute = ApiPromptGeneratorRouteImport.update({
   id: '/api/prompt-generator',
   path: '/api/prompt-generator',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
+const ApiProductDesignPlanRoute = ApiProductDesignPlanRouteImport.update({
+  id: '/api/product-design-plan',
+  path: '/api/product-design-plan',
+  getParentRoute: () => rootRouteImport,
+} as any);
 const ApiParametricChatRoute = ApiParametricChatRouteImport.update({
   id: '/api/parametric-chat',
   path: '/api/parametric-chat',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiMeshRoute = ApiMeshRouteImport.update({
   id: '/api/mesh',
   path: '/api/mesh',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiFalWebhookRoute = ApiFalWebhookRouteImport.update({
   id: '/api/fal-webhook',
   path: '/api/fal-webhook',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiDeleteUserRoute = ApiDeleteUserRouteImport.update({
   id: '/api/delete-user',
   path: '/api/delete-user',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiCreativeChatRoute = ApiCreativeChatRouteImport.update({
   id: '/api/creative-chat',
   path: '/api/creative-chat',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiBillingStatusRoute = ApiBillingStatusRouteImport.update({
   id: '/api/billing-status',
   path: '/api/billing-status',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiBillingProductsRoute = ApiBillingProductsRouteImport.update({
   id: '/api/billing-products',
   path: '/api/billing-products',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiBillingPortalRoute = ApiBillingPortalRouteImport.update({
   id: '/api/billing-portal',
   path: '/api/billing-portal',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiBillingCheckoutRoute = ApiBillingCheckoutRouteImport.update({
   id: '/api/billing-checkout',
   path: '/api/billing-checkout',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
+const LayoutProductDesignerRoute = LayoutProductDesignerRouteImport.update({
+  id: '/product-designer',
+  path: '/product-designer',
+  getParentRoute: () => LayoutRoute,
+} as any);
 const LayoutAuthRoute = LayoutAuthRouteImport.update({
   id: '/_auth',
   getParentRoute: () => LayoutRoute,
-} as any)
+} as any);
 const LayoutSplatRoute = LayoutSplatRouteImport.update({
   id: '/$',
   path: '/$',
   getParentRoute: () => LayoutRoute,
-} as any)
+} as any);
 const ApiJacksonPollockSplatRoute = ApiJacksonPollockSplatRouteImport.update({
   id: '/api/jackson-pollock/$',
   path: '/api/jackson-pollock/$',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LayoutShareIdRoute = LayoutShareIdRouteImport.update({
   id: '/share/$id',
   path: '/share/$id',
   getParentRoute: () => LayoutRoute,
-} as any)
+} as any);
 const LayoutAuthSubscriptionRoute = LayoutAuthSubscriptionRouteImport.update({
   id: '/subscription',
   path: '/subscription',
   getParentRoute: () => LayoutAuthRoute,
-} as any)
+} as any);
 const LayoutAuthSettingsRoute = LayoutAuthSettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
   getParentRoute: () => LayoutAuthRoute,
-} as any)
+} as any);
 const LayoutAuthHistoryRoute = LayoutAuthHistoryRouteImport.update({
   id: '/history',
   path: '/history',
   getParentRoute: () => LayoutAuthRoute,
-} as any)
+} as any);
 const LayoutAuthEditorIdRoute = LayoutAuthEditorIdRouteImport.update({
   id: '/editor/$id',
   path: '/editor/$id',
   getParentRoute: () => LayoutAuthRoute,
-} as any)
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof LayoutIndexRoute
-  '/confirm-email': typeof ConfirmEmailRoute
-  '/privacy-policy': typeof PrivacyPolicyRoute
-  '/reset-password': typeof ResetPasswordRoute
-  '/signin': typeof SigninRoute
-  '/signup': typeof SignupRoute
-  '/signup-email': typeof SignupEmailRoute
-  '/terms-of-service': typeof TermsOfServiceRoute
-  '/update-password': typeof UpdatePasswordRoute
-  '/$': typeof LayoutSplatRoute
-  '/api/billing-checkout': typeof ApiBillingCheckoutRoute
-  '/api/billing-portal': typeof ApiBillingPortalRoute
-  '/api/billing-products': typeof ApiBillingProductsRoute
-  '/api/billing-status': typeof ApiBillingStatusRoute
-  '/api/creative-chat': typeof ApiCreativeChatRoute
-  '/api/delete-user': typeof ApiDeleteUserRoute
-  '/api/fal-webhook': typeof ApiFalWebhookRoute
-  '/api/mesh': typeof ApiMeshRoute
-  '/api/parametric-chat': typeof ApiParametricChatRoute
-  '/api/prompt-generator': typeof ApiPromptGeneratorRoute
-  '/api/title-generator': typeof ApiTitleGeneratorRoute
-  '/history': typeof LayoutAuthHistoryRoute
-  '/settings': typeof LayoutAuthSettingsRoute
-  '/subscription': typeof LayoutAuthSubscriptionRoute
-  '/share/$id': typeof LayoutShareIdRoute
-  '/api/jackson-pollock/$': typeof ApiJacksonPollockSplatRoute
-  '/editor/$id': typeof LayoutAuthEditorIdRoute
+  '/': typeof LayoutIndexRoute;
+  '/confirm-email': typeof ConfirmEmailRoute;
+  '/privacy-policy': typeof PrivacyPolicyRoute;
+  '/reset-password': typeof ResetPasswordRoute;
+  '/signin': typeof SigninRoute;
+  '/signup': typeof SignupRoute;
+  '/signup-email': typeof SignupEmailRoute;
+  '/terms-of-service': typeof TermsOfServiceRoute;
+  '/update-password': typeof UpdatePasswordRoute;
+  '/$': typeof LayoutSplatRoute;
+  '/product-designer': typeof LayoutProductDesignerRoute;
+  '/api/billing-checkout': typeof ApiBillingCheckoutRoute;
+  '/api/billing-portal': typeof ApiBillingPortalRoute;
+  '/api/billing-products': typeof ApiBillingProductsRoute;
+  '/api/billing-status': typeof ApiBillingStatusRoute;
+  '/api/creative-chat': typeof ApiCreativeChatRoute;
+  '/api/delete-user': typeof ApiDeleteUserRoute;
+  '/api/fal-webhook': typeof ApiFalWebhookRoute;
+  '/api/mesh': typeof ApiMeshRoute;
+  '/api/parametric-chat': typeof ApiParametricChatRoute;
+  '/api/product-design-plan': typeof ApiProductDesignPlanRoute;
+  '/api/prompt-generator': typeof ApiPromptGeneratorRoute;
+  '/api/title-generator': typeof ApiTitleGeneratorRoute;
+  '/history': typeof LayoutAuthHistoryRoute;
+  '/settings': typeof LayoutAuthSettingsRoute;
+  '/subscription': typeof LayoutAuthSubscriptionRoute;
+  '/share/$id': typeof LayoutShareIdRoute;
+  '/api/jackson-pollock/$': typeof ApiJacksonPollockSplatRoute;
+  '/editor/$id': typeof LayoutAuthEditorIdRoute;
 }
 export interface FileRoutesByTo {
-  '/confirm-email': typeof ConfirmEmailRoute
-  '/privacy-policy': typeof PrivacyPolicyRoute
-  '/reset-password': typeof ResetPasswordRoute
-  '/signin': typeof SigninRoute
-  '/signup': typeof SignupRoute
-  '/signup-email': typeof SignupEmailRoute
-  '/terms-of-service': typeof TermsOfServiceRoute
-  '/update-password': typeof UpdatePasswordRoute
-  '/$': typeof LayoutSplatRoute
-  '/': typeof LayoutIndexRoute
-  '/api/billing-checkout': typeof ApiBillingCheckoutRoute
-  '/api/billing-portal': typeof ApiBillingPortalRoute
-  '/api/billing-products': typeof ApiBillingProductsRoute
-  '/api/billing-status': typeof ApiBillingStatusRoute
-  '/api/creative-chat': typeof ApiCreativeChatRoute
-  '/api/delete-user': typeof ApiDeleteUserRoute
-  '/api/fal-webhook': typeof ApiFalWebhookRoute
-  '/api/mesh': typeof ApiMeshRoute
-  '/api/parametric-chat': typeof ApiParametricChatRoute
-  '/api/prompt-generator': typeof ApiPromptGeneratorRoute
-  '/api/title-generator': typeof ApiTitleGeneratorRoute
-  '/history': typeof LayoutAuthHistoryRoute
-  '/settings': typeof LayoutAuthSettingsRoute
-  '/subscription': typeof LayoutAuthSubscriptionRoute
-  '/share/$id': typeof LayoutShareIdRoute
-  '/api/jackson-pollock/$': typeof ApiJacksonPollockSplatRoute
-  '/editor/$id': typeof LayoutAuthEditorIdRoute
+  '/confirm-email': typeof ConfirmEmailRoute;
+  '/privacy-policy': typeof PrivacyPolicyRoute;
+  '/reset-password': typeof ResetPasswordRoute;
+  '/signin': typeof SigninRoute;
+  '/signup': typeof SignupRoute;
+  '/signup-email': typeof SignupEmailRoute;
+  '/terms-of-service': typeof TermsOfServiceRoute;
+  '/update-password': typeof UpdatePasswordRoute;
+  '/$': typeof LayoutSplatRoute;
+  '/': typeof LayoutIndexRoute;
+  '/product-designer': typeof LayoutProductDesignerRoute;
+  '/api/billing-checkout': typeof ApiBillingCheckoutRoute;
+  '/api/billing-portal': typeof ApiBillingPortalRoute;
+  '/api/billing-products': typeof ApiBillingProductsRoute;
+  '/api/billing-status': typeof ApiBillingStatusRoute;
+  '/api/creative-chat': typeof ApiCreativeChatRoute;
+  '/api/delete-user': typeof ApiDeleteUserRoute;
+  '/api/fal-webhook': typeof ApiFalWebhookRoute;
+  '/api/mesh': typeof ApiMeshRoute;
+  '/api/parametric-chat': typeof ApiParametricChatRoute;
+  '/api/product-design-plan': typeof ApiProductDesignPlanRoute;
+  '/api/prompt-generator': typeof ApiPromptGeneratorRoute;
+  '/api/title-generator': typeof ApiTitleGeneratorRoute;
+  '/history': typeof LayoutAuthHistoryRoute;
+  '/settings': typeof LayoutAuthSettingsRoute;
+  '/subscription': typeof LayoutAuthSubscriptionRoute;
+  '/share/$id': typeof LayoutShareIdRoute;
+  '/api/jackson-pollock/$': typeof ApiJacksonPollockSplatRoute;
+  '/editor/$id': typeof LayoutAuthEditorIdRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/_layout': typeof LayoutRouteWithChildren
-  '/confirm-email': typeof ConfirmEmailRoute
-  '/privacy-policy': typeof PrivacyPolicyRoute
-  '/reset-password': typeof ResetPasswordRoute
-  '/signin': typeof SigninRoute
-  '/signup': typeof SignupRoute
-  '/signup-email': typeof SignupEmailRoute
-  '/terms-of-service': typeof TermsOfServiceRoute
-  '/update-password': typeof UpdatePasswordRoute
-  '/_layout/$': typeof LayoutSplatRoute
-  '/_layout/_auth': typeof LayoutAuthRouteWithChildren
-  '/api/billing-checkout': typeof ApiBillingCheckoutRoute
-  '/api/billing-portal': typeof ApiBillingPortalRoute
-  '/api/billing-products': typeof ApiBillingProductsRoute
-  '/api/billing-status': typeof ApiBillingStatusRoute
-  '/api/creative-chat': typeof ApiCreativeChatRoute
-  '/api/delete-user': typeof ApiDeleteUserRoute
-  '/api/fal-webhook': typeof ApiFalWebhookRoute
-  '/api/mesh': typeof ApiMeshRoute
-  '/api/parametric-chat': typeof ApiParametricChatRoute
-  '/api/prompt-generator': typeof ApiPromptGeneratorRoute
-  '/api/title-generator': typeof ApiTitleGeneratorRoute
-  '/_layout/': typeof LayoutIndexRoute
-  '/_layout/_auth/history': typeof LayoutAuthHistoryRoute
-  '/_layout/_auth/settings': typeof LayoutAuthSettingsRoute
-  '/_layout/_auth/subscription': typeof LayoutAuthSubscriptionRoute
-  '/_layout/share/$id': typeof LayoutShareIdRoute
-  '/api/jackson-pollock/$': typeof ApiJacksonPollockSplatRoute
-  '/_layout/_auth/editor/$id': typeof LayoutAuthEditorIdRoute
+  __root__: typeof rootRouteImport;
+  '/_layout': typeof LayoutRouteWithChildren;
+  '/confirm-email': typeof ConfirmEmailRoute;
+  '/privacy-policy': typeof PrivacyPolicyRoute;
+  '/reset-password': typeof ResetPasswordRoute;
+  '/signin': typeof SigninRoute;
+  '/signup': typeof SignupRoute;
+  '/signup-email': typeof SignupEmailRoute;
+  '/terms-of-service': typeof TermsOfServiceRoute;
+  '/update-password': typeof UpdatePasswordRoute;
+  '/_layout/$': typeof LayoutSplatRoute;
+  '/_layout/_auth': typeof LayoutAuthRouteWithChildren;
+  '/_layout/product-designer': typeof LayoutProductDesignerRoute;
+  '/api/billing-checkout': typeof ApiBillingCheckoutRoute;
+  '/api/billing-portal': typeof ApiBillingPortalRoute;
+  '/api/billing-products': typeof ApiBillingProductsRoute;
+  '/api/billing-status': typeof ApiBillingStatusRoute;
+  '/api/creative-chat': typeof ApiCreativeChatRoute;
+  '/api/delete-user': typeof ApiDeleteUserRoute;
+  '/api/fal-webhook': typeof ApiFalWebhookRoute;
+  '/api/mesh': typeof ApiMeshRoute;
+  '/api/parametric-chat': typeof ApiParametricChatRoute;
+  '/api/product-design-plan': typeof ApiProductDesignPlanRoute;
+  '/api/prompt-generator': typeof ApiPromptGeneratorRoute;
+  '/api/title-generator': typeof ApiTitleGeneratorRoute;
+  '/_layout/': typeof LayoutIndexRoute;
+  '/_layout/_auth/history': typeof LayoutAuthHistoryRoute;
+  '/_layout/_auth/settings': typeof LayoutAuthSettingsRoute;
+  '/_layout/_auth/subscription': typeof LayoutAuthSubscriptionRoute;
+  '/_layout/share/$id': typeof LayoutShareIdRoute;
+  '/api/jackson-pollock/$': typeof ApiJacksonPollockSplatRoute;
+  '/_layout/_auth/editor/$id': typeof LayoutAuthEditorIdRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
+  fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
     | '/'
     | '/confirm-email'
@@ -286,6 +304,7 @@ export interface FileRouteTypes {
     | '/terms-of-service'
     | '/update-password'
     | '/$'
+    | '/product-designer'
     | '/api/billing-checkout'
     | '/api/billing-portal'
     | '/api/billing-products'
@@ -295,6 +314,7 @@ export interface FileRouteTypes {
     | '/api/fal-webhook'
     | '/api/mesh'
     | '/api/parametric-chat'
+    | '/api/product-design-plan'
     | '/api/prompt-generator'
     | '/api/title-generator'
     | '/history'
@@ -302,8 +322,8 @@ export interface FileRouteTypes {
     | '/subscription'
     | '/share/$id'
     | '/api/jackson-pollock/$'
-    | '/editor/$id'
-  fileRoutesByTo: FileRoutesByTo
+    | '/editor/$id';
+  fileRoutesByTo: FileRoutesByTo;
   to:
     | '/confirm-email'
     | '/privacy-policy'
@@ -315,6 +335,7 @@ export interface FileRouteTypes {
     | '/update-password'
     | '/$'
     | '/'
+    | '/product-designer'
     | '/api/billing-checkout'
     | '/api/billing-portal'
     | '/api/billing-products'
@@ -324,6 +345,7 @@ export interface FileRouteTypes {
     | '/api/fal-webhook'
     | '/api/mesh'
     | '/api/parametric-chat'
+    | '/api/product-design-plan'
     | '/api/prompt-generator'
     | '/api/title-generator'
     | '/history'
@@ -331,7 +353,7 @@ export interface FileRouteTypes {
     | '/subscription'
     | '/share/$id'
     | '/api/jackson-pollock/$'
-    | '/editor/$id'
+    | '/editor/$id';
   id:
     | '__root__'
     | '/_layout'
@@ -345,6 +367,7 @@ export interface FileRouteTypes {
     | '/update-password'
     | '/_layout/$'
     | '/_layout/_auth'
+    | '/_layout/product-designer'
     | '/api/billing-checkout'
     | '/api/billing-portal'
     | '/api/billing-products'
@@ -354,6 +377,7 @@ export interface FileRouteTypes {
     | '/api/fal-webhook'
     | '/api/mesh'
     | '/api/parametric-chat'
+    | '/api/product-design-plan'
     | '/api/prompt-generator'
     | '/api/title-generator'
     | '/_layout/'
@@ -362,246 +386,261 @@ export interface FileRouteTypes {
     | '/_layout/_auth/subscription'
     | '/_layout/share/$id'
     | '/api/jackson-pollock/$'
-    | '/_layout/_auth/editor/$id'
-  fileRoutesById: FileRoutesById
+    | '/_layout/_auth/editor/$id';
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  LayoutRoute: typeof LayoutRouteWithChildren
-  ConfirmEmailRoute: typeof ConfirmEmailRoute
-  PrivacyPolicyRoute: typeof PrivacyPolicyRoute
-  ResetPasswordRoute: typeof ResetPasswordRoute
-  SigninRoute: typeof SigninRoute
-  SignupRoute: typeof SignupRoute
-  SignupEmailRoute: typeof SignupEmailRoute
-  TermsOfServiceRoute: typeof TermsOfServiceRoute
-  UpdatePasswordRoute: typeof UpdatePasswordRoute
-  ApiBillingCheckoutRoute: typeof ApiBillingCheckoutRoute
-  ApiBillingPortalRoute: typeof ApiBillingPortalRoute
-  ApiBillingProductsRoute: typeof ApiBillingProductsRoute
-  ApiBillingStatusRoute: typeof ApiBillingStatusRoute
-  ApiCreativeChatRoute: typeof ApiCreativeChatRoute
-  ApiDeleteUserRoute: typeof ApiDeleteUserRoute
-  ApiFalWebhookRoute: typeof ApiFalWebhookRoute
-  ApiMeshRoute: typeof ApiMeshRoute
-  ApiParametricChatRoute: typeof ApiParametricChatRoute
-  ApiPromptGeneratorRoute: typeof ApiPromptGeneratorRoute
-  ApiTitleGeneratorRoute: typeof ApiTitleGeneratorRoute
-  ApiJacksonPollockSplatRoute: typeof ApiJacksonPollockSplatRoute
+  LayoutRoute: typeof LayoutRouteWithChildren;
+  ConfirmEmailRoute: typeof ConfirmEmailRoute;
+  PrivacyPolicyRoute: typeof PrivacyPolicyRoute;
+  ResetPasswordRoute: typeof ResetPasswordRoute;
+  SigninRoute: typeof SigninRoute;
+  SignupRoute: typeof SignupRoute;
+  SignupEmailRoute: typeof SignupEmailRoute;
+  TermsOfServiceRoute: typeof TermsOfServiceRoute;
+  UpdatePasswordRoute: typeof UpdatePasswordRoute;
+  ApiBillingCheckoutRoute: typeof ApiBillingCheckoutRoute;
+  ApiBillingPortalRoute: typeof ApiBillingPortalRoute;
+  ApiBillingProductsRoute: typeof ApiBillingProductsRoute;
+  ApiBillingStatusRoute: typeof ApiBillingStatusRoute;
+  ApiCreativeChatRoute: typeof ApiCreativeChatRoute;
+  ApiDeleteUserRoute: typeof ApiDeleteUserRoute;
+  ApiFalWebhookRoute: typeof ApiFalWebhookRoute;
+  ApiMeshRoute: typeof ApiMeshRoute;
+  ApiParametricChatRoute: typeof ApiParametricChatRoute;
+  ApiProductDesignPlanRoute: typeof ApiProductDesignPlanRoute;
+  ApiPromptGeneratorRoute: typeof ApiPromptGeneratorRoute;
+  ApiTitleGeneratorRoute: typeof ApiTitleGeneratorRoute;
+  ApiJacksonPollockSplatRoute: typeof ApiJacksonPollockSplatRoute;
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/update-password': {
-      id: '/update-password'
-      path: '/update-password'
-      fullPath: '/update-password'
-      preLoaderRoute: typeof UpdatePasswordRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/update-password';
+      path: '/update-password';
+      fullPath: '/update-password';
+      preLoaderRoute: typeof UpdatePasswordRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/terms-of-service': {
-      id: '/terms-of-service'
-      path: '/terms-of-service'
-      fullPath: '/terms-of-service'
-      preLoaderRoute: typeof TermsOfServiceRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/terms-of-service';
+      path: '/terms-of-service';
+      fullPath: '/terms-of-service';
+      preLoaderRoute: typeof TermsOfServiceRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/signup-email': {
-      id: '/signup-email'
-      path: '/signup-email'
-      fullPath: '/signup-email'
-      preLoaderRoute: typeof SignupEmailRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/signup-email';
+      path: '/signup-email';
+      fullPath: '/signup-email';
+      preLoaderRoute: typeof SignupEmailRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/signup': {
-      id: '/signup'
-      path: '/signup'
-      fullPath: '/signup'
-      preLoaderRoute: typeof SignupRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/signup';
+      path: '/signup';
+      fullPath: '/signup';
+      preLoaderRoute: typeof SignupRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/signin': {
-      id: '/signin'
-      path: '/signin'
-      fullPath: '/signin'
-      preLoaderRoute: typeof SigninRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/signin';
+      path: '/signin';
+      fullPath: '/signin';
+      preLoaderRoute: typeof SigninRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/reset-password': {
-      id: '/reset-password'
-      path: '/reset-password'
-      fullPath: '/reset-password'
-      preLoaderRoute: typeof ResetPasswordRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/reset-password';
+      path: '/reset-password';
+      fullPath: '/reset-password';
+      preLoaderRoute: typeof ResetPasswordRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/privacy-policy': {
-      id: '/privacy-policy'
-      path: '/privacy-policy'
-      fullPath: '/privacy-policy'
-      preLoaderRoute: typeof PrivacyPolicyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/privacy-policy';
+      path: '/privacy-policy';
+      fullPath: '/privacy-policy';
+      preLoaderRoute: typeof PrivacyPolicyRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/confirm-email': {
-      id: '/confirm-email'
-      path: '/confirm-email'
-      fullPath: '/confirm-email'
-      preLoaderRoute: typeof ConfirmEmailRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/confirm-email';
+      path: '/confirm-email';
+      fullPath: '/confirm-email';
+      preLoaderRoute: typeof ConfirmEmailRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/_layout': {
-      id: '/_layout'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof LayoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/_layout';
+      path: '';
+      fullPath: '/';
+      preLoaderRoute: typeof LayoutRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/_layout/': {
-      id: '/_layout/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof LayoutIndexRouteImport
-      parentRoute: typeof LayoutRoute
-    }
+      id: '/_layout/';
+      path: '/';
+      fullPath: '/';
+      preLoaderRoute: typeof LayoutIndexRouteImport;
+      parentRoute: typeof LayoutRoute;
+    };
     '/api/title-generator': {
-      id: '/api/title-generator'
-      path: '/api/title-generator'
-      fullPath: '/api/title-generator'
-      preLoaderRoute: typeof ApiTitleGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/title-generator';
+      path: '/api/title-generator';
+      fullPath: '/api/title-generator';
+      preLoaderRoute: typeof ApiTitleGeneratorRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/prompt-generator': {
-      id: '/api/prompt-generator'
-      path: '/api/prompt-generator'
-      fullPath: '/api/prompt-generator'
-      preLoaderRoute: typeof ApiPromptGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/prompt-generator';
+      path: '/api/prompt-generator';
+      fullPath: '/api/prompt-generator';
+      preLoaderRoute: typeof ApiPromptGeneratorRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    '/api/product-design-plan': {
+      id: '/api/product-design-plan';
+      path: '/api/product-design-plan';
+      fullPath: '/api/product-design-plan';
+      preLoaderRoute: typeof ApiProductDesignPlanRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/parametric-chat': {
-      id: '/api/parametric-chat'
-      path: '/api/parametric-chat'
-      fullPath: '/api/parametric-chat'
-      preLoaderRoute: typeof ApiParametricChatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/parametric-chat';
+      path: '/api/parametric-chat';
+      fullPath: '/api/parametric-chat';
+      preLoaderRoute: typeof ApiParametricChatRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/mesh': {
-      id: '/api/mesh'
-      path: '/api/mesh'
-      fullPath: '/api/mesh'
-      preLoaderRoute: typeof ApiMeshRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/mesh';
+      path: '/api/mesh';
+      fullPath: '/api/mesh';
+      preLoaderRoute: typeof ApiMeshRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/fal-webhook': {
-      id: '/api/fal-webhook'
-      path: '/api/fal-webhook'
-      fullPath: '/api/fal-webhook'
-      preLoaderRoute: typeof ApiFalWebhookRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/fal-webhook';
+      path: '/api/fal-webhook';
+      fullPath: '/api/fal-webhook';
+      preLoaderRoute: typeof ApiFalWebhookRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/delete-user': {
-      id: '/api/delete-user'
-      path: '/api/delete-user'
-      fullPath: '/api/delete-user'
-      preLoaderRoute: typeof ApiDeleteUserRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/delete-user';
+      path: '/api/delete-user';
+      fullPath: '/api/delete-user';
+      preLoaderRoute: typeof ApiDeleteUserRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/creative-chat': {
-      id: '/api/creative-chat'
-      path: '/api/creative-chat'
-      fullPath: '/api/creative-chat'
-      preLoaderRoute: typeof ApiCreativeChatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/creative-chat';
+      path: '/api/creative-chat';
+      fullPath: '/api/creative-chat';
+      preLoaderRoute: typeof ApiCreativeChatRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/billing-status': {
-      id: '/api/billing-status'
-      path: '/api/billing-status'
-      fullPath: '/api/billing-status'
-      preLoaderRoute: typeof ApiBillingStatusRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/billing-status';
+      path: '/api/billing-status';
+      fullPath: '/api/billing-status';
+      preLoaderRoute: typeof ApiBillingStatusRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/billing-products': {
-      id: '/api/billing-products'
-      path: '/api/billing-products'
-      fullPath: '/api/billing-products'
-      preLoaderRoute: typeof ApiBillingProductsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/billing-products';
+      path: '/api/billing-products';
+      fullPath: '/api/billing-products';
+      preLoaderRoute: typeof ApiBillingProductsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/billing-portal': {
-      id: '/api/billing-portal'
-      path: '/api/billing-portal'
-      fullPath: '/api/billing-portal'
-      preLoaderRoute: typeof ApiBillingPortalRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/billing-portal';
+      path: '/api/billing-portal';
+      fullPath: '/api/billing-portal';
+      preLoaderRoute: typeof ApiBillingPortalRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/billing-checkout': {
-      id: '/api/billing-checkout'
-      path: '/api/billing-checkout'
-      fullPath: '/api/billing-checkout'
-      preLoaderRoute: typeof ApiBillingCheckoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/billing-checkout';
+      path: '/api/billing-checkout';
+      fullPath: '/api/billing-checkout';
+      preLoaderRoute: typeof ApiBillingCheckoutRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    '/_layout/product-designer': {
+      id: '/_layout/product-designer';
+      path: '/product-designer';
+      fullPath: '/product-designer';
+      preLoaderRoute: typeof LayoutProductDesignerRouteImport;
+      parentRoute: typeof LayoutRoute;
+    };
     '/_layout/_auth': {
-      id: '/_layout/_auth'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof LayoutAuthRouteImport
-      parentRoute: typeof LayoutRoute
-    }
+      id: '/_layout/_auth';
+      path: '';
+      fullPath: '/';
+      preLoaderRoute: typeof LayoutAuthRouteImport;
+      parentRoute: typeof LayoutRoute;
+    };
     '/_layout/$': {
-      id: '/_layout/$'
-      path: '/$'
-      fullPath: '/$'
-      preLoaderRoute: typeof LayoutSplatRouteImport
-      parentRoute: typeof LayoutRoute
-    }
+      id: '/_layout/$';
+      path: '/$';
+      fullPath: '/$';
+      preLoaderRoute: typeof LayoutSplatRouteImport;
+      parentRoute: typeof LayoutRoute;
+    };
     '/api/jackson-pollock/$': {
-      id: '/api/jackson-pollock/$'
-      path: '/api/jackson-pollock/$'
-      fullPath: '/api/jackson-pollock/$'
-      preLoaderRoute: typeof ApiJacksonPollockSplatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/jackson-pollock/$';
+      path: '/api/jackson-pollock/$';
+      fullPath: '/api/jackson-pollock/$';
+      preLoaderRoute: typeof ApiJacksonPollockSplatRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/_layout/share/$id': {
-      id: '/_layout/share/$id'
-      path: '/share/$id'
-      fullPath: '/share/$id'
-      preLoaderRoute: typeof LayoutShareIdRouteImport
-      parentRoute: typeof LayoutRoute
-    }
+      id: '/_layout/share/$id';
+      path: '/share/$id';
+      fullPath: '/share/$id';
+      preLoaderRoute: typeof LayoutShareIdRouteImport;
+      parentRoute: typeof LayoutRoute;
+    };
     '/_layout/_auth/subscription': {
-      id: '/_layout/_auth/subscription'
-      path: '/subscription'
-      fullPath: '/subscription'
-      preLoaderRoute: typeof LayoutAuthSubscriptionRouteImport
-      parentRoute: typeof LayoutAuthRoute
-    }
+      id: '/_layout/_auth/subscription';
+      path: '/subscription';
+      fullPath: '/subscription';
+      preLoaderRoute: typeof LayoutAuthSubscriptionRouteImport;
+      parentRoute: typeof LayoutAuthRoute;
+    };
     '/_layout/_auth/settings': {
-      id: '/_layout/_auth/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof LayoutAuthSettingsRouteImport
-      parentRoute: typeof LayoutAuthRoute
-    }
+      id: '/_layout/_auth/settings';
+      path: '/settings';
+      fullPath: '/settings';
+      preLoaderRoute: typeof LayoutAuthSettingsRouteImport;
+      parentRoute: typeof LayoutAuthRoute;
+    };
     '/_layout/_auth/history': {
-      id: '/_layout/_auth/history'
-      path: '/history'
-      fullPath: '/history'
-      preLoaderRoute: typeof LayoutAuthHistoryRouteImport
-      parentRoute: typeof LayoutAuthRoute
-    }
+      id: '/_layout/_auth/history';
+      path: '/history';
+      fullPath: '/history';
+      preLoaderRoute: typeof LayoutAuthHistoryRouteImport;
+      parentRoute: typeof LayoutAuthRoute;
+    };
     '/_layout/_auth/editor/$id': {
-      id: '/_layout/_auth/editor/$id'
-      path: '/editor/$id'
-      fullPath: '/editor/$id'
-      preLoaderRoute: typeof LayoutAuthEditorIdRouteImport
-      parentRoute: typeof LayoutAuthRoute
-    }
+      id: '/_layout/_auth/editor/$id';
+      path: '/editor/$id';
+      fullPath: '/editor/$id';
+      preLoaderRoute: typeof LayoutAuthEditorIdRouteImport;
+      parentRoute: typeof LayoutAuthRoute;
+    };
   }
 }
 
 interface LayoutAuthRouteChildren {
-  LayoutAuthHistoryRoute: typeof LayoutAuthHistoryRoute
-  LayoutAuthSettingsRoute: typeof LayoutAuthSettingsRoute
-  LayoutAuthSubscriptionRoute: typeof LayoutAuthSubscriptionRoute
-  LayoutAuthEditorIdRoute: typeof LayoutAuthEditorIdRoute
+  LayoutAuthHistoryRoute: typeof LayoutAuthHistoryRoute;
+  LayoutAuthSettingsRoute: typeof LayoutAuthSettingsRoute;
+  LayoutAuthSubscriptionRoute: typeof LayoutAuthSubscriptionRoute;
+  LayoutAuthEditorIdRoute: typeof LayoutAuthEditorIdRoute;
 }
 
 const LayoutAuthRouteChildren: LayoutAuthRouteChildren = {
@@ -609,28 +648,30 @@ const LayoutAuthRouteChildren: LayoutAuthRouteChildren = {
   LayoutAuthSettingsRoute: LayoutAuthSettingsRoute,
   LayoutAuthSubscriptionRoute: LayoutAuthSubscriptionRoute,
   LayoutAuthEditorIdRoute: LayoutAuthEditorIdRoute,
-}
+};
 
 const LayoutAuthRouteWithChildren = LayoutAuthRoute._addFileChildren(
   LayoutAuthRouteChildren,
-)
+);
 
 interface LayoutRouteChildren {
-  LayoutSplatRoute: typeof LayoutSplatRoute
-  LayoutAuthRoute: typeof LayoutAuthRouteWithChildren
-  LayoutIndexRoute: typeof LayoutIndexRoute
-  LayoutShareIdRoute: typeof LayoutShareIdRoute
+  LayoutSplatRoute: typeof LayoutSplatRoute;
+  LayoutAuthRoute: typeof LayoutAuthRouteWithChildren;
+  LayoutProductDesignerRoute: typeof LayoutProductDesignerRoute;
+  LayoutIndexRoute: typeof LayoutIndexRoute;
+  LayoutShareIdRoute: typeof LayoutShareIdRoute;
 }
 
 const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutSplatRoute: LayoutSplatRoute,
   LayoutAuthRoute: LayoutAuthRouteWithChildren,
+  LayoutProductDesignerRoute: LayoutProductDesignerRoute,
   LayoutIndexRoute: LayoutIndexRoute,
   LayoutShareIdRoute: LayoutShareIdRoute,
-}
+};
 
 const LayoutRouteWithChildren =
-  LayoutRoute._addFileChildren(LayoutRouteChildren)
+  LayoutRoute._addFileChildren(LayoutRouteChildren);
 
 const rootRouteChildren: RootRouteChildren = {
   LayoutRoute: LayoutRouteWithChildren,
@@ -651,19 +692,20 @@ const rootRouteChildren: RootRouteChildren = {
   ApiFalWebhookRoute: ApiFalWebhookRoute,
   ApiMeshRoute: ApiMeshRoute,
   ApiParametricChatRoute: ApiParametricChatRoute,
+  ApiProductDesignPlanRoute: ApiProductDesignPlanRoute,
   ApiPromptGeneratorRoute: ApiPromptGeneratorRoute,
   ApiTitleGeneratorRoute: ApiTitleGeneratorRoute,
   ApiJacksonPollockSplatRoute: ApiJacksonPollockSplatRoute,
-}
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();
 
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
+import type { getRouter } from './router.tsx';
+import type { createStart } from '@tanstack/react-start';
 declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
+    ssr: true;
+    router: Awaited<ReturnType<typeof getRouter>>;
   }
 }

--- a/src/routes/_layout/product-designer.tsx
+++ b/src/routes/_layout/product-designer.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import ProductDesignerView from '@/views/ProductDesignerView';
+
+export const Route = createFileRoute('/_layout/product-designer')({
+  component: ProductDesignerView,
+});

--- a/src/routes/api/product-design-plan.ts
+++ b/src/routes/api/product-design-plan.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { handleProductDesignPlanRequest } from '@/server/productDesignPlan';
+
+export const Route = createFileRoute('/api/product-design-plan')({
+  server: {
+    handlers: {
+      GET: ({ request }) => handleProductDesignPlanRequest(request),
+      POST: ({ request }) => handleProductDesignPlanRequest(request),
+      OPTIONS: ({ request }) => handleProductDesignPlanRequest(request),
+    },
+  },
+});

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -2,6 +2,7 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { chatTools, type AppUIMessage, type AppTools } from '@shared/chatAi';
+import { PRODUCT_DESIGNER_PROMPT_EXTENSION } from '@shared/cadamProductDesigner';
 import { getParametricText } from '@shared/parametricParts';
 import type { Conversation, Message, MeshFileType, Model } from '@shared/types';
 import {
@@ -709,7 +710,7 @@ function chatModel(conversation: ConversationAccess, model: Model) {
 function systemPrompt(conversation: ConversationAccess) {
   return conversation.type === 'creative'
     ? CREATIVE_AGENT_PROMPT
-    : PARAMETRIC_AGENT_PROMPT;
+    : `${PARAMETRIC_AGENT_PROMPT}\n\n${PRODUCT_DESIGNER_PROMPT_EXTENSION}`;
 }
 
 export async function handleAiChatRequest(req: Request) {

--- a/src/server/productDesignPlan.ts
+++ b/src/server/productDesignPlan.ts
@@ -1,0 +1,48 @@
+import {
+  buildCandidateGenerationPrompt,
+  extractProductBrief,
+  proposeDesignCandidates,
+  rankDesignCandidates,
+  summarizeZooWorkflowTrace,
+  vertexGeminiReadiness,
+} from '@shared/cadamProductDesigner';
+import { isRecord, json, methodNotAllowed, preflight } from './api';
+
+export async function handleProductDesignPlanRequest(req: Request) {
+  if (req.method === 'OPTIONS') return preflight();
+  if (req.method !== 'POST') return methodNotAllowed();
+
+  const body = await req.json().catch(() => null);
+  if (!isRecord(body) || typeof body.prompt !== 'string') {
+    return json({ error: 'prompt is required' }, 400);
+  }
+
+  const originalPrompt = body.prompt;
+  const brief = extractProductBrief(originalPrompt);
+  const candidates = rankDesignCandidates(
+    proposeDesignCandidates(brief),
+    brief,
+  );
+  const generationPrompts = Object.fromEntries(
+    candidates.map((candidate) => [
+      candidate.id,
+      buildCandidateGenerationPrompt({
+        originalPrompt,
+        brief,
+        candidate,
+      }),
+    ]),
+  );
+  const traceSummary =
+    typeof body.traceMarkdown === 'string'
+      ? summarizeZooWorkflowTrace(body.traceMarkdown)
+      : undefined;
+
+  return json({
+    brief,
+    candidates,
+    generationPrompts,
+    traceSummary,
+    gemini: vertexGeminiReadiness(),
+  });
+}

--- a/src/views/ProductDesignerView.tsx
+++ b/src/views/ProductDesignerView.tsx
@@ -1,0 +1,537 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from '@tanstack/react-router';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithToolCalls,
+} from 'ai';
+import * as Sentry from '@sentry/react';
+import { ArrowLeft, Clipboard, Loader2, Play, Sparkles } from 'lucide-react';
+import type {
+  DesignCandidate,
+  ProductDesignPlan,
+} from '@shared/cadamProductDesigner';
+import { buildCandidateGenerationPrompt } from '@shared/cadamProductDesigner';
+import type { AppUIMessage } from '@shared/chatAi';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { useAuth } from '@/contexts/AuthContext';
+import { ensureInputRecords } from '@/lib/aiMessages';
+import { supabase } from '@/lib/supabase';
+import { apiJson, apiUrl } from '@/services/api';
+import { persistUserMessage } from '@/services/messageService';
+import { createAndCacheAiChat } from '@/hooks/useCachedAiChat';
+import { useToast } from '@/hooks/use-toast';
+
+const EXAMPLE_PROMPTS = [
+  'Soporte de pared FDM para una herramienta de 1.2 kg, tornillos M4, costillas visibles mínimas y tolerancias editables.',
+  'Caja electrónica para ESP32 con tapa snap-fit, ventilación, bosses para tornillos y puerto USB accesible.',
+  'Jig de perforación parametrico con guía de alineación, bujes metálicos y mordazas impresas reemplazables.',
+];
+
+const PARAMETRIC_MODEL = 'google/gemini-3.1-pro-preview' as const;
+const CADAM_PRODUCT_DESIGNER_BRANCHES = 'cadam.productDesigner.branches.v1';
+
+type ProductDesignPlanResponse = ProductDesignPlan & {
+  generationPrompts?: Record<string, string>;
+};
+
+type SavedBranch = {
+  id: string;
+  createdAt: string;
+  originalPrompt: string;
+  candidate: DesignCandidate;
+  generationPrompt: string;
+};
+
+function compactList(values: string[]) {
+  return values.length > 0 ? values.join(' · ') : '—';
+}
+
+function CandidateCard({
+  candidate,
+  prompt,
+  isStarting,
+  onSelect,
+  onSave,
+  onStart,
+}: {
+  candidate: DesignCandidate;
+  prompt: string;
+  isStarting: boolean;
+  onSelect: (prompt: string) => void;
+  onSave: (candidate: DesignCandidate, prompt: string) => void;
+  onStart: (candidate: DesignCandidate, prompt: string) => void;
+}) {
+  return (
+    <Card className="border-white/10 bg-white/[0.03] text-adam-text-primary">
+      <CardHeader className="space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle className="text-base">{candidate.title}</CardTitle>
+            <CardDescription className="mt-1 text-adam-text-secondary">
+              {candidate.strategy}
+            </CardDescription>
+          </div>
+          <Badge className="bg-adam-blue/20 text-adam-blue">
+            {candidate.score?.overall ?? '—'}/10
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm text-adam-text-secondary">
+        <p>{compactList(candidate.notes)}</p>
+        {candidate.warnings.length > 0 && (
+          <p className="rounded-md border border-yellow-400/20 bg-yellow-400/10 p-2 text-yellow-100">
+            {compactList(candidate.warnings)}
+          </p>
+        )}
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onSelect(prompt)}
+            className="gap-2"
+          >
+            <Clipboard className="h-3.5 w-3.5" />
+            Generate CAD prompt
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onSave(candidate, prompt)}
+            className="gap-2"
+          >
+            Save branch
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => onStart(candidate, prompt)}
+            disabled={isStarting}
+            className="gap-2"
+          >
+            {isStarting ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Play className="h-3.5 w-3.5" />
+            )}
+            Start CAD generation
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function ProductDesignerView() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const [prompt, setPrompt] = useState(EXAMPLE_PROMPTS[0]);
+  const [plan, setPlan] = useState<ProductDesignPlanResponse | null>(null);
+  const [selectedPrompt, setSelectedPrompt] = useState('');
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [savedBranches, setSavedBranches] = useState<SavedBranch[]>([]);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(CADAM_PRODUCT_DESIGNER_BRANCHES);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as SavedBranch[];
+      if (Array.isArray(parsed)) setSavedBranches(parsed.slice(0, 20));
+    } catch {
+      localStorage.removeItem(CADAM_PRODUCT_DESIGNER_BRANCHES);
+    }
+  }, []);
+
+  const candidatePrompts = useMemo(() => {
+    if (!plan) return {};
+    return Object.fromEntries(
+      plan.candidates.map((candidate) => [
+        candidate.id,
+        plan.generationPrompts?.[candidate.id] ??
+          buildCandidateGenerationPrompt({
+            originalPrompt: prompt,
+            brief: plan.brief,
+            candidate,
+          }),
+      ]),
+    );
+  }, [plan, prompt]);
+
+  const { mutate: startCadGeneration, isPending: isStartingCad } = useMutation({
+    mutationFn: async ({
+      candidate,
+      generationPrompt,
+    }: {
+      candidate: DesignCandidate;
+      generationPrompt: string;
+    }) => {
+      if (!user?.id)
+        throw new Error('User must be authenticated to start CAD generation');
+
+      const conversationId = crypto.randomUUID();
+      const parts: AppUIMessage['parts'] = [
+        { type: 'text', text: generationPrompt },
+      ];
+
+      const { data: conversation, error: conversationError } = await supabase
+        .from('conversations')
+        .insert([
+          {
+            id: conversationId,
+            user_id: user.id,
+            title: `Product Designer: ${candidate.title}`,
+            type: 'parametric',
+            settings: {
+              model: PARAMETRIC_MODEL,
+              productDesignerCandidateId: candidate.id,
+              product_designer_candidate_id: candidate.id,
+            },
+          },
+        ])
+        .select()
+        .single();
+
+      if (conversationError) throw conversationError;
+
+      await ensureInputRecords({
+        parts,
+        conversationId: conversation.id,
+        userId: user.id,
+      });
+
+      const userMessageId = await persistUserMessage({
+        conversationId: conversation.id,
+        parts,
+        metadata: {
+          model: PARAMETRIC_MODEL,
+          productDesignerCandidateId: candidate.id,
+          product_designer_candidate_id: candidate.id,
+        },
+        parentMessageId: null,
+      });
+
+      const chat = createAndCacheAiChat({
+        id: conversation.id,
+        generateId: () => crypto.randomUUID(),
+        messages: [],
+        transport: new DefaultChatTransport<AppUIMessage>({
+          api: apiUrl('parametric-chat'),
+          headers: async (): Promise<Record<string, string>> => {
+            const accessToken = (await supabase.auth.getSession()).data.session
+              ?.access_token;
+            const headers: Record<string, string> = {};
+            if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
+            return headers;
+          },
+          prepareSendMessagesRequest: ({ body }) => ({
+            body: {
+              conversationId: conversation.id,
+              model: PARAMETRIC_MODEL,
+              ...(body ?? {}),
+            },
+          }),
+        }),
+        sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+      });
+
+      void chat
+        .sendMessage({
+          id: userMessageId,
+          parts,
+          metadata: {
+            model: PARAMETRIC_MODEL,
+            productDesignerCandidateId: candidate.id,
+            product_designer_candidate_id: candidate.id,
+          },
+        })
+        .catch((error) => {
+          Sentry.captureException(error, {
+            extra: {
+              hook: 'ProductDesignerView initial chat',
+              conversationId: conversation.id,
+              productDesignerCandidateId: candidate.id,
+            },
+          });
+        });
+
+      return { conversationId: conversation.id };
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['conversations'] });
+      navigate({ to: '/editor/$id', params: { id: data.conversationId } });
+    },
+    onError: (err) => {
+      if (!user?.id) {
+        navigate({ to: '/signin' });
+        return;
+      }
+      Sentry.captureException(err);
+      toast({
+        title: 'Could not start CAD generation',
+        description:
+          err instanceof Error
+            ? err.message
+            : 'Unexpected product-designer error',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  function persistSavedBranches(nextBranches: SavedBranch[]) {
+    setSavedBranches(nextBranches);
+    localStorage.setItem(
+      CADAM_PRODUCT_DESIGNER_BRANCHES,
+      JSON.stringify(nextBranches.slice(0, 20)),
+    );
+  }
+
+  function saveBranch(candidate: DesignCandidate, generationPrompt: string) {
+    const nextBranch: SavedBranch = {
+      id: `${candidate.id}-${Date.now()}`,
+      createdAt: new Date().toISOString(),
+      originalPrompt: prompt,
+      candidate,
+      generationPrompt,
+    };
+    persistSavedBranches([nextBranch, ...savedBranches].slice(0, 20));
+    toast({ title: 'Candidate branch saved', description: candidate.title });
+  }
+
+  function restoreSavedBranch(branch: SavedBranch) {
+    setPrompt(branch.originalPrompt);
+    setSelectedPrompt(branch.generationPrompt);
+  }
+
+  function handleStartCadGeneration(
+    candidate: DesignCandidate,
+    generationPrompt: string,
+  ) {
+    if (!user?.id) {
+      navigate({ to: '/signin' });
+      return;
+    }
+    startCadGeneration({ candidate, generationPrompt });
+  }
+
+  async function analyze() {
+    setError('');
+    setIsLoading(true);
+    setSelectedPrompt('');
+    try {
+      const response = (await apiJson('product-design-plan', {
+        method: 'POST',
+        body: JSON.stringify({ prompt }),
+      })) as ProductDesignPlanResponse;
+      setPlan(response);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Could not create product design plan',
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-full bg-adam-bg-secondary-dark px-4 py-8 text-adam-text-primary md:px-8">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <div className="flex items-center justify-between gap-4">
+          <Button
+            asChild
+            variant="ghost"
+            className="gap-2 text-adam-text-secondary"
+          >
+            <Link to="/">
+              <ArrowLeft className="h-4 w-4" />
+              Back to CADAM
+            </Link>
+          </Button>
+          <Badge className="bg-white/10 text-adam-text-secondary">
+            Zoo/KCL visible-trace inspired workflow
+          </Badge>
+        </div>
+
+        <section className="rounded-2xl border border-white/10 bg-white/[0.03] p-6 shadow-xl">
+          <div className="mb-5 max-w-3xl space-y-3">
+            <h1 className="text-3xl font-semibold">CADAM Product Designer</h1>
+            <p className="text-adam-text-secondary">
+              General CADAM planning layer for text-to-CAD products. It extracts
+              a product brief, proposes multiple printable/mechanical
+              strategies, ranks them, and produces an enriched OpenSCAD
+              generation prompt for the selected candidate.
+            </p>
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+            <div className="space-y-4">
+              <Textarea
+                value={prompt}
+                onChange={(event) => setPrompt(event.target.value)}
+                className="min-h-40 border-white/10 bg-black/20 text-adam-text-primary"
+                placeholder="Describe any CAD product: enclosure, jig, bracket, mechanism, fixture, aesthetic shell..."
+              />
+              <div className="flex flex-wrap gap-2">
+                {EXAMPLE_PROMPTS.map((example) => (
+                  <Button
+                    key={example}
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setPrompt(example)}
+                  >
+                    {example.split(' ').slice(0, 4).join(' ')}…
+                  </Button>
+                ))}
+              </div>
+              <Button
+                onClick={analyze}
+                disabled={isLoading || prompt.trim().length === 0}
+                className="gap-2"
+              >
+                {isLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Sparkles className="h-4 w-4" />
+                )}
+                Analyze product brief
+              </Button>
+              {error && (
+                <p className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200">
+                  {error}
+                </p>
+              )}
+            </div>
+
+            <Card className="border-white/10 bg-black/20 text-adam-text-primary">
+              <CardHeader>
+                <CardTitle>Brief extraction</CardTitle>
+                <CardDescription className="text-adam-text-secondary">
+                  Offline heuristics; Gemini/Vertex is optional readiness only.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm text-adam-text-secondary">
+                {plan ? (
+                  <>
+                    <p>
+                      <span className="text-adam-text-primary">Type:</span>{' '}
+                      {plan.brief.objectType}
+                    </p>
+                    <p>
+                      <span className="text-adam-text-primary">
+                        Manufacturing:
+                      </span>{' '}
+                      {plan.brief.manufacturing}
+                    </p>
+                    <p>
+                      <span className="text-adam-text-primary">Assembly:</span>{' '}
+                      {compactList(plan.brief.assemblyRequirements)}
+                    </p>
+                    <p>
+                      <span className="text-adam-text-primary">
+                        Constraints:
+                      </span>{' '}
+                      {compactList(plan.brief.constraints)}
+                    </p>
+                    <p>
+                      <span className="text-adam-text-primary">Unknowns:</span>{' '}
+                      {compactList(plan.brief.unknowns)}
+                    </p>
+                    <p>
+                      <span className="text-adam-text-primary">Gemini:</span>{' '}
+                      {plan.gemini.available
+                        ? 'ready'
+                        : `not configured (${plan.gemini.missing.join(', ')})`}
+                    </p>
+                  </>
+                ) : (
+                  <p>Run an analysis to see the structured brief.</p>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        {plan && (
+          <section className="grid gap-4 lg:grid-cols-2">
+            {plan.candidates.map((candidate) => (
+              <CandidateCard
+                key={candidate.id}
+                candidate={candidate}
+                prompt={candidatePrompts[candidate.id] ?? ''}
+                isStarting={isStartingCad}
+                onSelect={setSelectedPrompt}
+                onSave={saveBranch}
+                onStart={handleStartCadGeneration}
+              />
+            ))}
+          </section>
+        )}
+
+        {savedBranches.length > 0 && (
+          <section className="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
+            <h2 className="mb-3 text-lg font-medium">
+              Saved candidate branches
+            </h2>
+            <div className="grid gap-3 md:grid-cols-2">
+              {savedBranches.map((branch) => (
+                <button
+                  key={branch.id}
+                  type="button"
+                  onClick={() => restoreSavedBranch(branch)}
+                  className="rounded-lg border border-white/10 bg-black/20 p-3 text-left text-sm text-adam-text-secondary transition hover:border-adam-blue/50"
+                >
+                  <span className="block font-medium text-adam-text-primary">
+                    {branch.candidate.title}
+                  </span>
+                  <span className="block">
+                    {new Date(branch.createdAt).toLocaleString()}
+                  </span>
+                  <span className="mt-1 line-clamp-2 block">
+                    {branch.originalPrompt}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {selectedPrompt && (
+          <section className="rounded-2xl border border-adam-blue/30 bg-adam-blue/10 p-5">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <h2 className="text-lg font-medium">
+                Enriched prompt for CAD generation
+              </h2>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() =>
+                    void navigator.clipboard?.writeText(selectedPrompt)
+                  }
+                >
+                  Copy
+                </Button>
+              </div>
+            </div>
+            <pre className="max-h-96 overflow-auto whitespace-pre-wrap rounded-lg bg-black/40 p-4 text-xs text-adam-text-secondary">
+              {selectedPrompt}
+            </pre>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a general CADAM Product Designer core for product brief extraction, candidate generation/ranking, and enriched CAD prompts.
- Adds /cadam/product-designer UI with candidate comparison, local branch persistence, and Start CAD generation into the existing parametric chat flow.
- Adds /cadam/api/product-design-plan endpoint, docs, reusable Hermes skill copy, and offline smoke tests.

## Test Plan
- node --experimental-strip-types scripts/test-cadam-product-designer.mjs
- node --experimental-strip-types scripts/test-cadam-product-designer-v2.mjs
- node --experimental-strip-types scripts/test-cadam-product-designer-v3.mjs
- node --experimental-strip-types scripts/test-cadam-product-designer-v4.mjs
- npm run typecheck
- npm run lint
- npm run build

## Notes
- Gemini/Vertex remains optional/readiness-only.
- No private chain-of-thought is copied; Zoo/KCL influence is limited to visible trace patterns.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces the CADAM Product Designer that turns a user prompt into a brief, proposes and ranks multiple design strategies, and sends an enriched prompt to the parametric chat to start CAD. Adds a new UI at /cadam/product-designer and a POST /api/product-design-plan endpoint.

- **New Features**
  - Core: `shared/cadamProductDesigner.ts` with brief extraction, candidate generation/ranking, prompt builder, and `PRODUCT_DESIGNER_PROMPT_EXTENSION` wired into the parametric agent.
  - UI: /cadam/product-designer for candidate comparison and “Start CAD generation”; save/restore candidate branches via `localStorage`.
  - API: `POST /api/product-design-plan` returns the brief, ranked candidates, and per-candidate generation prompts.
  - Chat plumbing: Adds `productDesignerCandidateId` fields to `AppUIMessage` and conversation settings. Docs and smoke tests included.

- **Migration**
  - To generate from the UI, set at least one provider key in `.env.local` (e.g., `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, or `GOOGLE_API_KEY`). Sign-in is required to start CAD generation.

<sup>Written for commit ab9fe28b46857cb020f8d3b747a55f6d5d92cde9. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/164?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

