### PR TITLE
Limit chat suggestions to two

### DIFF
--- a/shared/suggestions.test.ts
+++ b/shared/suggestions.test.ts
@@ -32,7 +32,7 @@ describe('suggestion word limits', () => {
         '  add screw holes  ',
         'increase wall thickness',
       ]),
-      ['add fillets', 'add screw holes', 'increase wall thickness'],
+      ['add fillets', 'add screw holes'],
     );
   });
 
@@ -44,18 +44,18 @@ describe('suggestion word limits', () => {
         'add screw holes',
         'increase wall thickness',
       ]),
-      ['add fillets', 'add screw holes', 'increase wall thickness'],
+      ['add fillets', 'add screw holes'],
     );
   });
 
-  it('truncates invalid suggestions only when needed to fill three slots', () => {
+  it('truncates invalid suggestions only when needed to fill two slots', () => {
     assert.deepEqual(
       normalizeConversationSuggestions([
         'add chamfers',
         'make the handle much larger',
         'add four mounting holes',
       ]),
-      ['add chamfers', 'make the handle', 'add four mounting'],
+      ['add chamfers', 'make the handle'],
     );
   });
 });

--- a/shared/suggestions.ts
+++ b/shared/suggestions.ts
@@ -1,5 +1,5 @@
 const MAX_SUGGESTION_WORDS = 3;
-const MAX_SUGGESTIONS = 3;
+const MAX_SUGGESTIONS = 2;
 
 export function countSuggestionWords(suggestion: string): number {
   const trimmed = suggestion.trim();

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -561,7 +561,7 @@ async function generateConversationTitle({
 }
 
 /**
- * Produce ~3 short follow-up suggestions for the user's NEXT prompt, given
+ * Produce ~2 short follow-up suggestions for the user's NEXT prompt, given
  * the current branch. Used as transient `data-suggestions-update` parts —
  * the conversation-level pills below the input. Suggestions are
  * conversation-scoped (not per-message) because that's how they appear in
@@ -594,8 +594,8 @@ async function generateConversationSuggestions({
       model: anthropic('claude-haiku-4-5'),
       system:
         conversationType === 'creative'
-          ? 'Given a 3D mesh design conversation, return an array of exactly 3 follow-up prompts the user might want to send next. Each prompt is a concise instruction of 3 words or fewer, not a question. Return exactly 3 items — no more, no fewer.'
-          : 'Given a parametric CAD conversation, return an array of exactly 3 follow-up prompts the user might want to send next. Each prompt is a concise instruction of 3 words or fewer, not a question. Return exactly 3 items — no more, no fewer.',
+          ? 'Given a 3D mesh design conversation, return an array of exactly 2 follow-up prompts the user might want to send next. Each prompt is a concise instruction of 3 words or fewer, not a question. Return exactly 2 items — no more, no fewer.'
+          : 'Given a parametric CAD conversation, return an array of exactly 2 follow-up prompts the user might want to send next. Each prompt is a concise instruction of 3 words or fewer, not a question. Return exactly 2 items — no more, no fewer.',
       prompt: summary,
       output: Output.object({
         schema: z.object({

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -599,7 +599,7 @@ async function generateConversationSuggestions({
       prompt: summary,
       output: Output.object({
         schema: z.object({
-          suggestions: z.array(z.string().min(1).max(80)),
+          suggestions: z.array(z.string().min(1).max(80)).length(2),
         }),
       }),
     });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Limit follow-up chat suggestions to two to reduce clutter and make next steps clearer. Sets `MAX_SUGGESTIONS = 2`, updates prompts to require exactly two, enforces length via schema validation, and updates normalization/tests.

<sup>Written for commit d7d926ae7efabc96ab9a36369a54daa37c376ea8. Summary will update on new commits. <a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/172?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

