### PR TITLE
Fix mobile conversation layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10249,6 +10249,24 @@
         }
       }
     },
+    "node_modules/nitro/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/nitro/node_modules/db0": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
@@ -10282,6 +10300,34 @@
         "sqlite3": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nitro/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/nitro/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/nitro/node_modules/unstorage": {

--- a/src/components/chat/ChatSession.tsx
+++ b/src/components/chat/ChatSession.tsx
@@ -694,8 +694,12 @@ export function ChatSession({
 
   return (
     <>
-      <ScrollArea className="min-h-0 flex-1 p-4" ref={scrollRef}>
-        <div className="mx-auto flex max-w-3xl flex-col gap-8">
+      <ScrollArea
+        className="relative w-full max-w-xl flex-1 self-center px-2 py-0 md:min-h-0 md:max-w-none md:p-4"
+        ref={scrollRef}
+      >
+        <div className="pointer-events-none sticky left-0 top-0 z-50 mr-4 h-3 bg-gradient-to-b from-adam-bg-secondary-dark/90 to-transparent md:hidden" />
+        <div className="mx-auto flex max-w-3xl flex-col gap-4 pb-6 md:gap-8 md:pb-0">
           {branchNodes.map((node, index) => {
             const isLastMessage = index === branchNodes.length - 1;
             return (
@@ -732,7 +736,7 @@ export function ChatSession({
         </div>
       </ScrollArea>
 
-      <div className="shrink-0 px-4 pb-4">
+      <div className="w-full shrink-0 self-center px-4 pb-6 md:pb-4">
         {/* Suggestions are conversation-level — the server writes them
             to `conversation.settings.suggestions` and emits a transient
             `data-suggestions-update` on each non-tool-call assistant
@@ -741,7 +745,7 @@ export function ChatSession({
             flight; the freshly-arrived pills replace the stale ones
             when streaming finishes. */}
         {!isLoading && (
-          <div className="mx-auto max-w-3xl pt-1">
+          <div className="mx-auto max-w-xl pt-1 md:max-w-3xl">
             <SuggestionPills
               suggestions={conversation.settings?.suggestions ?? []}
               onSelect={(suggestion) =>

--- a/src/components/chat/ChatSession.tsx
+++ b/src/components/chat/ChatSession.tsx
@@ -698,7 +698,7 @@ export function ChatSession({
         className="relative w-full max-w-xl flex-1 self-center px-2 py-0 md:min-h-0 md:max-w-none md:p-4"
         ref={scrollRef}
       >
-        <div className="pointer-events-none sticky left-0 top-0 z-50 mr-4 h-3 bg-gradient-to-b from-adam-bg-secondary-dark/90 to-transparent md:hidden" />
+        <div className="pointer-events-none sticky left-0 top-0 z-50 h-3 bg-gradient-to-b from-adam-bg-secondary-dark/90 to-transparent md:hidden" />
         <div className="mx-auto flex max-w-3xl flex-col gap-4 pb-6 md:gap-8 md:pb-0">
           {branchNodes.map((node, index) => {
             const isLastMessage = index === branchNodes.length - 1;

--- a/src/components/parameter/ParameterSheetContent.tsx
+++ b/src/components/parameter/ParameterSheetContent.tsx
@@ -1,0 +1,205 @@
+import { Download, ChevronUp, Loader2 } from 'lucide-react';
+import { useEffect, useState, useRef, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import type { Parameter } from '@shared/types';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { ParameterInput } from '@/components/parameter/ParameterInput';
+import { validateParameterValue } from '@/utils/parameterUtils';
+import {
+  downloadSTLFile,
+  downloadOpenSCADFile,
+  downloadDXFFile,
+  type DxfExporter,
+} from '@/utils/downloadUtils';
+import { useToast } from '@/hooks/use-toast';
+
+interface ParameterSheetContentProps {
+  parameters: Parameter[];
+  onParameterChange: (parameters: Parameter[]) => void;
+  currentOutput?: Blob;
+  dxfExporter?: DxfExporter | null;
+  code?: string;
+}
+
+type DownloadFormat = 'stl' | 'scad' | 'dxf';
+
+export function ParameterSheetContent({
+  parameters,
+  onParameterChange,
+  currentOutput,
+  dxfExporter,
+  code,
+}: ParameterSheetContentProps) {
+  const { toast } = useToast();
+  const [selectedFormat, setSelectedFormat] = useState<DownloadFormat>('stl');
+  const [isExporting, setIsExporting] = useState(false);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingParametersRef = useRef<Parameter[] | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
+  const debouncedSubmit = useCallback(
+    (params: Parameter[]) => {
+      pendingParametersRef.current = params;
+
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+
+      debounceTimerRef.current = setTimeout(() => {
+        if (pendingParametersRef.current) {
+          onParameterChange(pendingParametersRef.current);
+          pendingParametersRef.current = null;
+        }
+      }, 200);
+    },
+    [onParameterChange],
+  );
+
+  const handleCommit = (param: Parameter, value: Parameter['value']) => {
+    const validatedValue = validateParameterValue(param, value);
+    const updatedParam = { ...param, value: validatedValue };
+    const updatedParameters = parameters.map((p) =>
+      p.name === param.name ? updatedParam : p,
+    );
+
+    debouncedSubmit(updatedParameters);
+  };
+
+  const handleDownloadSTL = () => {
+    if (!currentOutput) return;
+    downloadSTLFile(currentOutput);
+  };
+
+  const handleDownloadOpenSCAD = () => {
+    if (!code) return;
+    downloadOpenSCADFile(code);
+  };
+
+  const handleDownloadDXF = async () => {
+    if (!dxfExporter) return;
+
+    try {
+      setIsExporting(true);
+      const dxfOutput = await dxfExporter();
+      downloadDXFFile(dxfOutput);
+    } catch (error) {
+      console.error('[OpenSCAD] Failed to export DXF:', error);
+      toast({
+        title: 'DXF export failed',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'Adam could not export this model as DXF.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const downloadHandlers: Record<DownloadFormat, () => void | Promise<void>> = {
+    stl: handleDownloadSTL,
+    scad: handleDownloadOpenSCAD,
+    dxf: handleDownloadDXF,
+  };
+  const formatAvailable: Record<DownloadFormat, boolean> = {
+    stl: !!currentOutput,
+    scad: !!code,
+    dxf: !!dxfExporter && !isExporting,
+  };
+
+  const handleDownload = async () => {
+    await downloadHandlers[selectedFormat]();
+  };
+  const isDownloadDisabled = !formatAvailable[selectedFormat];
+  const isAnyFormatAvailable = Object.values(formatAvailable).some(Boolean);
+
+  return (
+    <>
+      <ScrollArea className="h-full w-full px-4">
+        <div className="flex flex-col gap-6 pb-4 pt-2">
+          {parameters.map((param) => (
+            <ParameterInput
+              key={param.name}
+              param={param}
+              handleCommit={handleCommit}
+            />
+          ))}
+        </div>
+      </ScrollArea>
+      <div className="flex w-full flex-col gap-4 p-4">
+        <div className="flex border-t border-adam-neutral-700 pt-2">
+          <Button
+            onClick={handleDownload}
+            disabled={isDownloadDisabled}
+            aria-label={`download ${selectedFormat.toUpperCase()} file`}
+            className="flex-1 rounded-r-none bg-adam-neutral-50 text-adam-neutral-800 hover:bg-adam-neutral-100 hover:text-adam-neutral-900"
+          >
+            {isExporting ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Download className="mr-2 h-4 w-4" />
+            )}
+            {selectedFormat.toUpperCase()}
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                disabled={!isAnyFormatAvailable}
+                aria-label="select download format"
+                className="rounded-l-none border-l border-adam-neutral-300 bg-adam-neutral-50 px-2 text-adam-neutral-800 hover:bg-adam-neutral-100 hover:text-adam-neutral-900"
+              >
+                <ChevronUp className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => setSelectedFormat('stl')}
+                disabled={!formatAvailable.stl}
+                className="grid cursor-pointer grid-cols-3 text-adam-text-primary"
+              >
+                <span className="text-sm">.STL</span>
+                <span className="col-span-2 text-xs text-adam-text-primary/60">
+                  3D Printing
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setSelectedFormat('scad')}
+                disabled={!formatAvailable.scad}
+                className="grid cursor-pointer grid-cols-3 text-adam-text-primary"
+              >
+                <span className="text-sm">.SCAD</span>
+                <span className="col-span-2 text-xs text-adam-text-primary/60">
+                  OpenSCAD Code
+                </span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setSelectedFormat('dxf')}
+                disabled={!formatAvailable.dxf}
+                className="grid cursor-pointer grid-cols-3 text-adam-text-primary"
+              >
+                <span className="text-sm">.DXF</span>
+                <span className="col-span-2 text-xs text-adam-text-primary/60">
+                  2D Projection to the (x,y) plane
+                </span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/parameter/ParameterSheetContent.tsx
+++ b/src/components/parameter/ParameterSheetContent.tsx
@@ -41,6 +41,11 @@ export function ParameterSheetContent({
   const [isExporting, setIsExporting] = useState(false);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingParametersRef = useRef<Parameter[] | null>(null);
+  const latestParametersRef = useRef(parameters);
+
+  useEffect(() => {
+    latestParametersRef.current = parameters;
+  }, [parameters]);
 
   useEffect(() => {
     return () => {
@@ -61,6 +66,7 @@ export function ParameterSheetContent({
       debounceTimerRef.current = setTimeout(() => {
         if (pendingParametersRef.current) {
           onParameterChange(pendingParametersRef.current);
+          latestParametersRef.current = pendingParametersRef.current;
           pendingParametersRef.current = null;
         }
       }, 200);
@@ -71,7 +77,9 @@ export function ParameterSheetContent({
   const handleCommit = (param: Parameter, value: Parameter['value']) => {
     const validatedValue = validateParameterValue(param, value);
     const updatedParam = { ...param, value: validatedValue };
-    const updatedParameters = parameters.map((p) =>
+    const baseParameters =
+      pendingParametersRef.current ?? latestParametersRef.current;
+    const updatedParameters = baseParameters.map((p) =>
       p.name === param.name ? updatedParam : p,
     );
 

--- a/src/components/parameter/ParameterSheetContent.tsx
+++ b/src/components/parameter/ParameterSheetContent.tsx
@@ -136,8 +136,8 @@ export function ParameterSheetContent({
   const isAnyFormatAvailable = Object.values(formatAvailable).some(Boolean);
 
   return (
-    <>
-      <ScrollArea className="h-full w-full px-4">
+    <div className="flex h-full min-h-0 w-full flex-col">
+      <ScrollArea className="min-h-0 w-full flex-1 px-4">
         <div className="flex flex-col gap-6 pb-4 pt-2">
           {parameters.map((param) => (
             <ParameterInput
@@ -208,6 +208,6 @@ export function ParameterSheetContent({
           </DropdownMenu>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,13 +1,17 @@
 import { useState, useEffect } from 'react';
 
+const MOBILE_BREAKPOINT = 768;
+
 export function useIsMobile(): boolean {
   const [isMobile, setIsMobile] = useState(() =>
-    typeof window === 'undefined' ? false : window.innerWidth < 640,
+    typeof window === 'undefined'
+      ? false
+      : window.innerWidth < MOBILE_BREAKPOINT,
   );
 
   useEffect(() => {
     const checkIsMobile = () => {
-      setIsMobile(window.innerWidth < 640);
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
     };
 
     checkIsMobile();

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-const MOBILE_BREAKPOINT = 768;
+const MOBILE_BREAKPOINT = 1024;
 
 export function useIsMobile(): boolean {
   const [isMobile, setIsMobile] = useState(() =>

--- a/src/views/ConversationView.tsx
+++ b/src/views/ConversationView.tsx
@@ -1,8 +1,18 @@
 import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Separator } from '@/components/ui/separator';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { cn } from '@/lib/utils';
+import * as SheetPrimitive from '@radix-ui/react-dialog';
 import { ChevronsRight } from 'lucide-react';
 import {
   type ReactNode,
+  type TouchEvent,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -27,6 +37,10 @@ interface ConversationViewProps {
   chatPanelSlot: ReactNode;
   previewSlot: ReactNode;
   parametersSlot: ReactNode;
+  mobilePreviewSlot?: ReactNode;
+  mobileParametersSlot?: ReactNode;
+  mobilePreviewKey?: string | null;
+  mobilePreviewVersion?: number;
   /**
    * Drives the right-hand parameters panel: when false the panel collapses to
    * 0 and its resize handle stays inert. Editor uses this to show parameters
@@ -52,6 +66,10 @@ export function ConversationView({
   chatPanelSlot,
   previewSlot,
   parametersSlot,
+  mobilePreviewSlot,
+  mobileParametersSlot,
+  mobilePreviewKey = null,
+  mobilePreviewVersion = 0,
   hasParameters,
 }: ConversationViewProps) {
   const chatPanelRef = useRef<ImperativePanelHandle>(null);
@@ -60,6 +78,11 @@ export function ConversationView({
   const [containerWidth, setContainerWidth] = useState(0);
   const [isChatCollapsed, setIsChatCollapsed] = useState(false);
   const [isParametersCollapsed, setIsParametersCollapsed] = useState(false);
+  const [isMobilePreviewOpen, setIsMobilePreviewOpen] = useState(false);
+  const [isDraggingMobileSheet, setIsDraggingMobileSheet] = useState(false);
+  const [mobileSheetDragDistance, setMobileSheetDragDistance] = useState(0);
+  const mobileSheetTouchStartYRef = useRef(0);
+  const isTabletOrMobile = useMediaQuery('(max-width: 1024px)');
 
   const setContainerRef = useCallback((element: HTMLDivElement | null) => {
     resizeObserverRef.current?.disconnect();
@@ -142,6 +165,138 @@ export function ConversationView({
     parametersPanelRef.current?.expand();
     setIsParametersCollapsed(false);
   }, []);
+
+  useEffect(() => {
+    setIsMobilePreviewOpen(!!mobilePreviewKey);
+  }, [mobilePreviewKey, mobilePreviewVersion]);
+
+  const handleMobilePreviewOpenChange = useCallback((open: boolean) => {
+    setIsMobilePreviewOpen(open);
+    if (!open) {
+      window.setTimeout(() => {
+        setMobileSheetDragDistance(0);
+        setIsDraggingMobileSheet(false);
+      }, 150);
+    }
+  }, []);
+
+  const handleMobileSheetTouchStart = useCallback((event: TouchEvent) => {
+    mobileSheetTouchStartYRef.current = event.touches[0].clientY;
+    setIsDraggingMobileSheet(true);
+  }, []);
+
+  const handleMobileSheetTouchMove = useCallback(
+    (event: TouchEvent) => {
+      if (!isDraggingMobileSheet) return;
+      setMobileSheetDragDistance(
+        event.touches[0].clientY - mobileSheetTouchStartYRef.current,
+      );
+    },
+    [isDraggingMobileSheet],
+  );
+
+  const handleMobileSheetTouchEnd = useCallback(() => {
+    if (!isDraggingMobileSheet) return;
+    if (mobileSheetDragDistance > 0) {
+      handleMobilePreviewOpenChange(false);
+      return;
+    }
+    setMobileSheetDragDistance(0);
+    setIsDraggingMobileSheet(false);
+  }, [
+    handleMobilePreviewOpenChange,
+    isDraggingMobileSheet,
+    mobileSheetDragDistance,
+  ]);
+
+  const mobileSheetHeight = useMemo(() => {
+    if (!isDraggingMobileSheet) return 'calc(100dvh - 56px)';
+    if (mobileSheetDragDistance <= 0) return 'calc(100dvh - 56px)';
+    if (typeof window === 'undefined') return 'calc(100dvh - 56px)';
+    return `${Math.max(56, window.innerHeight - 56 - mobileSheetDragDistance)}px`;
+  }, [isDraggingMobileSheet, mobileSheetDragDistance]);
+
+  if (isTabletOrMobile) {
+    return (
+      <div
+        className="relative h-full w-full overflow-hidden bg-[#292828]"
+        ref={setContainerRef}
+      >
+        <div className="flex h-full min-w-0 flex-col items-center bg-adam-bg-secondary-dark">
+          {chatPanelSlot}
+        </div>
+
+        <Sheet
+          open={!!mobilePreviewKey && isMobilePreviewOpen}
+          onOpenChange={handleMobilePreviewOpenChange}
+        >
+          <SheetPrimitive.Portal>
+            <SheetPrimitive.Content
+              className={cn(
+                'fixed z-50 shadow-[0_0_10px_rgba(0,0,0,0.5)] transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
+                'inset-x-0 bottom-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+                'rounded-t-3xl bg-adam-bg-secondary-dark',
+              )}
+              style={{ height: mobileSheetHeight }}
+            >
+              <SheetHeader className="hidden">
+                <SheetTitle>Model preview</SheetTitle>
+                <SheetDescription>
+                  Preview and parameters for the selected model.
+                </SheetDescription>
+              </SheetHeader>
+              <SheetPrimitive.Close
+                onTouchStart={handleMobileSheetTouchStart}
+                onTouchMove={handleMobileSheetTouchMove}
+                onTouchEnd={handleMobileSheetTouchEnd}
+                className="flex w-full justify-center rounded-sm opacity-70 transition-opacity hover:opacity-100"
+              >
+                <svg
+                  width="32"
+                  height="32"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M21.5262 10.75L11.9999 16L2.47363 10.75"
+                    stroke="currentColor"
+                    strokeLinecap="round"
+                    strokeWidth="2"
+                    className="text-adam-neutral-400"
+                  />
+                </svg>
+              </SheetPrimitive.Close>
+              <div className="mx-auto flex h-full max-w-xl flex-col items-center pb-6">
+                <div
+                  className={cn(
+                    'w-full px-4',
+                    hasParameters
+                      ? 'h-[40dvh] min-h-[40dvh]'
+                      : 'min-h-[52dvh] flex-1',
+                  )}
+                >
+                  <div className="h-full w-full overflow-hidden rounded-xl">
+                    {mobilePreviewSlot ?? previewSlot}
+                  </div>
+                </div>
+                {hasParameters && (
+                  <>
+                    <div className="w-full px-4">
+                      <Separator className="w-full bg-adam-neutral-700" />
+                    </div>
+                    <div className="min-h-0 w-full flex-1">
+                      {mobileParametersSlot ?? parametersSlot}
+                    </div>
+                  </>
+                )}
+              </div>
+            </SheetPrimitive.Content>
+          </SheetPrimitive.Portal>
+        </Sheet>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/views/ConversationView.tsx
+++ b/src/views/ConversationView.tsx
@@ -83,6 +83,8 @@ export function ConversationView({
   const [isDraggingMobileSheet, setIsDraggingMobileSheet] = useState(false);
   const [mobileSheetDragDistance, setMobileSheetDragDistance] = useState(0);
   const mobileSheetTouchStartYRef = useRef(0);
+  const isDraggingMobileSheetRef = useRef(false);
+  const didDragMobileSheetRef = useRef(false);
   const isTabletOrMobile = useMediaQuery('(max-width: 1024px)');
 
   const setContainerRef = useCallback((element: HTMLDivElement | null) => {
@@ -176,37 +178,51 @@ export function ConversationView({
     if (!open) {
       setMobileSheetDragDistance(0);
       setIsDraggingMobileSheet(false);
+      isDraggingMobileSheetRef.current = false;
+      didDragMobileSheetRef.current = false;
     }
   }, []);
 
   const handleMobileSheetTouchStart = useCallback((event: TouchEvent) => {
     mobileSheetTouchStartYRef.current = event.touches[0].clientY;
+    isDraggingMobileSheetRef.current = true;
+    didDragMobileSheetRef.current = false;
     setIsDraggingMobileSheet(true);
   }, []);
 
-  const handleMobileSheetTouchMove = useCallback(
-    (event: TouchEvent) => {
-      if (!isDraggingMobileSheet) return;
-      setMobileSheetDragDistance(
-        event.touches[0].clientY - mobileSheetTouchStartYRef.current,
-      );
-    },
-    [isDraggingMobileSheet],
-  );
+  const handleMobileSheetTouchMove = useCallback((event: TouchEvent) => {
+    if (!isDraggingMobileSheetRef.current) return;
+    const dragDistance =
+      event.touches[0].clientY - mobileSheetTouchStartYRef.current;
+    didDragMobileSheetRef.current ||= Math.abs(dragDistance) > 4;
+    setMobileSheetDragDistance(dragDistance);
+  }, []);
 
   const handleMobileSheetTouchEnd = useCallback(() => {
-    if (!isDraggingMobileSheet) return;
+    if (!isDraggingMobileSheetRef.current) return;
+    isDraggingMobileSheetRef.current = false;
     if (mobileSheetDragDistance >= MOBILE_SHEET_DISMISS_THRESHOLD) {
       handleMobilePreviewOpenChange(false);
       return;
     }
     setMobileSheetDragDistance(0);
     setIsDraggingMobileSheet(false);
-  }, [
-    handleMobilePreviewOpenChange,
-    isDraggingMobileSheet,
-    mobileSheetDragDistance,
-  ]);
+  }, [handleMobilePreviewOpenChange, mobileSheetDragDistance]);
+
+  const handleMobileSheetTouchCancel = useCallback(() => {
+    isDraggingMobileSheetRef.current = false;
+    didDragMobileSheetRef.current = false;
+    setMobileSheetDragDistance(0);
+    setIsDraggingMobileSheet(false);
+  }, []);
+
+  const handleMobileSheetHandleClick = useCallback(() => {
+    if (didDragMobileSheetRef.current) {
+      didDragMobileSheetRef.current = false;
+      return;
+    }
+    handleMobilePreviewOpenChange(false);
+  }, [handleMobilePreviewOpenChange]);
 
   const mobileSheetHeight = useMemo(() => {
     if (!isDraggingMobileSheet) return 'calc(100dvh - 56px)';
@@ -245,10 +261,12 @@ export function ConversationView({
               </SheetHeader>
               <button
                 type="button"
-                aria-label="Drag down to close preview"
+                aria-label="Close preview"
                 onTouchStart={handleMobileSheetTouchStart}
                 onTouchMove={handleMobileSheetTouchMove}
                 onTouchEnd={handleMobileSheetTouchEnd}
+                onTouchCancel={handleMobileSheetTouchCancel}
+                onClick={handleMobileSheetHandleClick}
                 className="flex w-full justify-center rounded-sm opacity-70 transition-opacity hover:opacity-100"
               >
                 <svg

--- a/src/views/ConversationView.tsx
+++ b/src/views/ConversationView.tsx
@@ -212,7 +212,6 @@ export function ConversationView({
   const mobileSheetHeight = useMemo(() => {
     if (!isDraggingMobileSheet) return 'calc(100dvh - 56px)';
     if (mobileSheetDragDistance <= 0) return 'calc(100dvh - 56px)';
-    if (typeof window === 'undefined') return 'calc(100dvh - 56px)';
     return `${Math.max(56, window.innerHeight - 56 - mobileSheetDragDistance)}px`;
   }, [isDraggingMobileSheet, mobileSheetDragDistance]);
 

--- a/src/views/ConversationView.tsx
+++ b/src/views/ConversationView.tsx
@@ -32,6 +32,7 @@ const PANEL_SIZES = {
   PREVIEW: { DEFAULT: 45, MIN: 20 },
   PARAMETERS: { DEFAULT: 30, MIN: 320, MAX: 384 },
 } as const;
+const MOBILE_SHEET_DISMISS_THRESHOLD = 48;
 
 interface ConversationViewProps {
   chatPanelSlot: ReactNode;
@@ -173,10 +174,8 @@ export function ConversationView({
   const handleMobilePreviewOpenChange = useCallback((open: boolean) => {
     setIsMobilePreviewOpen(open);
     if (!open) {
-      window.setTimeout(() => {
-        setMobileSheetDragDistance(0);
-        setIsDraggingMobileSheet(false);
-      }, 150);
+      setMobileSheetDragDistance(0);
+      setIsDraggingMobileSheet(false);
     }
   }, []);
 
@@ -197,7 +196,7 @@ export function ConversationView({
 
   const handleMobileSheetTouchEnd = useCallback(() => {
     if (!isDraggingMobileSheet) return;
-    if (mobileSheetDragDistance > 0) {
+    if (mobileSheetDragDistance >= MOBILE_SHEET_DISMISS_THRESHOLD) {
       handleMobilePreviewOpenChange(false);
       return;
     }

--- a/src/views/ConversationView.tsx
+++ b/src/views/ConversationView.tsx
@@ -243,7 +243,9 @@ export function ConversationView({
                   Preview and parameters for the selected model.
                 </SheetDescription>
               </SheetHeader>
-              <SheetPrimitive.Close
+              <button
+                type="button"
+                aria-label="Drag down to close preview"
                 onTouchStart={handleMobileSheetTouchStart}
                 onTouchMove={handleMobileSheetTouchMove}
                 onTouchEnd={handleMobileSheetTouchEnd}
@@ -264,7 +266,7 @@ export function ConversationView({
                     className="text-adam-neutral-400"
                   />
                 </svg>
-              </SheetPrimitive.Close>
+              </button>
               <div className="mx-auto flex h-full max-w-xl flex-col items-center pb-6">
                 <div
                   className={cn(

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -1,6 +1,8 @@
 import { ChatTitle } from '@/components/chat/ChatTitle';
 import { ChatSession } from '@/components/chat/ChatSession';
+import { CreateIcon } from '@/components/icons/ui/CreateIcon';
 import { ParameterSection } from '@/components/parameter/ParameterSection';
+import { ParameterSheetContent } from '@/components/parameter/ParameterSheetContent';
 import { Button } from '@/components/ui/button';
 import {
   Popover,
@@ -179,6 +181,7 @@ function ConversationEditor() {
     useConversation();
   const { user, billing } = useAuth();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const totalTokens = billing?.tokens.total ?? 0;
 
   // ── Per-conversation UI state ───────────────────────────────────────────
@@ -192,6 +195,7 @@ function ConversationEditor() {
   const [parameters, setParameters] = useState<Parameter[]>([]);
   const [currentOutput, setCurrentOutput] = useState<Blob | undefined>();
   const [dxfExporter, setDxfExporter] = useState<DxfExporter | null>(null);
+  const [mobilePreviewVersion, setMobilePreviewVersion] = useState(0);
   // Streaming flag surfaced from <ChatSession>. While true, the preview
   // pane swaps to the bouncing loader instead of mounting OpenSCAD —
   // matches the legacy ParametricPreviewSection behavior.
@@ -431,6 +435,7 @@ function ConversationEditor() {
       setCurrentOutput(undefined);
       setDxfExporter(() => null);
       setActivePreview({ type: 'artifact', messageId, artifact });
+      setMobilePreviewVersion((version) => version + 1);
     },
     [],
   );
@@ -438,6 +443,7 @@ function ConversationEditor() {
     setCurrentOutput(undefined);
     setDxfExporter(() => null);
     setActivePreview({ type: 'mesh', messageId, meshId });
+    setMobilePreviewVersion((version) => version + 1);
   }, []);
 
   const changeParameters = useCallback(
@@ -496,6 +502,14 @@ function ConversationEditor() {
   return (
     <ConversationView
       hasParameters={hasArtifact}
+      mobilePreviewKey={
+        sharePreview
+          ? sharePreview.type === 'artifact'
+            ? `artifact:${sharePreview.messageId}`
+            : `mesh:${sharePreview.messageId}:${sharePreview.meshId}`
+          : null
+      }
+      mobilePreviewVersion={mobilePreviewVersion}
       chatPanelSlot={
         <>
           {/* `pl-12` reserves space for the rotated "Chat" expand button
@@ -518,7 +532,7 @@ function ConversationEditor() {
                 />
               </div>
             </div>
-            <div className="flex items-center gap-3">
+            <div className="hidden items-center gap-3 md:flex">
               <Popover>
                 <PopoverTrigger asChild>
                   <Button
@@ -550,6 +564,19 @@ function ConversationEditor() {
                   />
                 </PopoverContent>
               </Popover>
+            </div>
+            <div className="flex items-center gap-3 md:hidden">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 bg-transparent p-0 hover:bg-transparent"
+                onClick={() => {
+                  navigate({ to: '/' });
+                }}
+                aria-label="New Creation"
+              >
+                <CreateIcon className="h-5 w-5 text-adam-text-primary" />
+              </Button>
             </div>
           </div>
 
@@ -594,6 +621,28 @@ function ConversationEditor() {
           )}
         </div>
       }
+      mobilePreviewSlot={
+        <div className="flex h-full w-full items-center justify-center bg-adam-bg-secondary-dark">
+          {isChatStreaming ? (
+            <Loader message="Generating model" />
+          ) : activePreview?.type === 'artifact' ? (
+            <OpenSCADPreview
+              scadCode={activePreview.artifact.code}
+              color="#00A6FF"
+              onOutputChange={setCurrentOutput}
+              onDxfExportChange={handleDxfExporterChange}
+              isMobile={true}
+              backgroundColor="#212121"
+            />
+          ) : activePreview?.type === 'mesh' ? (
+            <MeshPreview meshId={activePreview.meshId} />
+          ) : (
+            <div className="text-sm text-adam-text-secondary">
+              Send a message to start creating
+            </div>
+          )}
+        </div>
+      }
       parametersSlot={
         <div className="relative h-full">
           <ParameterSection
@@ -608,6 +657,19 @@ function ConversationEditor() {
             }
           />
         </div>
+      }
+      mobileParametersSlot={
+        <ParameterSheetContent
+          parameters={parameters}
+          onParameterChange={changeParameters}
+          currentOutput={currentOutput}
+          dxfExporter={dxfExporter}
+          code={
+            activePreview?.type === 'artifact'
+              ? activePreview.artifact.code
+              : undefined
+          }
+        />
       }
     />
   );

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -503,10 +503,10 @@ function ConversationEditor() {
     <ConversationView
       hasParameters={hasArtifact}
       mobilePreviewKey={
-        sharePreview
-          ? sharePreview.type === 'artifact'
-            ? `artifact:${sharePreview.messageId}`
-            : `mesh:${sharePreview.messageId}:${sharePreview.meshId}`
+        activePreview
+          ? activePreview.type === 'artifact'
+            ? `artifact:${activePreview.messageId}`
+            : `mesh:${activePreview.messageId}:${activePreview.meshId}`
           : null
       }
       mobilePreviewVersion={mobilePreviewVersion}

--- a/src/views/ShareView.tsx
+++ b/src/views/ShareView.tsx
@@ -1,6 +1,7 @@
 import { ChatTitle } from '@/components/chat/ChatTitle';
 import { MessageBubble } from '@/components/chat/MessageBubble';
 import { ParameterSection } from '@/components/parameter/ParameterSection';
+import { ParameterSheetContent } from '@/components/parameter/ParameterSheetContent';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { MeshPreview } from '@/components/viewer/MeshPreview';
 import { OpenSCADPreview } from '@/components/viewer/OpenSCADViewer';
@@ -138,6 +139,7 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
   const [activePreview, setActivePreview] = useState<ActivePreview>(null);
   const [parameters, setParameters] = useState<Parameter[]>([]);
   const [currentOutput, setCurrentOutput] = useState<Blob | undefined>();
+  const [mobilePreviewVersion, setMobilePreviewVersion] = useState(0);
   const baseCodeRef = useRef<string | null>(null);
 
   // Auto-switch the preview pane to the latest artifact / mesh in the
@@ -161,6 +163,7 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
         messageId: latest.messageId,
         artifact: latest.artifact,
       });
+      setMobilePreviewVersion((version) => version + 1);
     } else {
       setCurrentOutput(undefined);
       setActivePreview({
@@ -168,6 +171,7 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
         messageId: latest.messageId,
         meshId: latest.meshId,
       });
+      setMobilePreviewVersion((version) => version + 1);
     }
   }, [branch]);
 
@@ -177,12 +181,14 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
       setParameters(parseParameters(artifact.code));
       setCurrentOutput(undefined);
       setActivePreview({ type: 'artifact', messageId, artifact });
+      setMobilePreviewVersion((version) => version + 1);
     },
     [],
   );
   const handleViewMesh = useCallback((meshId: string, messageId: string) => {
     setCurrentOutput(undefined);
     setActivePreview({ type: 'mesh', messageId, meshId });
+    setMobilePreviewVersion((version) => version + 1);
   }, []);
 
   const changeParameters = useCallback(
@@ -210,6 +216,14 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
   return (
     <ConversationView
       hasParameters={hasArtifact}
+      mobilePreviewKey={
+        activePreview
+          ? activePreview.type === 'artifact'
+            ? `artifact:${activePreview.messageId}`
+            : `mesh:${activePreview.messageId}:${activePreview.meshId}`
+          : null
+      }
+      mobilePreviewVersion={mobilePreviewVersion}
       chatPanelSlot={
         <>
           <div className="flex w-full items-center justify-between bg-transparent p-3 pl-12">
@@ -229,8 +243,9 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
             </div>
           </div>
 
-          <ScrollArea className="min-h-0 flex-1 p-4">
-            <div className="mx-auto flex max-w-3xl flex-col gap-4">
+          <ScrollArea className="relative w-full max-w-xl flex-1 self-center px-2 py-0 md:min-h-0 md:max-w-none md:p-4">
+            <div className="pointer-events-none sticky left-0 top-0 z-50 mr-4 h-3 bg-gradient-to-b from-adam-bg-secondary-dark/90 to-transparent md:hidden" />
+            <div className="mx-auto flex max-w-3xl flex-col gap-4 pb-6 md:pb-0">
               {branch.map((node) => (
                 <MessageBubble
                   key={node.id}
@@ -264,6 +279,25 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
           )}
         </div>
       }
+      mobilePreviewSlot={
+        <div className="flex h-full w-full items-center justify-center bg-adam-bg-secondary-dark">
+          {activePreview?.type === 'artifact' ? (
+            <OpenSCADPreview
+              scadCode={activePreview.artifact.code}
+              color="#00A6FF"
+              onOutputChange={setCurrentOutput}
+              isMobile={true}
+              backgroundColor="#212121"
+            />
+          ) : activePreview?.type === 'mesh' ? (
+            <MeshPreview meshId={activePreview.meshId} />
+          ) : (
+            <div className="text-sm text-adam-text-secondary">
+              Nothing to preview yet
+            </div>
+          )}
+        </div>
+      }
       parametersSlot={
         <div className="relative h-full">
           <ParameterSection
@@ -278,6 +312,19 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
             }
           />
         </div>
+      }
+      mobileParametersSlot={
+        <ParameterSheetContent
+          parameters={parameters}
+          onParameterChange={changeParameters}
+          currentOutput={currentOutput}
+          dxfExporter={null}
+          code={
+            activePreview?.type === 'artifact'
+              ? activePreview.artifact.code
+              : undefined
+          }
+        />
       }
     />
   );

--- a/src/views/ShareView.tsx
+++ b/src/views/ShareView.tsx
@@ -244,7 +244,7 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
           </div>
 
           <ScrollArea className="relative w-full max-w-xl flex-1 self-center px-2 py-0 md:min-h-0 md:max-w-none md:p-4">
-            <div className="pointer-events-none sticky left-0 top-0 z-50 mr-4 h-3 bg-gradient-to-b from-adam-bg-secondary-dark/90 to-transparent md:hidden" />
+            <div className="pointer-events-none sticky left-0 top-0 z-50 h-3 bg-gradient-to-b from-adam-bg-secondary-dark/90 to-transparent md:hidden" />
             <div className="mx-auto flex max-w-3xl flex-col gap-4 pb-6 md:pb-0">
               {branch.map((node) => (
                 <MessageBubble


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves the mobile and tablet conversation experience with a draggable bottom sheet for preview and parameters, tighter chat layout on small screens, and simple export options.

- **New Features**
  - Bottom sheet on screens ≤1024px for model preview and parameters; supports drag-to-close and auto-opens when a preview is selected.
  - New `ParameterSheetContent` with debounced parameter updates and a download menu for .STL, .SCAD, and .DXF (with loading state and error toasts).
  - Mobile-only “New Creation” button in the editor header.

- **Bug Fixes**
  - Centered and constrained chat content on mobile (`max-w-xl`), adjusted spacing, and added a subtle sticky top fade for scroll context.
  - Unified mobile layout in editor and share views; fixed a drag-to-close reset race; refined the sheet handle and footer spacing; improved suggestion pill wrapping and scroll areas on small screens.
  - Updated mobile detection breakpoint to 1024px for more accurate detection.

<sup>Written for commit 53c268a17b1e12376ee15ed4dbb8c9d3e1e47921. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/167?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

