### PR TITLE
ui fixes

### DIFF
--- a/shared/suggestions.test.ts
+++ b/shared/suggestions.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  countSuggestionWords,
+  limitSuggestionWords,
+  normalizeConversationSuggestions,
+} from './suggestions.ts';
+
+describe('suggestion word limits', () => {
+  it('counts whitespace-separated words', () => {
+    assert.equal(countSuggestionWords('  add   mounting holes  '), 3);
+    assert.equal(countSuggestionWords(''), 0);
+  });
+
+  it('treats punctuation and hyphenated terms as part of a word', () => {
+    assert.equal(countSuggestionWords('make snap-fit tabs'), 3);
+    assert.equal(countSuggestionWords('add ribs, fillets'), 3);
+  });
+
+  it('limits suggestions to three words', () => {
+    assert.equal(
+      limitSuggestionWords('make the brackets thicker'),
+      'make the brackets',
+    );
+  });
+
+  it('keeps valid suggestions before truncating fallback suggestions', () => {
+    assert.deepEqual(
+      normalizeConversationSuggestions([
+        'make the brackets much thicker',
+        'add fillets',
+        '  add screw holes  ',
+        'increase wall thickness',
+      ]),
+      ['add fillets', 'add screw holes', 'increase wall thickness'],
+    );
+  });
+
+  it('truncates invalid suggestions only when needed to fill three slots', () => {
+    assert.deepEqual(
+      normalizeConversationSuggestions([
+        'add chamfers',
+        'make the handle much larger',
+        'add four mounting holes',
+      ]),
+      ['add chamfers', 'make the handle', 'add four mounting'],
+    );
+  });
+});

--- a/shared/suggestions.test.ts
+++ b/shared/suggestions.test.ts
@@ -36,6 +36,18 @@ describe('suggestion word limits', () => {
     );
   });
 
+  it('deduplicates accepted suggestions before filling slots', () => {
+    assert.deepEqual(
+      normalizeConversationSuggestions([
+        'add fillets',
+        'add fillets',
+        'add screw holes',
+        'increase wall thickness',
+      ]),
+      ['add fillets', 'add screw holes', 'increase wall thickness'],
+    );
+  });
+
   it('truncates invalid suggestions only when needed to fill three slots', () => {
     assert.deepEqual(
       normalizeConversationSuggestions([

--- a/shared/suggestions.ts
+++ b/shared/suggestions.ts
@@ -22,8 +22,13 @@ export function normalizeConversationSuggestions(
     .map((suggestion) => suggestion.trim())
     .filter(Boolean);
 
-  const accepted = trimmedSuggestions.filter(
-    (suggestion) => countSuggestionWords(suggestion) <= MAX_SUGGESTION_WORDS,
+  const accepted = Array.from(
+    new Set(
+      trimmedSuggestions.filter(
+        (suggestion) =>
+          countSuggestionWords(suggestion) <= MAX_SUGGESTION_WORDS,
+      ),
+    ),
   );
 
   if (accepted.length >= maxSuggestions) {

--- a/shared/suggestions.ts
+++ b/shared/suggestions.ts
@@ -1,0 +1,46 @@
+const MAX_SUGGESTION_WORDS = 3;
+const MAX_SUGGESTIONS = 3;
+
+export function countSuggestionWords(suggestion: string): number {
+  const trimmed = suggestion.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+export function limitSuggestionWords(
+  suggestion: string,
+  maxWords = MAX_SUGGESTION_WORDS,
+): string {
+  return suggestion.trim().split(/\s+/).slice(0, maxWords).join(' ');
+}
+
+export function normalizeConversationSuggestions(
+  suggestions: string[],
+  maxSuggestions = MAX_SUGGESTIONS,
+): string[] {
+  const trimmedSuggestions = suggestions
+    .map((suggestion) => suggestion.trim())
+    .filter(Boolean);
+
+  const accepted = trimmedSuggestions.filter(
+    (suggestion) => countSuggestionWords(suggestion) <= MAX_SUGGESTION_WORDS,
+  );
+
+  if (accepted.length >= maxSuggestions) {
+    return accepted.slice(0, maxSuggestions);
+  }
+
+  const seen = new Set(accepted);
+  const fallback = trimmedSuggestions
+    .filter(
+      (suggestion) => countSuggestionWords(suggestion) > MAX_SUGGESTION_WORDS,
+    )
+    .map((suggestion) => limitSuggestionWords(suggestion))
+    .filter((suggestion) => {
+      if (!suggestion || seen.has(suggestion)) return false;
+      seen.add(suggestion);
+      return true;
+    });
+
+  return [...accepted, ...fallback].slice(0, maxSuggestions);
+}

--- a/src/components/ai-elements/reasoning.tsx
+++ b/src/components/ai-elements/reasoning.tsx
@@ -152,6 +152,7 @@ export type ReasoningTriggerProps = ComponentProps<
   typeof CollapsibleTrigger
 > & {
   getThinkingMessage?: (isStreaming: boolean, duration?: number) => ReactNode;
+  showIcon?: boolean;
 };
 
 const defaultGetThinkingMessage = (isStreaming: boolean, duration?: number) => {
@@ -169,6 +170,7 @@ export const ReasoningTrigger = memo(
     className,
     children,
     getThinkingMessage = defaultGetThinkingMessage,
+    showIcon = true,
     ...props
   }: ReasoningTriggerProps) => {
     const { isStreaming, isOpen, duration } = useReasoning();
@@ -183,7 +185,7 @@ export const ReasoningTrigger = memo(
       >
         {children ?? (
           <>
-            <BrainIcon className="size-4" />
+            {showIcon && <BrainIcon className="size-4" />}
             {getThinkingMessage(isStreaming, duration)}
             <ChevronDownIcon
               className={cn(

--- a/src/components/chat/ChatReasoning.tsx
+++ b/src/components/chat/ChatReasoning.tsx
@@ -4,12 +4,14 @@ import { cjk } from '@streamdown/cjk';
 import { code } from '@streamdown/code';
 import { math } from '@streamdown/math';
 import { mermaid } from '@streamdown/mermaid';
+import { Shimmer } from '@/components/ai-elements/shimmer';
 import {
   Reasoning,
   ReasoningTrigger,
 } from '@/components/ai-elements/reasoning';
 import { CollapsibleContent } from '@/components/ui/collapsible';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { useSharedSpinnerVerb } from '@/hooks/useSharedSpinnerVerb';
 import { cn } from '@/lib/utils';
 
 // Mirrors `streamdownPlugins` from ai-elements/reasoning.tsx ReasoningContent
@@ -58,9 +60,23 @@ export function ChatReasoning({
   isStreaming,
   className,
 }: ChatReasoningProps) {
+  const thinkingVerb = useSharedSpinnerVerb(isStreaming);
+
   return (
-    <Reasoning isStreaming={isStreaming} className={cn('mb-0', className)}>
-      <ReasoningTrigger className="text-adam-text-secondary hover:text-adam-text-primary" />
+    <Reasoning isStreaming={isStreaming} className={cn('mb-0 mt-1', className)}>
+      <ReasoningTrigger
+        className="min-h-9 text-adam-text-secondary hover:text-adam-text-primary"
+        showIcon={false}
+        getThinkingMessage={(streaming, duration) => {
+          if (streaming || duration === 0) {
+            return <Shimmer duration={1}>{`${thinkingVerb}...`}</Shimmer>;
+          }
+          if (duration === undefined) {
+            return <p>Thought for a few seconds</p>;
+          }
+          return <p>Thought for {duration} seconds</p>;
+        }}
+      />
       <ChatReasoningBody isStreaming={isStreaming}>{text}</ChatReasoningBody>
     </Reasoning>
   );

--- a/src/components/viewer/Loader.tsx
+++ b/src/components/viewer/Loader.tsx
@@ -4,13 +4,13 @@ import adamLoading from '@/assets/adam-loading.json';
 import { useSharedSpinnerVerb } from '@/hooks/useSharedSpinnerVerb';
 
 type Props = {
-  message?: string;
+  showLoadingText?: boolean;
 };
 
-const Loader = ({ message }: Props) => {
+const Loader = ({ showLoadingText = false }: Props) => {
   const dot2 = useRef<HTMLSpanElement>(null);
   const dot3 = useRef<HTMLSpanElement>(null);
-  const sharedVerb = useSharedSpinnerVerb();
+  const sharedVerb = useSharedSpinnerVerb(showLoadingText);
   const { View: loadingAnimation } = useLottie(
     {
       animationData: adamLoading,
@@ -38,7 +38,7 @@ const Loader = ({ message }: Props) => {
   return (
     <div className="flex flex-col items-center justify-center">
       <div className="relative h-32 w-32">{loadingAnimation}</div>
-      {message && (
+      {showLoadingText && (
         <p className="mt-4 text-base text-adam-text-primary">
           {sharedVerb}
           <span>.</span>

--- a/src/components/viewer/Loader.tsx
+++ b/src/components/viewer/Loader.tsx
@@ -1,22 +1,16 @@
 import { useLottie } from 'lottie-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import adamLoading from '@/assets/adam-loading.json';
-import { pickSpinnerVerb } from '@/constants/spinnerVerbs';
+import { useSharedSpinnerVerb } from '@/hooks/useSharedSpinnerVerb';
 
 type Props = {
   message?: string;
 };
 
-const INITIAL_MESSAGE_MS = 2000;
-const VERB_ROTATE_MS = 2800;
-// Must match `duration-200` on the <p> element in the JSX below.
-const FADE_MS = 200;
-
 const Loader = ({ message }: Props) => {
   const dot2 = useRef<HTMLSpanElement>(null);
   const dot3 = useRef<HTMLSpanElement>(null);
-  const loadingMessage = useRef<HTMLParagraphElement>(null);
-  const fadeTimeouts = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const sharedVerb = useSharedSpinnerVerb();
   const { View: loadingAnimation } = useLottie(
     {
       animationData: adamLoading,
@@ -25,34 +19,7 @@ const Loader = ({ message }: Props) => {
     { width: '100%', height: '100%' },
   );
 
-  const [changingMessage, setChangingMessage] = useState(message);
-
   useEffect(() => {
-    const swapMessage = (next: string) => {
-      if (!loadingMessage.current) {
-        setChangingMessage(next);
-        return;
-      }
-      loadingMessage.current.classList.add('opacity-0');
-      const fadeId = setTimeout(() => {
-        loadingMessage.current?.classList.remove('opacity-0');
-        setChangingMessage(next);
-      }, FADE_MS);
-      fadeTimeouts.current.push(fadeId);
-    };
-
-    // Kick off the whimsical verb rotation after the initial message.
-    const initialTimeout = setTimeout(() => {
-      swapMessage(pickSpinnerVerb());
-    }, INITIAL_MESSAGE_MS);
-
-    let rotateInterval: ReturnType<typeof setInterval> | undefined;
-    const startRotateTimeout = setTimeout(() => {
-      rotateInterval = setInterval(() => {
-        swapMessage(pickSpinnerVerb());
-      }, VERB_ROTATE_MS);
-    }, INITIAL_MESSAGE_MS);
-
     // ANIMATE LAST TWO DOTS WITH DELAYS AND INTERVALS
     const interval = setInterval(() => {
       dot2.current?.classList.toggle('opacity-0');
@@ -65,26 +32,15 @@ const Loader = ({ message }: Props) => {
       }, 600);
     }, 900);
 
-    // Cleanup intervals on unmount
-    return () => {
-      clearTimeout(initialTimeout);
-      clearTimeout(startRotateTimeout);
-      if (rotateInterval) clearInterval(rotateInterval);
-      clearInterval(interval);
-      fadeTimeouts.current.forEach(clearTimeout);
-      fadeTimeouts.current = [];
-    };
+    return () => clearInterval(interval);
   }, []);
 
   return (
     <div className="flex flex-col items-center justify-center">
       <div className="relative h-32 w-32">{loadingAnimation}</div>
       {message && (
-        <p
-          ref={loadingMessage}
-          className="mt-4 text-base text-adam-text-primary transition-opacity duration-200"
-        >
-          {changingMessage}
+        <p className="mt-4 text-base text-adam-text-primary">
+          {sharedVerb}
           <span>.</span>
           <span
             ref={dot2}

--- a/src/hooks/useSharedSpinnerVerb.ts
+++ b/src/hooks/useSharedSpinnerVerb.ts
@@ -1,0 +1,41 @@
+import { useSyncExternalStore } from 'react';
+import { pickSpinnerVerb, SPINNER_VERBS } from '@/constants/spinnerVerbs';
+
+const VERB_ROTATE_MS = 2800;
+
+let currentVerb = SPINNER_VERBS[0] ?? 'Thinking';
+let rotateInterval: ReturnType<typeof setInterval> | undefined;
+const listeners = new Set<() => void>();
+
+function rotateVerb() {
+  currentVerb = pickSpinnerVerb();
+  listeners.forEach((listener) => listener());
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+
+  if (!rotateInterval) {
+    rotateInterval = setInterval(rotateVerb, VERB_ROTATE_MS);
+  }
+
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && rotateInterval) {
+      clearInterval(rotateInterval);
+      rotateInterval = undefined;
+    }
+  };
+}
+
+function getSnapshot() {
+  return currentVerb;
+}
+
+export function useSharedSpinnerVerb(enabled = true) {
+  return useSyncExternalStore(
+    (listener) => (enabled ? subscribe(listener) : () => {}),
+    getSnapshot,
+    getSnapshot,
+  );
+}

--- a/src/hooks/useSharedSpinnerVerb.ts
+++ b/src/hooks/useSharedSpinnerVerb.ts
@@ -28,13 +28,17 @@ function subscribe(listener: () => void) {
   };
 }
 
+function subscribeDisabled() {
+  return () => {};
+}
+
 function getSnapshot() {
   return currentVerb;
 }
 
 export function useSharedSpinnerVerb(enabled = true) {
   return useSyncExternalStore(
-    (listener) => (enabled ? subscribe(listener) : () => {}),
+    enabled ? subscribe : subscribeDisabled,
     getSnapshot,
     getSnapshot,
   );

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -3,6 +3,7 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { chatTools, type AppUIMessage, type AppTools } from '@shared/chatAi';
 import { getParametricText } from '@shared/parametricParts';
+import { normalizeConversationSuggestions } from '@shared/suggestions';
 import type { Conversation, Message, MeshFileType, Model } from '@shared/types';
 import {
   convertToModelMessages,
@@ -22,7 +23,7 @@ import type { ProviderOptions } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
 import { billing, BillingClientError } from './billingClient';
 import { corsHeaders, isRecord } from './api';
-import { requiredEnv } from './env';
+import { env, requiredEnv } from './env';
 import { logError } from './serverLog';
 import { handleMeshRequest } from './mesh';
 import { getAnonSupabaseClient } from './supabaseClient';
@@ -248,21 +249,31 @@ function providerFor(modelId: string): ChatProvider {
 
 type AnthropicProvider = ReturnType<typeof createAnthropic>;
 type GoogleProvider = ReturnType<typeof createGoogleGenerativeAI>;
+type OpenRouterProvider = ReturnType<typeof createOpenRouter>;
 
 type ChatProviders = {
-  anthropic: AnthropicProvider;
-  google: GoogleProvider;
-  /** Lazy — only initialized if a non-Anthropic / non-Google model is used. */
-  openrouter: () => ReturnType<typeof createOpenRouter>;
+  anthropic: () => AnthropicProvider;
+  google: () => GoogleProvider;
+  openrouter: () => OpenRouterProvider;
 };
 
 function createChatProviders(): ChatProviders {
-  let openrouter: ReturnType<typeof createOpenRouter> | undefined;
+  let anthropic: AnthropicProvider | undefined;
+  let google: GoogleProvider | undefined;
+  let openrouter: OpenRouterProvider | undefined;
   return {
-    anthropic: createAnthropic({ apiKey: requiredEnv('ANTHROPIC_API_KEY') }),
-    google: createGoogleGenerativeAI({
-      apiKey: requiredEnv('GOOGLE_API_KEY'),
-    }),
+    anthropic: () => {
+      anthropic ??= createAnthropic({
+        apiKey: requiredEnv('ANTHROPIC_API_KEY'),
+      });
+      return anthropic;
+    },
+    google: () => {
+      google ??= createGoogleGenerativeAI({
+        apiKey: requiredEnv('GOOGLE_API_KEY'),
+      });
+      return google;
+    },
     openrouter: () => {
       openrouter ??= createOpenRouter({
         apiKey: requiredEnv('OPENROUTER_API_KEY'),
@@ -290,7 +301,7 @@ function buildChatModel(
     // OpenRouter alias uses dots ("claude-haiku-4.5"). Normalize both.
     const id = modelId.slice('anthropic/'.length).replace(/\./g, '-');
     return {
-      model: providers.anthropic(id),
+      model: providers.anthropic()(id),
       providerOptions: thinking
         ? {
             anthropic: {
@@ -305,9 +316,20 @@ function buildChatModel(
   }
 
   if (modelId.startsWith('google/')) {
+    if (!env('GOOGLE_API_KEY') && env('OPENROUTER_API_KEY')) {
+      return {
+        model: providers.openrouter().chat(modelId, {
+          ...(thinking
+            ? { reasoning: { max_tokens: THINKING_BUDGET_TOKENS } }
+            : {}),
+          usage: { include: true },
+        }),
+      };
+    }
+
     const id = modelId.slice('google/'.length);
     return {
-      model: providers.google(id),
+      model: providers.google()(id),
       // Gemini 3 Pro (and most current Google reasoning models) always
       // think internally — `thinkingBudget` only controls how MUCH, not
       // whether. `includeThoughts` is what actually surfaces those
@@ -558,8 +580,8 @@ async function generateConversationSuggestions({
       model: anthropic('claude-haiku-4-5'),
       system:
         conversationType === 'creative'
-          ? 'Given a 3D mesh design conversation, return an array of exactly 3 follow-up prompts the user might want to send next. Each prompt is a single concise instruction (under 8 words), not a question. Return exactly 3 items — no more, no fewer.'
-          : 'Given a parametric CAD conversation, return an array of exactly 3 follow-up prompts the user might want to send next. Each prompt is a single concise instruction (under 8 words), not a question. Return exactly 3 items — no more, no fewer.',
+          ? 'Given a 3D mesh design conversation, return an array of exactly 3 follow-up prompts the user might want to send next. Each prompt is a concise instruction of 3 words or fewer, not a question. Return exactly 3 items — no more, no fewer.'
+          : 'Given a parametric CAD conversation, return an array of exactly 3 follow-up prompts the user might want to send next. Each prompt is a concise instruction of 3 words or fewer, not a question. Return exactly 3 items — no more, no fewer.',
       prompt: summary,
       output: Output.object({
         schema: z.object({
@@ -567,7 +589,7 @@ async function generateConversationSuggestions({
         }),
       }),
     });
-    return result.output.suggestions.slice(0, 3);
+    return normalizeConversationSuggestions(result.output.suggestions);
   } catch (error) {
     logError(error, {
       functionName: 'ai-chat',
@@ -990,7 +1012,7 @@ export async function handleAiChatRequest(req: Request) {
       if (isFirstUserTurn) {
         void emitConversationTitle({
           writer,
-          anthropic: providers.anthropic,
+          anthropic: providers.anthropic(),
           supabaseClient,
           conversation,
           firstMessage: branchMessages[0],
@@ -1107,7 +1129,7 @@ export async function handleAiChatRequest(req: Request) {
               // tradeoff for getting pills delivered.
               await emitConversationSuggestions({
                 writer,
-                anthropic: providers.anthropic,
+                anthropic: providers.anthropic(),
                 supabaseClient,
                 conversation,
                 branch: [

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -23,7 +23,7 @@ import type { ProviderOptions } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
 import { billing, BillingClientError } from './billingClient';
 import { corsHeaders, isRecord } from './api';
-import { env, requiredEnv } from './env';
+import { requiredEnv } from './env';
 import { logError } from './serverLog';
 import { handleMeshRequest } from './mesh';
 import { getAnonSupabaseClient } from './supabaseClient';
@@ -249,31 +249,21 @@ function providerFor(modelId: string): ChatProvider {
 
 type AnthropicProvider = ReturnType<typeof createAnthropic>;
 type GoogleProvider = ReturnType<typeof createGoogleGenerativeAI>;
-type OpenRouterProvider = ReturnType<typeof createOpenRouter>;
 
 type ChatProviders = {
-  anthropic: () => AnthropicProvider;
-  google: () => GoogleProvider;
-  openrouter: () => OpenRouterProvider;
+  anthropic: AnthropicProvider;
+  google: GoogleProvider;
+  /** Lazy — only initialized if a non-Anthropic / non-Google model is used. */
+  openrouter: () => ReturnType<typeof createOpenRouter>;
 };
 
 function createChatProviders(): ChatProviders {
-  let anthropic: AnthropicProvider | undefined;
-  let google: GoogleProvider | undefined;
-  let openrouter: OpenRouterProvider | undefined;
+  let openrouter: ReturnType<typeof createOpenRouter> | undefined;
   return {
-    anthropic: () => {
-      anthropic ??= createAnthropic({
-        apiKey: requiredEnv('ANTHROPIC_API_KEY'),
-      });
-      return anthropic;
-    },
-    google: () => {
-      google ??= createGoogleGenerativeAI({
-        apiKey: requiredEnv('GOOGLE_API_KEY'),
-      });
-      return google;
-    },
+    anthropic: createAnthropic({ apiKey: requiredEnv('ANTHROPIC_API_KEY') }),
+    google: createGoogleGenerativeAI({
+      apiKey: requiredEnv('GOOGLE_API_KEY'),
+    }),
     openrouter: () => {
       openrouter ??= createOpenRouter({
         apiKey: requiredEnv('OPENROUTER_API_KEY'),
@@ -301,7 +291,7 @@ function buildChatModel(
     // OpenRouter alias uses dots ("claude-haiku-4.5"). Normalize both.
     const id = modelId.slice('anthropic/'.length).replace(/\./g, '-');
     return {
-      model: providers.anthropic()(id),
+      model: providers.anthropic(id),
       providerOptions: thinking
         ? {
             anthropic: {
@@ -316,20 +306,9 @@ function buildChatModel(
   }
 
   if (modelId.startsWith('google/')) {
-    if (!env('GOOGLE_API_KEY') && env('OPENROUTER_API_KEY')) {
-      return {
-        model: providers.openrouter().chat(modelId, {
-          ...(thinking
-            ? { reasoning: { max_tokens: THINKING_BUDGET_TOKENS } }
-            : {}),
-          usage: { include: true },
-        }),
-      };
-    }
-
     const id = modelId.slice('google/'.length);
     return {
-      model: providers.google()(id),
+      model: providers.google(id),
       // Gemini 3 Pro (and most current Google reasoning models) always
       // think internally — `thinkingBudget` only controls how MUCH, not
       // whether. `includeThoughts` is what actually surfaces those
@@ -1012,7 +991,7 @@ export async function handleAiChatRequest(req: Request) {
       if (isFirstUserTurn) {
         void emitConversationTitle({
           writer,
-          anthropic: providers.anthropic(),
+          anthropic: providers.anthropic,
           supabaseClient,
           conversation,
           firstMessage: branchMessages[0],
@@ -1129,7 +1108,7 @@ export async function handleAiChatRequest(req: Request) {
               // tradeoff for getting pills delivered.
               await emitConversationSuggestions({
                 writer,
-                anthropic: providers.anthropic(),
+                anthropic: providers.anthropic,
                 supabaseClient,
                 conversation,
                 branch: [

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -577,7 +577,7 @@ function ConversationEditor() {
       previewSlot={
         <div className="flex h-full w-full items-center justify-center bg-adam-neutral-700">
           {isChatStreaming ? (
-            <Loader message="Generating model" />
+            <Loader showLoadingText />
           ) : activePreview?.type === 'artifact' ? (
             <OpenSCADPreview
               scadCode={activePreview.artifact.code}

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -78,9 +78,9 @@ export function PromptView() {
   const [images, setImages] = useState<MessageItem[]>([]);
   const [mesh, setMesh] = useState<MessageItem | null>(null);
 
-  const newConversationId = useMemo(() => {
-    return crypto.randomUUID();
-  }, []);
+  const [draftConversationId, setDraftConversationId] = useState(() =>
+    crypto.randomUUID(),
+  );
 
   const lowPrompts = useMemo(() => {
     if (isLoading) return false;
@@ -113,9 +113,10 @@ export function PromptView() {
     }
   }, []); // Empty dependency array means it only calculates once per page load
 
-  const { mutate: handleGenerate } = useMutation({
+  const { mutate: handleGenerate, isPending: isGenerating } = useMutation({
     mutationFn: async (parts: AppUIMessage['parts']) => {
       if (!user?.id) throw new Error('User must be authenticated');
+      const conversationId = draftConversationId;
 
       const text = parts
         .filter((p) => p.type === 'text')
@@ -134,7 +135,7 @@ export function PromptView() {
         text: text.trim().slice(0, 100),
         image_count: imageCount,
         mesh_count: meshCount,
-        conversation_id: newConversationId,
+        conversation_id: conversationId,
       });
 
       // Create conversation immediately with 'New Conversation'
@@ -142,7 +143,7 @@ export function PromptView() {
         .from('conversations')
         .insert([
           {
-            id: newConversationId,
+            id: conversationId,
             user_id: user.id,
             title: 'New Conversation',
             type: type,
@@ -220,6 +221,7 @@ export function PromptView() {
       navigate({ to: '/editor/$id', params: { id: data.conversationId } });
     },
     onError: (error) => {
+      setDraftConversationId(crypto.randomUUID());
       Sentry.captureException(error);
       toast({
         title: 'Error',
@@ -286,7 +288,7 @@ export function PromptView() {
                 <TextAreaChat
                   onSubmit={handleGenerate}
                   conversation={{
-                    id: newConversationId,
+                    id: draftConversationId,
                     user_id: user?.id ?? '',
                   }}
                   onFocus={() => {
@@ -297,7 +299,7 @@ export function PromptView() {
                   }}
                   placeholder="Start building with Adam..."
                   type={type}
-                  disabled={limitReached}
+                  disabled={limitReached || isGenerating}
                   model={model}
                   setModel={setModel}
                   showPromptGenerator={true}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Polishes chat reasoning/loading states and unifies rotating “thinking” verbs with a shared hook. Normalizes follow‑up suggestions to exactly three ≤3‑word commands and updates the AI prompt, with tests.

- **New Features**
  - Added `useSharedSpinnerVerb` to share rotating verbs; used in `Loader` (via `showLoadingText`) and `ChatReasoning` with a shimmer message.
  - Introduced `@shared/suggestions` with tests and integrated into `aiChat` to return 3 suggestions ≤3 words (deduped and truncated).

- **Refactors**
  - Simplified `Loader` (removed per-component timers) and added `showIcon` to `ReasoningTrigger`; polished `ChatReasoning` copy/spacing.
  - Stabilized conversation creation in `PromptView` with a draft ID that resets on errors; disabled input while generating.

<sup>Written for commit 57c026eb0c7f85ceb4558cffe95df1befbcf05d9. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/165?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

