### PR TITLE
feat(parametric): add annotated design tree viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,30 @@
 | **Smart Updates**          | Efficient parameter changes without AI re-generation |
 | **Custom Fonts**           | Built-in Geist font support for text in models       |
 
+## Design Tree Annotations
+
+CADAM can show a lightweight design tree for OpenSCAD models that include
+structured `@cadam-node` line comments. This first pass is source-driven: it
+does not map nodes to mesh faces or viewport selection.
+
+Supported JSON fields are `id` (required string), `kind` (required: `part`,
+`operation`, `group`, or `parameter`), `name`, `parentId`, `params`, and
+`moduleName`. `name` defaults to `id`, and `params` should be a string array.
+
+```scad
+width = 40; // [10:80]
+height = 12; // [4:30]
+
+// @cadam-node {"id":"base","kind":"part","name":"Base","params":["width","height"],"moduleName":"base"}
+module base() {
+  cube([width, 20, height]);
+}
+
+base();
+```
+
+See issue #139 for the initial design tree viewer scope.
+
 ## 📸 Demo
 
 <!-- Add demo GIFs or screenshots here -->

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint . --ignore-pattern 'supabase/**'",
-    "test:design-tree": "node --test --experimental-strip-types shared/parseDesignTree.test.ts",
     "typecheck": "tsc -b --noEmit",
     "format": "prettier --write .",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint . --ignore-pattern 'supabase/**'",
+    "test:design-tree": "node --test --experimental-strip-types shared/parseDesignTree.test.ts",
     "typecheck": "tsc -b --noEmit",
     "format": "prettier --write .",
     "preview": "vite preview",

--- a/shared/parseDesignTree.test.ts
+++ b/shared/parseDesignTree.test.ts
@@ -90,6 +90,19 @@ describe('parseDesignTree', () => {
     assert.equal(result.warnings[0].kind, 'sketch');
   });
 
+  it('returns a warning for non-string params entries', () => {
+    const result = parseDesignTree(
+      '// @cadam-node {"id":"base","kind":"part","params":["width",42,"height"]}',
+    );
+
+    assert.deepEqual(result.nodes, [
+      { id: 'base', kind: 'part', name: 'base', params: ['width', 'height'] },
+    ]);
+    assert.equal(result.warnings.length, 1);
+    assert.equal(result.warnings[0].code, 'invalid-param-entry');
+    assert.equal(result.warnings[0].id, 'base');
+  });
+
   it('returns an empty result when there are no annotations', () => {
     const result = parseDesignTree(`
 width = 10;

--- a/shared/parseDesignTree.test.ts
+++ b/shared/parseDesignTree.test.ts
@@ -70,6 +70,15 @@ describe('parseDesignTree', () => {
     assert.equal(result.warnings[0].code, 'missing-id');
   });
 
+  it('returns a warning for missing kind', () => {
+    const result = parseDesignTree('// @cadam-node {"id":"base"}');
+
+    assert.deepEqual(result.nodes, []);
+    assert.equal(result.warnings.length, 1);
+    assert.equal(result.warnings[0].code, 'missing-kind');
+    assert.equal(result.warnings[0].id, 'base');
+  });
+
   it('returns a warning for unknown kind', () => {
     const result = parseDesignTree(
       '// @cadam-node {"id":"base","kind":"sketch"}',

--- a/shared/parseDesignTree.test.ts
+++ b/shared/parseDesignTree.test.ts
@@ -103,6 +103,34 @@ describe('parseDesignTree', () => {
     assert.equal(result.warnings[0].id, 'base');
   });
 
+  it('returns a warning for a dangling parentId', () => {
+    const result = parseDesignTree(
+      '// @cadam-node {"id":"child","kind":"part","parentId":"missing"}',
+    );
+
+    assert.deepEqual(result.nodes, [
+      { id: 'child', kind: 'part', name: 'child', parentId: 'missing' },
+    ]);
+    assert.equal(result.warnings.length, 1);
+    assert.equal(result.warnings[0].code, 'missing-parent');
+    assert.equal(result.warnings[0].id, 'child');
+    assert.equal(result.warnings[0].parentId, 'missing');
+  });
+
+  it('returns a warning for a circular parentId cycle', () => {
+    const result = parseDesignTree(`
+// @cadam-node {"id":"a","kind":"part","parentId":"b"}
+// @cadam-node {"id":"b","kind":"part","parentId":"a"}
+`);
+
+    assert.deepEqual(result.nodes, [
+      { id: 'a', kind: 'part', name: 'a', parentId: 'b' },
+      { id: 'b', kind: 'part', name: 'b', parentId: 'a' },
+    ]);
+    assert.equal(result.warnings.length, 1);
+    assert.equal(result.warnings[0].code, 'circular-parent');
+  });
+
   it('returns an empty result when there are no annotations', () => {
     const result = parseDesignTree(`
 width = 10;

--- a/shared/parseDesignTree.test.ts
+++ b/shared/parseDesignTree.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import parseDesignTree from './parseDesignTree.ts';
+
+describe('parseDesignTree', () => {
+  it('parses a valid single node', () => {
+    const result = parseDesignTree(
+      '// @cadam-node {"id":"base","kind":"part","name":"Base","params":["width","height"],"moduleName":"base"}',
+    );
+
+    assert.deepEqual(result, {
+      nodes: [
+        {
+          id: 'base',
+          kind: 'part',
+          name: 'Base',
+          params: ['width', 'height'],
+          moduleName: 'base',
+        },
+      ],
+      warnings: [],
+    });
+  });
+
+  it('parses valid parent and child nodes', () => {
+    const result = parseDesignTree(`
+// @cadam-node {"id":"assembly","kind":"group","name":"Assembly"}
+// @cadam-node {"id":"base-cut","kind":"operation","name":"Base cut","parentId":"assembly"}
+`);
+
+    assert.deepEqual(result.nodes, [
+      { id: 'assembly', kind: 'group', name: 'Assembly' },
+      {
+        id: 'base-cut',
+        kind: 'operation',
+        name: 'Base cut',
+        parentId: 'assembly',
+      },
+    ]);
+    assert.deepEqual(result.warnings, []);
+  });
+
+  it('returns a warning for invalid JSON', () => {
+    const result = parseDesignTree('// @cadam-node {"id":"base","kind":"part"');
+
+    assert.deepEqual(result.nodes, []);
+    assert.equal(result.warnings.length, 1);
+    assert.equal(result.warnings[0].code, 'invalid-json');
+  });
+
+  it('returns a warning for duplicate ids', () => {
+    const result = parseDesignTree(`
+// @cadam-node {"id":"base","kind":"part"}
+// @cadam-node {"id":"base","kind":"operation"}
+`);
+
+    assert.deepEqual(result.nodes, [
+      { id: 'base', kind: 'part', name: 'base' },
+    ]);
+    assert.equal(result.warnings.length, 1);
+    assert.equal(result.warnings[0].code, 'duplicate-id');
+    assert.equal(result.warnings[0].id, 'base');
+  });
+
+  it('returns a warning for missing id', () => {
+    const result = parseDesignTree('// @cadam-node {"kind":"part"}');
+
+    assert.deepEqual(result.nodes, []);
+    assert.equal(result.warnings.length, 1);
+    assert.equal(result.warnings[0].code, 'missing-id');
+  });
+
+  it('returns a warning for unknown kind', () => {
+    const result = parseDesignTree(
+      '// @cadam-node {"id":"base","kind":"sketch"}',
+    );
+
+    assert.deepEqual(result.nodes, []);
+    assert.equal(result.warnings.length, 1);
+    assert.equal(result.warnings[0].code, 'unknown-kind');
+    assert.equal(result.warnings[0].kind, 'sketch');
+  });
+
+  it('returns an empty result when there are no annotations', () => {
+    const result = parseDesignTree(`
+width = 10;
+module base() {
+  cube([width, 20, 5]);
+}
+`);
+
+    assert.deepEqual(result, { nodes: [], warnings: [] });
+  });
+});

--- a/shared/parseDesignTree.ts
+++ b/shared/parseDesignTree.ts
@@ -22,12 +22,18 @@ type CadamNodePayload = {
   moduleName?: unknown;
 };
 
+type CadamNodeSource = {
+  line: number;
+  raw: string;
+};
+
 export default function parseDesignTree(
   source: string,
 ): CadamDesignTreeParseResult {
   const nodes: CadamDesignTreeNode[] = [];
   const warnings: CadamDesignTreeParseWarning[] = [];
   const seenIds = new Set<string>();
+  const nodeSources = new Map<string, CadamNodeSource>();
 
   let match: RegExpExecArray | null;
   while ((match = CADAM_NODE_COMMENT_REGEX.exec(source)) !== null) {
@@ -128,9 +134,71 @@ export default function parseDesignTree(
     if (moduleName) node.moduleName = moduleName;
 
     nodes.push(node);
+    nodeSources.set(id, { line, raw });
   }
 
+  validateParentLinks(nodes, warnings, nodeSources);
+
   return { nodes, warnings };
+}
+
+function validateParentLinks(
+  nodes: CadamDesignTreeNode[],
+  warnings: CadamDesignTreeParseWarning[],
+  nodeSources: Map<string, CadamNodeSource>,
+) {
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+
+  for (const node of nodes) {
+    if (!node.parentId || byId.has(node.parentId)) continue;
+    const source = nodeSources.get(node.id);
+    warnings.push({
+      code: 'missing-parent',
+      message: `@cadam-node parentId "${node.parentId}" does not match another node.`,
+      line: source?.line ?? 0,
+      raw: source?.raw ?? '',
+      id: node.id,
+      parentId: node.parentId,
+    });
+  }
+
+  const warnedCycles = new Set<string>();
+  for (const node of nodes) {
+    const path: string[] = [];
+    const pathIndex = new Map<string, number>();
+    let currentId: string | undefined = node.id;
+
+    while (currentId) {
+      const existingIndex = pathIndex.get(currentId);
+      if (existingIndex !== undefined) {
+        const cycleIds = path.slice(existingIndex);
+        const cycleKey = [...cycleIds].sort().join('\0');
+        if (!warnedCycles.has(cycleKey)) {
+          warnedCycles.add(cycleKey);
+          const warningNode = byId.get(cycleIds[0]);
+          const source = warningNode
+            ? nodeSources.get(warningNode.id)
+            : undefined;
+          warnings.push({
+            code: 'circular-parent',
+            message: `@cadam-node parentId chain contains a cycle: ${cycleIds.join(' -> ')}.`,
+            line: source?.line ?? 0,
+            raw: source?.raw ?? '',
+            id: warningNode?.id,
+            parentId: warningNode?.parentId,
+          });
+        }
+        break;
+      }
+
+      pathIndex.set(currentId, path.length);
+      path.push(currentId);
+
+      const current = byId.get(currentId);
+      if (!current?.parentId || !byId.has(current.parentId)) break;
+      currentId = current.parentId;
+    }
+  }
 }
 
 function isKnownNodeKind(kind: string): kind is CadamDesignTreeNodeKind {

--- a/shared/parseDesignTree.ts
+++ b/shared/parseDesignTree.ts
@@ -6,7 +6,7 @@ import type {
 } from './types.ts';
 
 const CADAM_NODE_COMMENT_REGEX = /^\s*\/\/\s*@cadam-node\s+(.+?)\s*$/gm;
-const KNOWN_NODE_KINDS = new Set<CadamDesignTreeNodeKind>([
+const KNOWN_NODE_KINDS = new Set<string>([
   'part',
   'operation',
   'group',
@@ -113,8 +113,17 @@ export default function parseDesignTree(
     };
     const parentId = stringOrUndefined(payload.parentId);
     if (parentId) node.parentId = parentId;
-    const params = stringArrayOrUndefined(payload.params);
-    if (params) node.params = params;
+    const params = stringArrayResult(payload.params);
+    if (params?.hasInvalidEntry) {
+      warnings.push({
+        code: 'invalid-param-entry',
+        message: '@cadam-node params must contain only strings.',
+        line,
+        raw,
+        id,
+      });
+    }
+    if (params && params.values.length > 0) node.params = params.values;
     const moduleName = stringOrUndefined(payload.moduleName);
     if (moduleName) node.moduleName = moduleName;
 
@@ -125,7 +134,7 @@ export default function parseDesignTree(
 }
 
 function isKnownNodeKind(kind: string): kind is CadamDesignTreeNodeKind {
-  return KNOWN_NODE_KINDS.has(kind as CadamDesignTreeNodeKind);
+  return KNOWN_NODE_KINDS.has(kind);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -138,12 +147,12 @@ function stringOrUndefined(value: unknown) {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function stringArrayOrUndefined(value: unknown) {
+function stringArrayResult(value: unknown) {
   if (!Array.isArray(value)) return undefined;
-  const strings = value.filter(
+  const values = value.filter(
     (item): item is string => typeof item === 'string',
   );
-  return strings.length > 0 ? strings : undefined;
+  return { values, hasInvalidEntry: values.length !== value.length };
 }
 
 function lineNumberForIndex(source: string, index: number) {

--- a/shared/parseDesignTree.ts
+++ b/shared/parseDesignTree.ts
@@ -1,0 +1,151 @@
+import type {
+  CadamDesignTreeNode,
+  CadamDesignTreeNodeKind,
+  CadamDesignTreeParseResult,
+  CadamDesignTreeParseWarning,
+} from './types.ts';
+
+const CADAM_NODE_COMMENT_REGEX = /^\s*\/\/\s*@cadam-node\s+(.+?)\s*$/gm;
+const KNOWN_NODE_KINDS = new Set<CadamDesignTreeNodeKind>([
+  'part',
+  'operation',
+  'group',
+  'parameter',
+]);
+
+type CadamNodePayload = {
+  id?: unknown;
+  kind?: unknown;
+  name?: unknown;
+  parentId?: unknown;
+  params?: unknown;
+  moduleName?: unknown;
+};
+
+export default function parseDesignTree(
+  source: string,
+): CadamDesignTreeParseResult {
+  const nodes: CadamDesignTreeNode[] = [];
+  const warnings: CadamDesignTreeParseWarning[] = [];
+  const seenIds = new Set<string>();
+
+  let match: RegExpExecArray | null;
+  while ((match = CADAM_NODE_COMMENT_REGEX.exec(source)) !== null) {
+    const raw = match[0];
+    const json = match[1].trim();
+    const line = lineNumberForIndex(source, match.index);
+    let payload: CadamNodePayload;
+
+    try {
+      const parsed: unknown = JSON.parse(json);
+      if (!isRecord(parsed)) {
+        warnings.push({
+          code: 'invalid-json',
+          message: '@cadam-node payload must be a JSON object.',
+          line,
+          raw,
+        });
+        continue;
+      }
+      payload = parsed;
+    } catch {
+      warnings.push({
+        code: 'invalid-json',
+        message: '@cadam-node payload is not valid JSON.',
+        line,
+        raw,
+      });
+      continue;
+    }
+
+    const id = stringOrUndefined(payload.id);
+    if (!id) {
+      warnings.push({
+        code: 'missing-id',
+        message: '@cadam-node payload is missing a string id.',
+        line,
+        raw,
+      });
+      continue;
+    }
+
+    const kind = stringOrUndefined(payload.kind);
+    if (!kind) {
+      warnings.push({
+        code: 'missing-kind',
+        message: '@cadam-node payload is missing a string kind.',
+        line,
+        raw,
+        id,
+      });
+      continue;
+    }
+
+    if (!isKnownNodeKind(kind)) {
+      warnings.push({
+        code: 'unknown-kind',
+        message: `@cadam-node kind "${kind}" is not supported.`,
+        line,
+        raw,
+        id,
+        kind,
+      });
+      continue;
+    }
+
+    if (seenIds.has(id)) {
+      warnings.push({
+        code: 'duplicate-id',
+        message: `@cadam-node id "${id}" was already used.`,
+        line,
+        raw,
+        id,
+      });
+      continue;
+    }
+
+    seenIds.add(id);
+
+    const node: CadamDesignTreeNode = {
+      id,
+      kind,
+      name: stringOrUndefined(payload.name) ?? id,
+    };
+    const parentId = stringOrUndefined(payload.parentId);
+    if (parentId) node.parentId = parentId;
+    const params = stringArrayOrUndefined(payload.params);
+    if (params) node.params = params;
+    const moduleName = stringOrUndefined(payload.moduleName);
+    if (moduleName) node.moduleName = moduleName;
+
+    nodes.push(node);
+  }
+
+  return { nodes, warnings };
+}
+
+function isKnownNodeKind(kind: string): kind is CadamDesignTreeNodeKind {
+  return KNOWN_NODE_KINDS.has(kind as CadamDesignTreeNodeKind);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringOrUndefined(value: unknown) {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function stringArrayOrUndefined(value: unknown) {
+  if (!Array.isArray(value)) return undefined;
+  const strings = value.filter(
+    (item): item is string => typeof item === 'string',
+  );
+  return strings.length > 0 ? strings : undefined;
+}
+
+function lineNumberForIndex(source: string, index: number) {
+  return source.slice(0, index).split('\n').length;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -89,12 +89,15 @@ export type CadamDesignTreeParseWarning = {
     | 'missing-kind'
     | 'duplicate-id'
     | 'unknown-kind'
-    | 'invalid-param-entry';
+    | 'invalid-param-entry'
+    | 'missing-parent'
+    | 'circular-parent';
   message: string;
   line: number;
   raw: string;
   id?: string;
   kind?: string;
+  parentId?: string;
 };
 
 export type CadamDesignTreeParseResult = {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -88,7 +88,8 @@ export type CadamDesignTreeParseWarning = {
     | 'missing-id'
     | 'missing-kind'
     | 'duplicate-id'
-    | 'unknown-kind';
+    | 'unknown-kind'
+    | 'invalid-param-entry';
   message: string;
   line: number;
   raw: string;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -67,6 +67,40 @@ export type Parameter = {
   maxLength?: number;
 };
 
+export type CadamDesignTreeNodeKind =
+  | 'part'
+  | 'operation'
+  | 'group'
+  | 'parameter';
+
+export type CadamDesignTreeNode = {
+  id: string;
+  kind: CadamDesignTreeNodeKind;
+  name: string;
+  parentId?: string;
+  params?: string[];
+  moduleName?: string;
+};
+
+export type CadamDesignTreeParseWarning = {
+  code:
+    | 'invalid-json'
+    | 'missing-id'
+    | 'missing-kind'
+    | 'duplicate-id'
+    | 'unknown-kind';
+  message: string;
+  line: number;
+  raw: string;
+  id?: string;
+  kind?: string;
+};
+
+export type CadamDesignTreeParseResult = {
+  nodes: CadamDesignTreeNode[];
+  warnings: CadamDesignTreeParseWarning[];
+};
+
 export type Conversation = Omit<
   Database['public']['Tables']['conversations']['Row'],
   'settings'

--- a/src/components/design-tree/DesignTreeViewer.tsx
+++ b/src/components/design-tree/DesignTreeViewer.tsx
@@ -64,7 +64,7 @@ export function DesignTreeViewer({
         <div className="rounded-md border border-amber-400/20 bg-amber-400/5 px-3 py-2 text-[11px] text-amber-100/90">
           {warnings.length === 1
             ? warnings[0].message
-            : `${warnings.length} annotations could not be shown.`}
+            : `${warnings.length} design tree annotation warnings.`}
         </div>
       )}
 

--- a/src/components/design-tree/DesignTreeViewer.tsx
+++ b/src/components/design-tree/DesignTreeViewer.tsx
@@ -1,0 +1,208 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { cn } from '@/lib/utils';
+import type {
+  CadamDesignTreeNode,
+  CadamDesignTreeParseWarning,
+} from '@shared/types';
+import {
+  AlertTriangle,
+  Box,
+  ChevronDown,
+  CircleDot,
+  Folder,
+  SlidersHorizontal,
+  Wrench,
+} from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+interface DesignTreeViewerProps {
+  nodes: CadamDesignTreeNode[];
+  selectedNodeId?: string | null;
+  onSelectNode?: (nodeId: string) => void;
+  warnings: CadamDesignTreeParseWarning[];
+}
+
+type TreeNode = CadamDesignTreeNode & {
+  children: TreeNode[];
+};
+
+export function DesignTreeViewer({
+  nodes,
+  selectedNodeId,
+  onSelectNode,
+  warnings,
+}: DesignTreeViewerProps) {
+  const treeNodes = useMemo(() => buildTree(nodes), [nodes]);
+  const selectedNode = useMemo(
+    () => nodes.find((node) => node.id === selectedNodeId),
+    [nodes, selectedNodeId],
+  );
+
+  return (
+    <section className="flex flex-col gap-3 border-b border-adam-neutral-700 pb-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-xs font-semibold text-adam-text-primary">
+            Design Tree
+          </h3>
+          <p className="mt-0.5 text-[11px] text-adam-text-secondary">
+            Source annotations
+          </p>
+        </div>
+        {warnings.length > 0 && (
+          <Badge className="shrink-0 border-amber-400/20 bg-amber-400/10 px-2 py-0.5 text-[10px] text-amber-200">
+            <AlertTriangle className="mr-1 h-3 w-3" />
+            {warnings.length}
+          </Badge>
+        )}
+      </div>
+
+      {warnings.length > 0 && (
+        <div className="rounded-md border border-amber-400/20 bg-amber-400/5 px-3 py-2 text-[11px] text-amber-100/90">
+          {warnings.length === 1
+            ? warnings[0].message
+            : `${warnings.length} annotations could not be shown.`}
+        </div>
+      )}
+
+      {treeNodes.length === 0 ? (
+        <div className="rounded-md border border-dashed border-adam-neutral-700 px-3 py-4 text-center text-xs text-adam-text-secondary">
+          No annotated design nodes found.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {treeNodes.map((node) => (
+            <DesignTreeRow
+              key={node.id}
+              node={node}
+              selectedNodeId={selectedNodeId}
+              onSelectNode={onSelectNode}
+            />
+          ))}
+        </div>
+      )}
+
+      {selectedNode?.params && selectedNode.params.length > 0 && (
+        <div className="rounded-md bg-adam-neutral-800/60 px-3 py-2 text-[11px] text-adam-text-secondary">
+          Linked params: {selectedNode.params.join(', ')}
+          <span className="mt-1 block text-adam-neutral-400">
+            Parameter focus is not wired up yet.
+          </span>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DesignTreeRow({
+  node,
+  selectedNodeId,
+  onSelectNode,
+}: {
+  node: TreeNode;
+  selectedNodeId?: string | null;
+  onSelectNode?: (nodeId: string) => void;
+}) {
+  const hasChildren = node.children.length > 0;
+  const [open, setOpen] = useState(true);
+  const isSelected = selectedNodeId === node.id;
+  const Icon = iconForKind(node.kind);
+
+  const content = (
+    <Button
+      type="button"
+      variant="ghost"
+      onClick={() => onSelectNode?.(node.id)}
+      className={cn(
+        'h-8 min-w-0 flex-1 justify-start gap-2 rounded-md px-2 text-left text-xs text-adam-text-secondary hover:bg-adam-neutral-800 hover:text-adam-text-primary',
+        isSelected && 'bg-adam-neutral-800 text-adam-text-primary',
+      )}
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <span className="min-w-0 truncate">{node.name}</span>
+      <span className="ml-auto shrink-0 text-[10px] text-adam-neutral-400">
+        {node.kind}
+      </span>
+    </Button>
+  );
+
+  if (!hasChildren) {
+    return <div className="flex items-center gap-1">{content}</div>;
+  }
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <div className="flex items-center gap-1">
+        <CollapsibleTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            aria-label={`${open ? 'Collapse' : 'Expand'} ${node.name}`}
+            className="h-8 w-6 shrink-0 rounded-md p-0 text-adam-neutral-400 hover:bg-adam-neutral-800 hover:text-adam-text-primary"
+          >
+            <ChevronDown
+              className={cn(
+                'h-3.5 w-3.5 transition-transform',
+                !open && '-rotate-90',
+              )}
+            />
+          </Button>
+        </CollapsibleTrigger>
+        {content}
+      </div>
+      <CollapsibleContent>
+        <div className="ml-4 border-l border-adam-neutral-700 pl-2">
+          {node.children.map((child) => (
+            <DesignTreeRow
+              key={child.id}
+              node={child}
+              selectedNodeId={selectedNodeId}
+              onSelectNode={onSelectNode}
+            />
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function buildTree(nodes: CadamDesignTreeNode[]) {
+  const byId = new Map<string, TreeNode>();
+  const roots: TreeNode[] = [];
+
+  for (const node of nodes) {
+    byId.set(node.id, { ...node, children: [] });
+  }
+
+  for (const node of byId.values()) {
+    const parent = node.parentId ? byId.get(node.parentId) : undefined;
+    if (parent) {
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  return roots;
+}
+
+function iconForKind(kind: CadamDesignTreeNode['kind']) {
+  switch (kind) {
+    case 'group':
+      return Folder;
+    case 'operation':
+      return Wrench;
+    case 'parameter':
+      return SlidersHorizontal;
+    case 'part':
+      return Box;
+    default:
+      return CircleDot;
+  }
+}

--- a/src/components/design-tree/DesignTreeViewer.tsx
+++ b/src/components/design-tree/DesignTreeViewer.tsx
@@ -166,7 +166,7 @@ function buildTree(nodes: CadamDesignTreeNode[]) {
 
   for (const node of byId.values()) {
     const parent = node.parentId ? byId.get(node.parentId) : undefined;
-    if (parent) {
+    if (parent && !wouldCreateCycle(node, parent, byId)) {
       parent.children.push(node);
     } else {
       roots.push(node);
@@ -174,6 +174,24 @@ function buildTree(nodes: CadamDesignTreeNode[]) {
   }
 
   return roots;
+}
+
+function wouldCreateCycle(
+  node: TreeNode,
+  parent: TreeNode,
+  byId: Map<string, TreeNode>,
+) {
+  const seenIds = new Set<string>();
+  let current: TreeNode | undefined = parent;
+
+  while (current) {
+    if (current.id === node.id) return true;
+    if (!current.parentId || seenIds.has(current.id)) return false;
+    seenIds.add(current.id);
+    current = byId.get(current.parentId);
+  }
+
+  return false;
 }
 
 function iconForKind(kind: CadamDesignTreeNode['kind']) {

--- a/src/components/design-tree/DesignTreeViewer.tsx
+++ b/src/components/design-tree/DesignTreeViewer.tsx
@@ -24,7 +24,7 @@ import { useMemo, useState } from 'react';
 interface DesignTreeViewerProps {
   nodes: CadamDesignTreeNode[];
   selectedNodeId?: string | null;
-  onSelectNode?: (nodeId: string) => void;
+  onSelectNode?: (nodeId: string | null) => void;
   warnings: CadamDesignTreeParseWarning[];
 }
 
@@ -39,10 +39,6 @@ export function DesignTreeViewer({
   warnings,
 }: DesignTreeViewerProps) {
   const treeNodes = useMemo(() => buildTree(nodes), [nodes]);
-  const selectedNode = useMemo(
-    () => nodes.find((node) => node.id === selectedNodeId),
-    [nodes, selectedNodeId],
-  );
 
   return (
     <section className="flex flex-col gap-3 border-b border-adam-neutral-700 pb-4">
@@ -87,15 +83,6 @@ export function DesignTreeViewer({
           ))}
         </div>
       )}
-
-      {selectedNode?.params && selectedNode.params.length > 0 && (
-        <div className="rounded-md bg-adam-neutral-800/60 px-3 py-2 text-[11px] text-adam-text-secondary">
-          Linked params: {selectedNode.params.join(', ')}
-          <span className="mt-1 block text-adam-neutral-400">
-            Parameter focus is not wired up yet.
-          </span>
-        </div>
-      )}
     </section>
   );
 }
@@ -107,7 +94,7 @@ function DesignTreeRow({
 }: {
   node: TreeNode;
   selectedNodeId?: string | null;
-  onSelectNode?: (nodeId: string) => void;
+  onSelectNode?: (nodeId: string | null) => void;
 }) {
   const hasChildren = node.children.length > 0;
   const [open, setOpen] = useState(true);
@@ -118,7 +105,7 @@ function DesignTreeRow({
     <Button
       type="button"
       variant="ghost"
-      onClick={() => onSelectNode?.(node.id)}
+      onClick={() => onSelectNode?.(isSelected ? null : node.id)}
       className={cn(
         'h-8 min-w-0 flex-1 justify-start gap-2 rounded-md px-2 text-left text-xs text-adam-text-secondary hover:bg-adam-neutral-800 hover:text-adam-text-primary',
         isSelected && 'bg-adam-neutral-800 text-adam-text-primary',

--- a/src/components/design-tree/DesignTreeViewer.tsx
+++ b/src/components/design-tree/DesignTreeViewer.tsx
@@ -39,6 +39,7 @@ export function DesignTreeViewer({
   warnings,
 }: DesignTreeViewerProps) {
   const treeNodes = useMemo(() => buildTree(nodes), [nodes]);
+  if (nodes.length === 0 && warnings.length === 0) return null;
 
   return (
     <section className="flex flex-col gap-3 border-b border-adam-neutral-700 pb-4">
@@ -67,11 +68,7 @@ export function DesignTreeViewer({
         </div>
       )}
 
-      {treeNodes.length === 0 ? (
-        <div className="rounded-md border border-dashed border-adam-neutral-700 px-3 py-4 text-center text-xs text-adam-text-secondary">
-          No annotated design nodes found.
-        </div>
-      ) : (
+      {treeNodes.length > 0 && (
         <div className="flex flex-col gap-1">
           {treeNodes.map((node) => (
             <DesignTreeRow

--- a/src/components/parameter/ParameterSection.tsx
+++ b/src/components/parameter/ParameterSection.tsx
@@ -6,9 +6,14 @@ import {
   Loader2,
 } from 'lucide-react';
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
+import { DesignTreeViewer } from '@/components/design-tree/DesignTreeViewer';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import type { Parameter } from '@shared/types';
+import type {
+  CadamDesignTreeNode,
+  CadamDesignTreeParseWarning,
+  Parameter,
+} from '@shared/types';
 import {
   Tooltip,
   TooltipContent,
@@ -45,6 +50,10 @@ interface ParameterSectionProps {
   currentOutput?: Blob;
   dxfExporter?: DxfExporter | null;
   code?: string;
+  designTreeNodes?: CadamDesignTreeNode[];
+  designTreeWarnings?: CadamDesignTreeParseWarning[];
+  selectedDesignTreeNodeId?: string | null;
+  onSelectDesignTreeNode?: (nodeId: string) => void;
 }
 
 type DownloadFormat = 'stl' | 'scad' | 'dxf';
@@ -55,6 +64,10 @@ export function ParameterSection({
   currentOutput,
   dxfExporter,
   code,
+  designTreeNodes = [],
+  designTreeWarnings = [],
+  selectedDesignTreeNodeId,
+  onSelectDesignTreeNode,
 }: ParameterSectionProps) {
   const { toast } = useToast();
   const [selectedFormat, setSelectedFormat] = useState<DownloadFormat>('stl');
@@ -209,6 +222,12 @@ export function ParameterSection({
       <div className="flex h-[calc(100%-3.5rem)] flex-col justify-between overflow-hidden">
         <ScrollArea className="flex-1 px-6 py-6">
           <div className="flex flex-col gap-3">
+            <DesignTreeViewer
+              nodes={designTreeNodes}
+              selectedNodeId={selectedDesignTreeNodeId}
+              onSelectNode={onSelectDesignTreeNode}
+              warnings={designTreeWarnings}
+            />
             {mainParameters.length > 0 && (
               <Collapsible
                 open={dimensionsOpen}

--- a/src/components/parameter/ParameterSection.tsx
+++ b/src/components/parameter/ParameterSection.tsx
@@ -80,6 +80,9 @@ export function ParameterSection({
     if (!selectedDesignTreeNode?.params?.length) return null;
     return new Set(selectedDesignTreeNode.params);
   }, [selectedDesignTreeNode]);
+  const activeSelectedParameterNames = onSelectDesignTreeNode
+    ? selectedParameterNames
+    : null;
 
   // Split params into the main list (non-color, shown by default) and a
   // collapsible Colors group below it. Keeps the dimensions the user
@@ -95,21 +98,21 @@ export function ParameterSection({
   }, [parameters]);
   const visibleMainParameters = useMemo(
     () =>
-      selectedParameterNames
+      activeSelectedParameterNames
         ? mainParameters.filter((param) =>
-            selectedParameterNames.has(param.name),
+            activeSelectedParameterNames.has(param.name),
           )
         : mainParameters,
-    [mainParameters, selectedParameterNames],
+    [mainParameters, activeSelectedParameterNames],
   );
   const visibleColorParameters = useMemo(
     () =>
-      selectedParameterNames
+      activeSelectedParameterNames
         ? colorParameters.filter((param) =>
-            selectedParameterNames.has(param.name),
+            activeSelectedParameterNames.has(param.name),
           )
         : colorParameters,
-    [colorParameters, selectedParameterNames],
+    [colorParameters, activeSelectedParameterNames],
   );
   const [colorsOpen, setColorsOpen] = useState(true);
   const [dimensionsOpen, setDimensionsOpen] = useState(true);
@@ -250,11 +253,13 @@ export function ParameterSection({
           <div className="flex flex-col gap-3">
             <DesignTreeViewer
               nodes={designTreeNodes}
-              selectedNodeId={selectedDesignTreeNodeId}
+              selectedNodeId={
+                onSelectDesignTreeNode ? selectedDesignTreeNodeId : null
+              }
               onSelectNode={onSelectDesignTreeNode}
               warnings={designTreeWarnings}
             />
-            {selectedParameterNames && selectedDesignTreeNode && (
+            {activeSelectedParameterNames && selectedDesignTreeNode && (
               <div className="flex items-center justify-between gap-3 rounded-md bg-adam-neutral-800/60 px-3 py-2">
                 <span className="min-w-0 truncate text-[11px] text-adam-text-secondary">
                   Showing parameters for {selectedDesignTreeNode.name}

--- a/src/components/parameter/ParameterSection.tsx
+++ b/src/components/parameter/ParameterSection.tsx
@@ -53,7 +53,7 @@ interface ParameterSectionProps {
   designTreeNodes?: CadamDesignTreeNode[];
   designTreeWarnings?: CadamDesignTreeParseWarning[];
   selectedDesignTreeNodeId?: string | null;
-  onSelectDesignTreeNode?: (nodeId: string) => void;
+  onSelectDesignTreeNode?: (nodeId: string | null) => void;
 }
 
 type DownloadFormat = 'stl' | 'scad' | 'dxf';
@@ -72,6 +72,14 @@ export function ParameterSection({
   const { toast } = useToast();
   const [selectedFormat, setSelectedFormat] = useState<DownloadFormat>('stl');
   const [isExporting, setIsExporting] = useState(false);
+  const selectedDesignTreeNode = useMemo(
+    () => designTreeNodes.find((node) => node.id === selectedDesignTreeNodeId),
+    [designTreeNodes, selectedDesignTreeNodeId],
+  );
+  const selectedParameterNames = useMemo(() => {
+    if (!selectedDesignTreeNode?.params?.length) return null;
+    return new Set(selectedDesignTreeNode.params);
+  }, [selectedDesignTreeNode]);
 
   // Split params into the main list (non-color, shown by default) and a
   // collapsible Colors group below it. Keeps the dimensions the user
@@ -85,6 +93,24 @@ export function ParameterSection({
     }
     return { mainParameters: main, colorParameters: color };
   }, [parameters]);
+  const visibleMainParameters = useMemo(
+    () =>
+      selectedParameterNames
+        ? mainParameters.filter((param) =>
+            selectedParameterNames.has(param.name),
+          )
+        : mainParameters,
+    [mainParameters, selectedParameterNames],
+  );
+  const visibleColorParameters = useMemo(
+    () =>
+      selectedParameterNames
+        ? colorParameters.filter((param) =>
+            selectedParameterNames.has(param.name),
+          )
+        : colorParameters,
+    [colorParameters, selectedParameterNames],
+  );
   const [colorsOpen, setColorsOpen] = useState(true);
   const [dimensionsOpen, setDimensionsOpen] = useState(true);
 
@@ -228,7 +254,22 @@ export function ParameterSection({
               onSelectNode={onSelectDesignTreeNode}
               warnings={designTreeWarnings}
             />
-            {mainParameters.length > 0 && (
+            {selectedParameterNames && selectedDesignTreeNode && (
+              <div className="flex items-center justify-between gap-3 rounded-md bg-adam-neutral-800/60 px-3 py-2">
+                <span className="min-w-0 truncate text-[11px] text-adam-text-secondary">
+                  Showing parameters for {selectedDesignTreeNode.name}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => onSelectDesignTreeNode?.(null)}
+                  className="h-6 shrink-0 px-2 text-[11px] text-adam-text-primary hover:bg-adam-neutral-700"
+                >
+                  Show all
+                </Button>
+              </div>
+            )}
+            {visibleMainParameters.length > 0 && (
               <Collapsible
                 open={dimensionsOpen}
                 onOpenChange={setDimensionsOpen}
@@ -240,7 +281,7 @@ export function ParameterSection({
                   <span className="flex items-center gap-2">
                     Dimensions
                     <span className="text-[10px] text-adam-neutral-400">
-                      {mainParameters.length}
+                      {visibleMainParameters.length}
                     </span>
                   </span>
                   <ChevronDown
@@ -251,7 +292,7 @@ export function ParameterSection({
                 </CollapsibleTrigger>
                 <CollapsibleContent className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
                   <div className="mt-3 flex flex-col gap-3">
-                    {mainParameters.map((param) => (
+                    {visibleMainParameters.map((param) => (
                       <ParameterInput
                         key={param.name}
                         param={param}
@@ -262,7 +303,7 @@ export function ParameterSection({
                 </CollapsibleContent>
               </Collapsible>
             )}
-            {colorParameters.length > 0 && (
+            {visibleColorParameters.length > 0 && (
               <Collapsible
                 open={colorsOpen}
                 onOpenChange={setColorsOpen}
@@ -275,7 +316,7 @@ export function ParameterSection({
                   <span className="flex items-center gap-2">
                     Colors
                     <span className="text-[10px] text-adam-neutral-400">
-                      {colorParameters.length}
+                      {visibleColorParameters.length}
                     </span>
                   </span>
                   <ChevronDown
@@ -286,7 +327,7 @@ export function ParameterSection({
                 </CollapsibleTrigger>
                 <CollapsibleContent className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
                   <div className="mt-3 flex flex-col gap-3">
-                    {colorParameters.map((param) => (
+                    {visibleColorParameters.map((param) => (
                       <ParameterInput
                         key={param.name}
                         param={param}

--- a/src/components/parameter/ParameterSheetContent.tsx
+++ b/src/components/parameter/ParameterSheetContent.tsx
@@ -1,5 +1,5 @@
 import { Download, ChevronUp, Loader2 } from 'lucide-react';
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { DesignTreeViewer } from '@/components/design-tree/DesignTreeViewer';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -33,7 +33,7 @@ interface ParameterSheetContentProps {
   designTreeNodes?: CadamDesignTreeNode[];
   designTreeWarnings?: CadamDesignTreeParseWarning[];
   selectedDesignTreeNodeId?: string | null;
-  onSelectDesignTreeNode?: (nodeId: string) => void;
+  onSelectDesignTreeNode?: (nodeId: string | null) => void;
 }
 
 type DownloadFormat = 'stl' | 'scad' | 'dxf';
@@ -55,6 +55,21 @@ export function ParameterSheetContent({
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingParametersRef = useRef<Parameter[] | null>(null);
   const latestParametersRef = useRef(parameters);
+  const selectedDesignTreeNode = useMemo(
+    () => designTreeNodes.find((node) => node.id === selectedDesignTreeNodeId),
+    [designTreeNodes, selectedDesignTreeNodeId],
+  );
+  const selectedParameterNames = useMemo(() => {
+    if (!selectedDesignTreeNode?.params?.length) return null;
+    return new Set(selectedDesignTreeNode.params);
+  }, [selectedDesignTreeNode]);
+  const visibleParameters = useMemo(
+    () =>
+      selectedParameterNames
+        ? parameters.filter((param) => selectedParameterNames.has(param.name))
+        : parameters,
+    [parameters, selectedParameterNames],
+  );
 
   useEffect(() => {
     latestParametersRef.current = parameters;
@@ -158,7 +173,22 @@ export function ParameterSheetContent({
             onSelectNode={onSelectDesignTreeNode}
             warnings={designTreeWarnings}
           />
-          {parameters.map((param) => (
+          {selectedParameterNames && selectedDesignTreeNode && (
+            <div className="flex items-center justify-between gap-3 rounded-md bg-adam-neutral-800/60 px-3 py-2">
+              <span className="min-w-0 truncate text-[11px] text-adam-text-secondary">
+                Showing parameters for {selectedDesignTreeNode.name}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => onSelectDesignTreeNode?.(null)}
+                className="h-6 shrink-0 px-2 text-[11px] text-adam-text-primary hover:bg-adam-neutral-700"
+              >
+                Show all
+              </Button>
+            </div>
+          )}
+          {visibleParameters.map((param) => (
             <ParameterInput
               key={param.name}
               param={param}

--- a/src/components/parameter/ParameterSheetContent.tsx
+++ b/src/components/parameter/ParameterSheetContent.tsx
@@ -63,12 +63,17 @@ export function ParameterSheetContent({
     if (!selectedDesignTreeNode?.params?.length) return null;
     return new Set(selectedDesignTreeNode.params);
   }, [selectedDesignTreeNode]);
+  const activeSelectedParameterNames = onSelectDesignTreeNode
+    ? selectedParameterNames
+    : null;
   const visibleParameters = useMemo(
     () =>
-      selectedParameterNames
-        ? parameters.filter((param) => selectedParameterNames.has(param.name))
+      activeSelectedParameterNames
+        ? parameters.filter((param) =>
+            activeSelectedParameterNames.has(param.name),
+          )
         : parameters,
-    [parameters, selectedParameterNames],
+    [parameters, activeSelectedParameterNames],
   );
 
   useEffect(() => {
@@ -169,11 +174,13 @@ export function ParameterSheetContent({
         <div className="flex flex-col gap-6 pb-4 pt-2">
           <DesignTreeViewer
             nodes={designTreeNodes}
-            selectedNodeId={selectedDesignTreeNodeId}
+            selectedNodeId={
+              onSelectDesignTreeNode ? selectedDesignTreeNodeId : null
+            }
             onSelectNode={onSelectDesignTreeNode}
             warnings={designTreeWarnings}
           />
-          {selectedParameterNames && selectedDesignTreeNode && (
+          {activeSelectedParameterNames && selectedDesignTreeNode && (
             <div className="flex items-center justify-between gap-3 rounded-md bg-adam-neutral-800/60 px-3 py-2">
               <span className="min-w-0 truncate text-[11px] text-adam-text-secondary">
                 Showing parameters for {selectedDesignTreeNode.name}

--- a/src/components/parameter/ParameterSheetContent.tsx
+++ b/src/components/parameter/ParameterSheetContent.tsx
@@ -1,8 +1,13 @@
 import { Download, ChevronUp, Loader2 } from 'lucide-react';
 import { useEffect, useState, useRef, useCallback } from 'react';
+import { DesignTreeViewer } from '@/components/design-tree/DesignTreeViewer';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import type { Parameter } from '@shared/types';
+import type {
+  CadamDesignTreeNode,
+  CadamDesignTreeParseWarning,
+  Parameter,
+} from '@shared/types';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -25,6 +30,10 @@ interface ParameterSheetContentProps {
   currentOutput?: Blob;
   dxfExporter?: DxfExporter | null;
   code?: string;
+  designTreeNodes?: CadamDesignTreeNode[];
+  designTreeWarnings?: CadamDesignTreeParseWarning[];
+  selectedDesignTreeNodeId?: string | null;
+  onSelectDesignTreeNode?: (nodeId: string) => void;
 }
 
 type DownloadFormat = 'stl' | 'scad' | 'dxf';
@@ -35,6 +44,10 @@ export function ParameterSheetContent({
   currentOutput,
   dxfExporter,
   code,
+  designTreeNodes = [],
+  designTreeWarnings = [],
+  selectedDesignTreeNodeId,
+  onSelectDesignTreeNode,
 }: ParameterSheetContentProps) {
   const { toast } = useToast();
   const [selectedFormat, setSelectedFormat] = useState<DownloadFormat>('stl');
@@ -139,6 +152,12 @@ export function ParameterSheetContent({
     <div className="flex h-full min-h-0 w-full flex-col">
       <ScrollArea className="min-h-0 w-full flex-1 px-4">
         <div className="flex flex-col gap-6 pb-4 pt-2">
+          <DesignTreeViewer
+            nodes={designTreeNodes}
+            selectedNodeId={selectedDesignTreeNodeId}
+            onSelectNode={onSelectDesignTreeNode}
+            warnings={designTreeWarnings}
+          />
           {parameters.map((param) => (
             <ParameterInput
               key={param.name}

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -34,8 +34,10 @@ import {
 import type { DxfExporter } from '@/utils/downloadUtils';
 import type { AppUIMessage } from '@shared/chatAi';
 import { isParametricArtifact } from '@shared/parametricParts';
+import parseDesignTree from '@shared/parseDesignTree';
 import Tree from '@shared/Tree';
 import type {
+  CadamDesignTreeParseResult,
   Conversation,
   Message,
   Model,
@@ -193,6 +195,11 @@ function ConversationEditor() {
   );
   const [activePreview, setActivePreview] = useState<ActivePreview>(null);
   const [parameters, setParameters] = useState<Parameter[]>([]);
+  const [designTreeResult, setDesignTreeResult] =
+    useState<CadamDesignTreeParseResult>({ nodes: [], warnings: [] });
+  const [selectedDesignTreeNodeId, setSelectedDesignTreeNodeId] = useState<
+    string | null
+  >(null);
   const [currentOutput, setCurrentOutput] = useState<Blob | undefined>();
   const [dxfExporter, setDxfExporter] = useState<DxfExporter | null>(null);
   const [mobilePreviewVersion, setMobilePreviewVersion] = useState(0);
@@ -214,6 +221,16 @@ function ConversationEditor() {
     },
     [],
   );
+
+  const updateDesignTree = useCallback((code: string) => {
+    const result = parseDesignTree(code);
+    setDesignTreeResult(result);
+    setSelectedDesignTreeNodeId((currentId) =>
+      currentId && result.nodes.some((node) => node.id === currentId)
+        ? currentId
+        : null,
+    );
+  }, []);
 
   // ── Source of truth: DB messages → tree → branch ───────────────────────
   const { data: dbMessages = [], isFetched: areMessagesFetched } =
@@ -432,16 +449,19 @@ function ConversationEditor() {
       // always yields the same `<ParameterSection>`, no matter which
       // model wrote it.
       setParameters(parseParameters(artifact.code));
+      updateDesignTree(artifact.code);
       setCurrentOutput(undefined);
       setDxfExporter(() => null);
       setActivePreview({ type: 'artifact', messageId, artifact });
       setMobilePreviewVersion((version) => version + 1);
     },
-    [],
+    [updateDesignTree],
   );
   const handleViewMesh = useCallback((meshId: string, messageId: string) => {
     setCurrentOutput(undefined);
     setDxfExporter(() => null);
+    setDesignTreeResult({ nodes: [], warnings: [] });
+    setSelectedDesignTreeNodeId(null);
     setActivePreview({ type: 'mesh', messageId, meshId });
     setMobilePreviewVersion((version) => version + 1);
   }, []);
@@ -454,6 +474,7 @@ function ConversationEditor() {
         nextCode = updateParameter(nextCode, parameter);
       }
       setParameters(nextParameters);
+      updateDesignTree(nextCode);
       setActivePreview({
         ...activePreview,
         artifact: {
@@ -462,7 +483,7 @@ function ConversationEditor() {
         },
       });
     },
-    [activePreview],
+    [activePreview, updateDesignTree],
   );
 
   const updatePrivacy = useCallback(
@@ -483,7 +504,10 @@ function ConversationEditor() {
   const sharePreview = activePreview ?? persistedLatestPreview;
 
   const hasArtifact =
-    activePreview?.type === 'artifact' && parameters.length > 0;
+    activePreview?.type === 'artifact' &&
+    (parameters.length > 0 ||
+      designTreeResult.nodes.length > 0 ||
+      designTreeResult.warnings.length > 0);
 
   // `useCachedAiChat` captures `initialBranch` once at Chat construction;
   // if the messages query hasn't completed its first fetch yet the
@@ -650,6 +674,10 @@ function ConversationEditor() {
             onParameterChange={changeParameters}
             currentOutput={currentOutput}
             dxfExporter={dxfExporter}
+            designTreeNodes={designTreeResult.nodes}
+            designTreeWarnings={designTreeResult.warnings}
+            selectedDesignTreeNodeId={selectedDesignTreeNodeId}
+            onSelectDesignTreeNode={setSelectedDesignTreeNodeId}
             code={
               activePreview?.type === 'artifact'
                 ? activePreview.artifact.code
@@ -664,6 +692,10 @@ function ConversationEditor() {
           onParameterChange={changeParameters}
           currentOutput={currentOutput}
           dxfExporter={dxfExporter}
+          designTreeNodes={designTreeResult.nodes}
+          designTreeWarnings={designTreeResult.warnings}
+          selectedDesignTreeNodeId={selectedDesignTreeNodeId}
+          onSelectDesignTreeNode={setSelectedDesignTreeNodeId}
           code={
             activePreview?.type === 'artifact'
               ? activePreview.artifact.code

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -222,15 +222,22 @@ function ConversationEditor() {
     [],
   );
 
-  const updateDesignTree = useCallback((code: string) => {
-    const result = parseDesignTree(code);
-    setDesignTreeResult(result);
-    setSelectedDesignTreeNodeId((currentId) =>
-      currentId && result.nodes.some((node) => node.id === currentId)
-        ? currentId
-        : null,
-    );
-  }, []);
+  const updateDesignTree = useCallback(
+    (code: string, options: { preserveSelection?: boolean } = {}) => {
+      const result = parseDesignTree(code);
+      setDesignTreeResult(result);
+      if (options.preserveSelection === false) {
+        setSelectedDesignTreeNodeId(null);
+        return;
+      }
+      setSelectedDesignTreeNodeId((currentId) =>
+        currentId && result.nodes.some((node) => node.id === currentId)
+          ? currentId
+          : null,
+      );
+    },
+    [],
+  );
 
   // ── Source of truth: DB messages → tree → branch ───────────────────────
   const { data: dbMessages = [], isFetched: areMessagesFetched } =
@@ -449,7 +456,7 @@ function ConversationEditor() {
       // always yields the same `<ParameterSection>`, no matter which
       // model wrote it.
       setParameters(parseParameters(artifact.code));
-      updateDesignTree(artifact.code);
+      updateDesignTree(artifact.code, { preserveSelection: false });
       setCurrentOutput(undefined);
       setDxfExporter(() => null);
       setActivePreview({ type: 'artifact', messageId, artifact });

--- a/src/views/ShareView.tsx
+++ b/src/views/ShareView.tsx
@@ -12,8 +12,10 @@ import { updateParameter } from '@/lib/utils';
 import parseParameters from '@shared/parseParameters';
 import type { AppUIMessage } from '@shared/chatAi';
 import { isParametricArtifact } from '@shared/parametricParts';
+import parseDesignTree from '@shared/parseDesignTree';
 import Tree from '@shared/Tree';
 import type {
+  CadamDesignTreeParseResult,
   Conversation,
   Message,
   Parameter,
@@ -138,9 +140,24 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
   // server-side persistence.
   const [activePreview, setActivePreview] = useState<ActivePreview>(null);
   const [parameters, setParameters] = useState<Parameter[]>([]);
+  const [designTreeResult, setDesignTreeResult] =
+    useState<CadamDesignTreeParseResult>({ nodes: [], warnings: [] });
+  const [selectedDesignTreeNodeId, setSelectedDesignTreeNodeId] = useState<
+    string | null
+  >(null);
   const [currentOutput, setCurrentOutput] = useState<Blob | undefined>();
   const [mobilePreviewVersion, setMobilePreviewVersion] = useState(0);
   const baseCodeRef = useRef<string | null>(null);
+
+  const updateDesignTree = useCallback((code: string) => {
+    const result = parseDesignTree(code);
+    setDesignTreeResult(result);
+    setSelectedDesignTreeNodeId((currentId) =>
+      currentId && result.nodes.some((node) => node.id === currentId)
+        ? currentId
+        : null,
+    );
+  }, []);
 
   // Auto-switch the preview pane to the latest artifact / mesh in the
   // current branch when it changes.
@@ -157,6 +174,7 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
     if (latest.type === 'artifact') {
       baseCodeRef.current = latest.artifact.code;
       setParameters(parseParameters(latest.artifact.code));
+      updateDesignTree(latest.artifact.code);
       setCurrentOutput(undefined);
       setActivePreview({
         type: 'artifact',
@@ -166,6 +184,8 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
       setMobilePreviewVersion((version) => version + 1);
     } else {
       setCurrentOutput(undefined);
+      setDesignTreeResult({ nodes: [], warnings: [] });
+      setSelectedDesignTreeNodeId(null);
       setActivePreview({
         type: 'mesh',
         messageId: latest.messageId,
@@ -173,20 +193,23 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
       });
       setMobilePreviewVersion((version) => version + 1);
     }
-  }, [branch]);
+  }, [branch, updateDesignTree]);
 
   const handleViewArtifact = useCallback(
     (artifact: ParametricArtifact, messageId: string) => {
       baseCodeRef.current = artifact.code;
       setParameters(parseParameters(artifact.code));
+      updateDesignTree(artifact.code);
       setCurrentOutput(undefined);
       setActivePreview({ type: 'artifact', messageId, artifact });
       setMobilePreviewVersion((version) => version + 1);
     },
-    [],
+    [updateDesignTree],
   );
   const handleViewMesh = useCallback((meshId: string, messageId: string) => {
     setCurrentOutput(undefined);
+    setDesignTreeResult({ nodes: [], warnings: [] });
+    setSelectedDesignTreeNodeId(null);
     setActivePreview({ type: 'mesh', messageId, meshId });
     setMobilePreviewVersion((version) => version + 1);
   }, []);
@@ -199,6 +222,7 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
         nextCode = updateParameter(nextCode, parameter);
       }
       setParameters(nextParameters);
+      updateDesignTree(nextCode);
       setActivePreview({
         ...activePreview,
         artifact: {
@@ -207,11 +231,14 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
         },
       });
     },
-    [activePreview],
+    [activePreview, updateDesignTree],
   );
 
   const hasArtifact =
-    activePreview?.type === 'artifact' && parameters.length > 0;
+    activePreview?.type === 'artifact' &&
+    (parameters.length > 0 ||
+      designTreeResult.nodes.length > 0 ||
+      designTreeResult.warnings.length > 0);
 
   return (
     <ConversationView
@@ -305,6 +332,10 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
             onParameterChange={changeParameters}
             currentOutput={currentOutput}
             dxfExporter={null}
+            designTreeNodes={designTreeResult.nodes}
+            designTreeWarnings={designTreeResult.warnings}
+            selectedDesignTreeNodeId={selectedDesignTreeNodeId}
+            onSelectDesignTreeNode={setSelectedDesignTreeNodeId}
             code={
               activePreview?.type === 'artifact'
                 ? activePreview.artifact.code
@@ -319,6 +350,10 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
           onParameterChange={changeParameters}
           currentOutput={currentOutput}
           dxfExporter={null}
+          designTreeNodes={designTreeResult.nodes}
+          designTreeWarnings={designTreeResult.warnings}
+          selectedDesignTreeNodeId={selectedDesignTreeNodeId}
+          onSelectDesignTreeNode={setSelectedDesignTreeNodeId}
           code={
             activePreview?.type === 'artifact'
               ? activePreview.artifact.code

--- a/src/views/ShareView.tsx
+++ b/src/views/ShareView.tsx
@@ -149,15 +149,22 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
   const [mobilePreviewVersion, setMobilePreviewVersion] = useState(0);
   const baseCodeRef = useRef<string | null>(null);
 
-  const updateDesignTree = useCallback((code: string) => {
-    const result = parseDesignTree(code);
-    setDesignTreeResult(result);
-    setSelectedDesignTreeNodeId((currentId) =>
-      currentId && result.nodes.some((node) => node.id === currentId)
-        ? currentId
-        : null,
-    );
-  }, []);
+  const updateDesignTree = useCallback(
+    (code: string, options: { preserveSelection?: boolean } = {}) => {
+      const result = parseDesignTree(code);
+      setDesignTreeResult(result);
+      if (options.preserveSelection === false) {
+        setSelectedDesignTreeNodeId(null);
+        return;
+      }
+      setSelectedDesignTreeNodeId((currentId) =>
+        currentId && result.nodes.some((node) => node.id === currentId)
+          ? currentId
+          : null,
+      );
+    },
+    [],
+  );
 
   // Auto-switch the preview pane to the latest artifact / mesh in the
   // current branch when it changes.
@@ -174,7 +181,7 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
     if (latest.type === 'artifact') {
       baseCodeRef.current = latest.artifact.code;
       setParameters(parseParameters(latest.artifact.code));
-      updateDesignTree(latest.artifact.code);
+      updateDesignTree(latest.artifact.code, { preserveSelection: false });
       setCurrentOutput(undefined);
       setActivePreview({
         type: 'artifact',
@@ -199,7 +206,7 @@ function ConversationShare({ conversation, messages }: ConversationShareProps) {
     (artifact: ParametricArtifact, messageId: string) => {
       baseCodeRef.current = artifact.code;
       setParameters(parseParameters(artifact.code));
-      updateDesignTree(artifact.code);
+      updateDesignTree(artifact.code, { preserveSelection: false });
       setCurrentOutput(undefined);
       setActivePreview({ type: 'artifact', messageId, artifact });
       setMobilePreviewVersion((version) => version + 1);


### PR DESCRIPTION
adds a first version of a design tree viewer for OpenSCAD

Closes #139.

What changed
- Added a parser for `@cadam-node` comments in OpenSCAD code
- Added types for design tree nodes and parser warnings
- Added a collapsible design tree UI
- Added the tree to the desktop and mobile parameter panels
- Added parameter filtering when a selected tree node has linked `params`
- Added a way to clear the filter with **Show all** or by clicking the selected node again
- Added basic parser tests
- Added a short README section for the annotation format

I could not fully test the live AI generation flow because I do not have the API keys set up locally. So I was not able to confirm the full browser flow. The code should work when the OpenSCAD artifact includes `@cadam-node` comments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a source-annotated design tree viewer for OpenSCAD using `@cadam-node` comments. It shows in desktop and mobile parameter panels, surfaces parse warnings, and lets users filter parameters by the selected node.

- **New Features**
  - Parser for `@cadam-node` line comments with strong types; supports kinds: part, operation, group, parameter, and fields: `name`, `parentId`, `params`, `moduleName`.
  - Collapsible Design Tree UI with kind icons and a warnings badge in both parameter panels; shows even when a model has no parameters.
  - Filter parameters to a node’s `params`; clear via “Show all” or by re-clicking; selection persists across code edits and resets on mesh previews.
  - Parser tests and README docs for the annotation format.

- **Bug Fixes**
  - Clearer warning copy and robust detection for invalid JSON, duplicate ids, missing/unknown kind, invalid `params` entries, and missing parents.
  - Detect and warn on circular `parentId` links, and skip cycles when building the tree.

<sup>Written for commit 2c23e8655d40d749c84db84254ebdc1be1ff10e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

