### PR TITLE
fix(parametric): guide OpenSCAD generation toward BOSL2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10249,6 +10249,24 @@
         }
       }
     },
+    "node_modules/nitro/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/nitro/node_modules/db0": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
@@ -10282,6 +10300,34 @@
         "sqlite3": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nitro/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/nitro/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/nitro/node_modules/unstorage": {

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -116,10 +116,12 @@ BOSL2 library guidance:
   grips, mouse shells, handles, fairings, smooth pocket traces), use BOSL2
   instead of stacking primitive cylinders/cubes. Include \`<BOSL2/skin.scad>\`
   for \`path_sweep()\` and \`skin()\`, \`<BOSL2/beziers.scad>\` for
-  \`bezier_curve()\` / \`bezpath_curve()\`, and \`<BOSL2/rounding.scad>\` for
+  \`bezier_curve()\` (single Bezier segment) and \`bezpath_curve()\`
+  (multi-segment Bezier path), and \`<BOSL2/rounding.scad>\` for
   \`round_corners()\` / \`offset_sweep()\`. Expose control points, radii, and
-  slice counts as parameters, and use \`$fn = 128;\` or higher for smooth
-  organic surfaces when appropriate.
+  slice counts as parameters, and use \`$fn = 48;\` as a preview-friendly
+  default; raise toward 96-128 only for final/export-quality renders or simple
+  shapes that still preview responsively.
 
 Parameters:
 - Declare every editable parameter as a top-of-file variable.

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -101,6 +101,26 @@ Geometry:
   be connected, and the model must be manifold and 3D-printable.
 - Use modules for repeated or meaningful model parts.
 
+BOSL2 library guidance:
+- BOSL2 is available to OpenSCAD code when the generated source includes the
+  literal token \`BOSL2\`. Include \`<BOSL2/std.scad>\` plus the specific module
+  file whenever the request needs a higher-level CAD primitive.
+- For screws, bolts, nuts, threaded rods, or tapped/threaded holes, use BOSL2
+  instead of trying to build threads from \`cylinder()\`, \`linear_extrude()\`,
+  or hand-rolled helices. Include \`<BOSL2/screws.scad>\` for \`screw()\`,
+  \`screw_hole()\`, and \`nut()\`; include \`<BOSL2/threading.scad>\` for
+  \`threaded_rod()\`, \`threaded_nut()\`, and custom thread profiles. Prefer
+  standard spec strings like \`"M6x1"\` or \`"#8-32"\`, expose diameter/length/
+  pitch as parameters, and set \`$fn = 64;\` or higher so threads resolve.
+- For organic, curved, swept, or lofted shapes (car panels, lights, ergonomic
+  grips, mouse shells, handles, fairings, smooth pocket traces), use BOSL2
+  instead of stacking primitive cylinders/cubes. Include \`<BOSL2/skin.scad>\`
+  for \`path_sweep()\` and \`skin()\`, \`<BOSL2/beziers.scad>\` for
+  \`bezier_curve()\` / \`bezpath_curve()\`, and \`<BOSL2/rounding.scad>\` for
+  \`round_corners()\` / \`offset_sweep()\`. Expose control points, radii, and
+  slice counts as parameters, and use \`$fn = 128;\` or higher for smooth
+  organic surfaces when appropriate.
+
 Parameters:
 - Declare every editable parameter as a top-of-file variable.
 - Use full descriptive snake_case names (e.g. \`wheel_radius\`, \`seat_offset\`) —


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Steers OpenSCAD generation to use the `BOSL2` library for threads and organic shapes. Produces more accurate hardware, smoother surfaces, and more printable models.

- **Bug Fixes**
  - Expand BOSL2 guidance in `src/server/aiChat.ts`: require the literal `BOSL2`; include `<BOSL2/std.scad>` and needed modules (`screws.scad`, `threading.scad`, `skin.scad`, `beziers.scad`, `rounding.scad`).
  - Route fasteners to BOSL2 (`screw()`, `screw_hole()`, `threaded_rod()`; use standard spec strings; `$fn ≥ 64`). Use `skin()`/`path_sweep()` plus `bezier_curve()`/`bezpath_curve()` and `round_corners()`/`offset_sweep()` for curved shapes; default `$fn = 48`, raise for final renders.

- **Dependencies**
  - Lockfile updated under `nitro`; adds optional peers `chokidar@5`, `readdirp@5`, and `lru-cache@11`.

<sup>Written for commit fadb5f7993e55d63611350305bc2e67cf2cc098a. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/168?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

