### PR TITLE
Restore mobile layout sizing

### DIFF
--- a/src/components/chat/ChatSession.tsx
+++ b/src/components/chat/ChatSession.tsx
@@ -695,7 +695,7 @@ export function ChatSession({
   return (
     <>
       <ScrollArea
-        className="relative w-full max-w-xl flex-1 self-center px-2 py-0 md:min-h-0 md:max-w-none md:p-4"
+        className="relative w-full max-w-none flex-1 self-center px-3 py-0 md:min-h-0 md:p-4"
         ref={scrollRef}
       >
         <div className="pointer-events-none sticky left-0 top-0 z-50 h-3 bg-gradient-to-b from-adam-bg-secondary-dark/90 to-transparent md:hidden" />
@@ -736,7 +736,7 @@ export function ChatSession({
         </div>
       </ScrollArea>
 
-      <div className="w-full shrink-0 self-center px-4 pb-6 md:pb-4">
+      <div className="w-full shrink-0 self-center px-3 pb-[calc(1rem+env(safe-area-inset-bottom))] sm:px-4 md:pb-4">
         {/* Suggestions are conversation-level — the server writes them
             to `conversation.settings.suggestions` and emits a transient
             `data-suggestions-update` on each non-tool-call assistant
@@ -745,7 +745,7 @@ export function ChatSession({
             flight; the freshly-arrived pills replace the stale ones
             when streaming finishes. */}
         {!isLoading && (
-          <div className="mx-auto max-w-xl pt-1 md:max-w-3xl">
+          <div className="mx-auto max-w-3xl pt-1">
             <SuggestionPills
               suggestions={conversation.settings?.suggestions ?? []}
               onSelect={(suggestion) =>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -29,6 +29,11 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
+        <meta charSet="UTF-8" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+        />
         <link rel="icon" type="image/x-icon" href={assetUrl('adam-icon.ico')} />
         <HeadContent />
       </head>

--- a/src/views/ConversationView.tsx
+++ b/src/views/ConversationView.tsx
@@ -285,7 +285,7 @@ export function ConversationView({
                   />
                 </svg>
               </button>
-              <div className="mx-auto flex h-full max-w-xl flex-col items-center pb-6">
+              <div className="mx-auto flex h-full w-full max-w-none flex-col items-center pb-6">
                 <div
                   className={cn(
                     'w-full px-4',

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -515,7 +515,7 @@ function ConversationEditor() {
           {/* `pl-12` reserves space for the rotated "Chat" expand button
               that sits in the left gutter when the chat panel is collapsed,
               so the title and share button don't get covered. */}
-          <div className="flex w-full items-center justify-between bg-transparent p-3 pl-12">
+          <div className="flex w-full items-center justify-between bg-transparent p-3 md:pl-12">
             <div className="flex min-w-0 flex-1 items-center space-x-2">
               <div className="min-w-0 flex-1">
                 <ChatTitle

--- a/src/views/ShareView.tsx
+++ b/src/views/ShareView.tsx
@@ -226,7 +226,7 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
       mobilePreviewVersion={mobilePreviewVersion}
       chatPanelSlot={
         <>
-          <div className="flex w-full items-center justify-between bg-transparent p-3 pl-12">
+          <div className="flex w-full items-center justify-between bg-transparent p-3 md:pl-12">
             <div className="min-w-0 flex-1">
               <ChatTitle
                 activeMeshId={
@@ -243,7 +243,7 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
             </div>
           </div>
 
-          <ScrollArea className="relative w-full max-w-xl flex-1 self-center px-2 py-0 md:min-h-0 md:max-w-none md:p-4">
+          <ScrollArea className="relative w-full max-w-none flex-1 self-center px-3 py-0 md:min-h-0 md:p-4">
             <div className="pointer-events-none sticky left-0 top-0 z-50 h-3 bg-gradient-to-b from-adam-bg-secondary-dark/90 to-transparent md:hidden" />
             <div className="mx-auto flex max-w-3xl flex-col gap-4 pb-6 md:pb-0">
               {branch.map((node) => (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores proper mobile layout sizing and safe-area handling across chat, editor, and share views. Content is full-width on phones and the input avoids the notch/home indicator.

- **Bug Fixes**
  - Removed mobile width caps on chat/share scroll areas; standardized mobile padding to px-3 and kept desktop constraints via max-w-3xl.
  - Added `<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">` and used `env(safe-area-inset-bottom)` for bottom padding to prevent input overlap.
  - Limited the side gutter (`pl-12`) to `md+` and set conversation containers to `w-full max-w-none` to maximize mobile space.

<sup>Written for commit 4d0a9d6e607cc775fbb8a2cde361ea8ab022ad2e. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/171?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

