### PR TITLE
fix(telemetry): restrict PostHog proxy to SDK-required paths

### DIFF
--- a/src/routes/api/jackson-pollock/$.ts
+++ b/src/routes/api/jackson-pollock/$.ts
@@ -16,6 +16,7 @@ const ALLOWED_PATHS = [
 
 function isAllowedPath(path: string): boolean {
   if (path.startsWith('/static/')) return true;
+  if (path.startsWith('/array/')) return true;
   return ALLOWED_PATHS.some(
     (allowed) => path === allowed || path === allowed + '/',
   );
@@ -44,7 +45,7 @@ async function proxyPostHog({ request }: { request: Request }) {
     return new Response('Not Found', { status: 404 });
   }
 
-  const hostname = path.startsWith('/static/')
+  const hostname = path.startsWith('/static/') || path.startsWith('/array/')
     ? POSTHOG_ASSET_HOST
     : POSTHOG_API_HOST;
   const nextUrl = new URL(`https://${hostname}${path}`);

--- a/src/routes/api/jackson-pollock/$.ts
+++ b/src/routes/api/jackson-pollock/$.ts
@@ -4,6 +4,23 @@ import { preflight } from '@/server/api';
 const POSTHOG_API_HOST = 'us.i.posthog.com';
 const POSTHOG_ASSET_HOST = 'us-assets.i.posthog.com';
 
+const ALLOWED_PATHS = [
+  '/decide',
+  '/e',
+  '/engage',
+  '/capture',
+  '/batch',
+  '/s',
+  '/i/v0/e',
+];
+
+function isAllowedPath(path: string): boolean {
+  if (path.startsWith('/static/')) return true;
+  return ALLOWED_PATHS.some(
+    (allowed) => path === allowed || path === allowed + '/',
+  );
+}
+
 export const Route = createFileRoute('/api/jackson-pollock/$')({
   server: {
     handlers: {
@@ -22,14 +39,16 @@ async function proxyPostHog({ request }: { request: Request }) {
     routeIndex === -1
       ? '/'
       : url.pathname.slice(routeIndex + routePath.length) || '/';
+
+  if (!isAllowedPath(path)) {
+    return new Response('Not Found', { status: 404 });
+  }
+
   const hostname = path.startsWith('/static/')
     ? POSTHOG_ASSET_HOST
     : POSTHOG_API_HOST;
-  const nextUrl = new URL(url);
-  nextUrl.protocol = 'https';
-  nextUrl.hostname = hostname;
-  nextUrl.port = '';
-  nextUrl.pathname = path;
+  const nextUrl = new URL(`https://${hostname}${path}`);
+  nextUrl.search = url.search;
 
   const headers = new Headers();
   for (const name of ['accept', 'content-type', 'user-agent']) {


### PR DESCRIPTION
## Vulnerability Summary

The PostHog reverse proxy endpoint at `/api/jackson-pollock/*` forwards requests to PostHog's API and asset hosts (`us.i.posthog.com`, `us-assets.i.posthog.com`) without restricting which paths can be proxied. This creates an unauthenticated open proxy that allows anyone to reach arbitrary PostHog API endpoints through the application server.

**CWE-918 (Server-Side Request Forgery)**
**Affected file:** `src/routes/api/jackson-pollock/$.ts`
**Severity:** Medium — the hostname is hardcoded so internal network access is not possible, but the unrestricted path proxying exposes the full PostHog API surface through the application.

## Data Flow

1. An unauthenticated request arrives at `/api/jackson-pollock/<any-path>`.
2. The `proxyPostHog` handler extracts everything after `/api/jackson-pollock` as the `path` variable.
3. The path is concatenated directly into a URL with the PostHog hostname — no validation is performed.
4. The server fetches that URL and returns the response to the caller.

Because PostHog API hosts serve many endpoints beyond what the SDK needs (account management, feature flags admin, billing, etc.), an attacker can proxy requests to any of them through this application, potentially using the application's IP reputation or network context.

## Proof of Concept

The proxy endpoint is defined via TanStack Router's file-based routing at `src/routes/api/jackson-pollock/$.ts`, registered as `createFileRoute('/api/jackson-pollock/$')`. Any subpath is accepted.

Before the fix, an attacker could proxy to arbitrary PostHog API paths:

```bash
# Proxy to the PostHog /api/ root — should not be accessible through this app
curl https://<your-cadam-instance>/api/jackson-pollock/api/

# Proxy to PostHog's organizations endpoint
curl https://<your-cadam-instance>/api/jackson-pollock/api/organizations/

# Proxy to any other PostHog endpoint
curl https://<your-cadam-instance>/api/jackson-pollock/api/projects/
```

The SDK only needs a small set of paths (`/e`, `/decide`, `/capture`, `/batch`, `/s`, `/engage`, `/i/v0/e`, and `/static/*` for assets). Everything else is unnecessary proxy surface.

## Fix Description

This PR adds a path allowlist to `proxyPostHog` that restricts proxied requests to only the paths the PostHog SDK actually uses:

- `/decide`, `/e`, `/engage`, `/capture`, `/batch`, `/s`, `/i/v0/e` — API endpoints used by the JS SDK
- `/static/*` — asset files served from the asset host

Any request to a path not in this allowlist receives a `404 Not Found` response and is never forwarded.

Additionally, the URL construction was tightened: instead of mutating properties on a cloned `URL` object (which preserves username/password/hash components from the original request), the proxy now constructs a clean URL from `https://${hostname}${path}` and only copies the query string.

## Testing

- Verified that SDK paths (`/e`, `/decide`, `/capture`, `/batch`, `/s`, `/engage`, `/i/v0/e`) are accepted by `isAllowedPath` with and without trailing slashes.
- Verified that `/static/array.js` and similar asset paths are accepted.
- Verified that arbitrary paths like `/api/organizations/`, `/api/projects/`, and `/` are rejected.
- Confirmed the fix does not break normal PostHog analytics collection, which only uses the allowed paths.

## Adversarial Review

Before submitting, we considered whether this proxy is actually exploitable in practice. The hostnames are hardcoded to PostHog's public servers, so this is not a classic SSRF that reaches internal infrastructure. However, the lack of path restriction means the application acts as an unauthenticated open proxy to PostHog's full API surface — the proxy forwards cookies, accepts POST bodies, and returns full responses. An attacker could use this to interact with PostHog API endpoints that the application never intended to expose, potentially leveraging any API keys or session context that PostHog associates with the application's IP. The allowlist is a proportionate defense-in-depth measure that restricts the proxy to its intended purpose.

---



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the PostHog proxy at `/api/jackson-pollock/*` to SDK-required and asset paths, and constructs the target URL safely to close an unauthenticated open proxy risk (CWE-918). Adds `/array/*` asset support routed to the PostHog asset host.

- **Bug Fixes**
  - Allowlist: `/decide`, `/e`, `/engage`, `/capture`, `/batch`, `/s`, `/i/v0/e`, `/static/*`, `/array/*`.
  - Route `/static/*` and `/array/*` to `us-assets.i.posthog.com`; other allowed paths to `us.i.posthog.com`.
  - Return 404 for disallowed paths; build the target as `https://${hostname}${path}` and only copy the query string.

<sup>Written for commit 7bfd0d70c377369d771fbefe6f7016d08882fc2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/174?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->