### PR TITLE
Fix chat tool result continuation race

### DIFF
--- a/src/components/chat/ChatSession.tsx
+++ b/src/components/chat/ChatSession.tsx
@@ -255,13 +255,6 @@ export function ChatSession({
       // subsequent send because the server can't continue a
       // conversation with an unresolved tool call).
       const finishWithError = async (errorText: string) => {
-        chat.addToolOutput({
-          state: 'output-error',
-          tool: 'build_parametric_model',
-          toolCallId: toolCall.toolCallId,
-          errorText,
-        });
-        if (!assistant) return;
         const errorPart = {
           type: 'tool-build_parametric_model',
           toolCallId: toolCall.toolCallId,
@@ -270,12 +263,20 @@ export function ChatSession({
           errorText,
         } as AppUIMessage['parts'][number];
         const nextParts = buildNextParts(errorPart);
-        if (!nextParts) return;
-        try {
+
+        // `addToolOutput` immediately triggers the SDK's auto-continuation.
+        // Persist first so the server sees the matching tool result when it
+        // reloads the branch from the DB.
+        if (assistant && nextParts) {
           await onToolOutput(assistant.id, nextParts);
-        } catch (persistError) {
-          console.warn('Failed to persist tool error to DB:', persistError);
         }
+
+        chat.addToolOutput({
+          state: 'output-error',
+          tool: 'build_parametric_model',
+          toolCallId: toolCall.toolCallId,
+          errorText,
+        });
       };
 
       const input = isParametricArtifact(toolCall.input)
@@ -341,11 +342,7 @@ export function ChatSession({
         const nextParts = buildNextParts(successPart);
 
         if (nextParts && assistant) {
-          try {
-            await onToolOutput(assistant.id, nextParts);
-          } catch (persistError) {
-            console.warn('Failed to persist tool output to DB:', persistError);
-          }
+          await onToolOutput(assistant.id, nextParts);
         }
 
         chat.addToolOutput({

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -459,6 +459,39 @@ function finalizeStreamingParts(
   });
 }
 
+function normalizeIncompleteToolCalls(
+  messages: AppUIMessage[],
+): AppUIMessage[] {
+  return messages.map((message) => {
+    if (message.role !== 'assistant') return message;
+
+    let dirty = false;
+    const parts = message.parts.map((part) => {
+      if (
+        part.type === 'tool-build_parametric_model' &&
+        part.state === 'input-available'
+      ) {
+        dirty = true;
+        return {
+          ...part,
+          state: 'output-error' as const,
+          errorText: 'Tool execution did not complete.',
+        };
+      }
+      if (
+        (part.type === 'reasoning' || part.type === 'text') &&
+        part.state === 'streaming'
+      ) {
+        dirty = true;
+        return { ...part, state: 'done' as const };
+      }
+      return part;
+    }) as AppUIMessage['parts'];
+
+    return dirty ? { ...message, parts } : message;
+  });
+}
+
 function messageRowToUIMessage(row: BranchMessageRow): AppUIMessage {
   return {
     id: row.id,
@@ -881,9 +914,10 @@ export async function handleAiChatRequest(req: Request) {
   // parallel with the model stream instead of blocking it. Only fires on
   // the very first user turn.
   const isFirstUserTurn = branchMessages.length === 1 && leafRole === 'user';
+  const modelBranchMessages = normalizeIncompleteToolCalls(branchMessages);
 
   const modelMessages = await convertToModelMessages<AppUIMessage>(
-    branchMessages,
+    modelBranchMessages,
     {
       tools,
       convertDataPart: (part) => {
@@ -1047,7 +1081,7 @@ export async function handleAiChatRequest(req: Request) {
 
       writer.merge(
         result.toUIMessageStream<AppUIMessage>({
-          originalMessages: branchMessages,
+          originalMessages: modelBranchMessages,
           generateMessageId: () => crypto.randomUUID(),
           onFinish: async ({ responseMessage, isContinuation }) => {
             const usage = await result.totalUsage;
@@ -1159,7 +1193,7 @@ export async function handleAiChatRequest(req: Request) {
                 supabaseClient,
                 conversation,
                 branch: [
-                  ...branchMessages,
+                  ...modelBranchMessages,
                   { ...responseMessage, parts: finalizedParts },
                 ],
               });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a race where chat auto-continuation could run before a tool result was persisted, causing mismatched tool calls and stuck threads. Also hardens server recovery by normalizing incomplete messages before continuing.

- **Bug Fixes**
  - Persist tool output with `onToolOutput` before calling `chat.addToolOutput` to ensure the server sees the matching result when auto-continuation triggers.
  - Add server-side `normalizeIncompleteToolCalls` to:
    - Convert `tool-build_parametric_model` parts stuck at `input-available` to `output-error` with a clear message.
    - Finalize `reasoning` and `text` parts stuck in `streaming` to `done`.
  - Use normalized messages for model input, streaming, and persistence paths to avoid continuing from inconsistent states.

<sup>Written for commit fdf2730abd67b0c18261e83d4c94417600a44cf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/175?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

