### PR TITLE
Bump free-tier daily copy 200 → 100

### DIFF
--- a/src/components/Subscriptions.tsx
+++ b/src/components/Subscriptions.tsx
@@ -102,7 +102,7 @@ function buildTier(
 }
 
 function creditsLines(tier: SubscriptionTier): string[] {
-  const daily = '200 free credits per day';
+  const daily = '100 free credits per day';
   if (tier.level === 'free') return [daily];
   const amount = tier.tokenAmount?.toLocaleString() ?? '';
   return [daily, `${amount} credits per month`];

--- a/src/components/UpgradeModal.tsx
+++ b/src/components/UpgradeModal.tsx
@@ -50,7 +50,7 @@ function findMonthly(
 }
 
 function creditsBadge(level: PlanLevel, product: BillingProduct | undefined) {
-  if (level === 'free') return '200 / day';
+  if (level === 'free') return '100 / day';
   const amount = product?.tokenAmount ?? 0;
   return `${amount.toLocaleString()} / mo`;
 }


### PR DESCRIPTION
## Summary
Paired with [adam-billing free-tier revert](https://github.com/Adam-CAD/adam-billing/pull/12).

- `src/components/UpgradeModal.tsx`: \`'200 / day'\` → \`'100 / day'\`
- `src/components/Subscriptions.tsx`: \`'200 free credits per day'\` → \`'100 free credits per day'\`

## Test plan
- [ ] Open UpgradeModal — free tier badge says \"100 / day\"
- [ ] Open Subscriptions / `/cadam/subscription` — free tier card says \"100 free credits per day\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the displayed free-tier allowance from 200/day to 100/day to match the billing change. Updates the free plan badge in UpgradeModal and the free-tier description on the Subscriptions page.

<sup>Written for commit 29ae9959bdaf3698a9f01e5bfed9d35c0c6ac500. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/170?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

