### PR TITLE
Update Claude Opus model to 4.8

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -246,8 +246,8 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'anthropic/claude-opus-4.7',
-    name: 'Claude Opus 4.7',
+    id: 'anthropic/claude-opus-4.8',
+    name: 'Claude Opus 4.8',
     description: 'Most powerful Anthropic model for complex reasoning',
     provider: 'Anthropic',
     supportsTools: true,

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -44,7 +44,7 @@ const MODEL_PRICES: Record<
   { input: number; output: number; cacheRead?: number; cacheWrite?: number }
 > = {
   // Anthropic
-  'anthropic/claude-opus-4.7': { input: 15, output: 75 },
+  'anthropic/claude-opus-4.8': { input: 5, output: 25 },
   'anthropic/claude-opus-4': { input: 15, output: 75 },
   'anthropic/claude-sonnet-4.6': { input: 3, output: 15 },
   'anthropic/claude-sonnet-4.5': { input: 3, output: 15 },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch to `anthropic/claude-opus-4.8` and update pricing (input: 5, output: 25), reducing cost vs 4.7.

<sup>Written for commit 0e420aa1f0de016a366c40f61f5893806983627e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/173?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

