### PR TITLE
Store image refs, not base64, in chat parts

### DIFF
--- a/shared/imageRefs.ts
+++ b/shared/imageRefs.ts
@@ -1,0 +1,46 @@
+// Helpers for resolving uploaded-image file parts to private-storage objects.
+//
+// Uploaded images live in the (private, RLS-protected) `images` bucket at
+// `${userId}/${conversationId}/${imageId}`. An AI SDK file part carries the
+// image id in its `filename` (`${imageId}.png`); the part's `url` is a stable
+// REFERENCE string, not something to fetch directly. The bytes are resolved
+// from storage by id at the two boundaries that actually need them:
+//   * the chat server downloads them to base64 for the model, and
+//   * the client downloads them via a signed URL for display.
+//
+// Persisting a base64 data URL in the part (as the AI SDK migration
+// accidentally did) duplicates the whole image into `messages.parts`; a raw
+// `/storage/.../public/...` path (as the backfill wrote) never resolves
+// because the bucket is private. Both are avoided by keeping `url` a
+// reference and resolving by id.
+
+export function imageIdFromFilename(
+  filename: string | null | undefined,
+): string | null {
+  if (!filename) return null;
+  return filename.replace(/\.[^.]+$/, '') || null;
+}
+
+export function imageStoragePath(
+  userId: string,
+  conversationId: string,
+  imageId: string,
+): string {
+  return `${userId}/${conversationId}/${imageId}`;
+}
+
+// Canonical reference persisted in a file part's `url`. Kept in the exact
+// shape the 2026-05-18 AI-SDK backfill produced so every row in
+// `messages.parts` carries a single, uniform format. Never fetched directly —
+// see the note above.
+export function imageFilePartUrl(
+  userId: string,
+  conversationId: string,
+  imageId: string,
+): string {
+  return `/storage/v1/object/public/images/${imageStoragePath(
+    userId,
+    conversationId,
+    imageId,
+  )}`;
+}

--- a/src/components/TextAreaChat.tsx
+++ b/src/components/TextAreaChat.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/lib/utils';
 import { CreativeModel, MeshFileType, Model } from '@shared/types';
 import type { AppUIMessage } from '@shared/chatAi';
+import { imageFilePartUrl } from '@shared/imageRefs';
 import {
   shouldShowPolygonControls,
   getModelDefaultPolygonCount,
@@ -747,7 +748,11 @@ function TextAreaChat({
       parts.push({
         type: 'file',
         mediaType: 'image/png',
-        url: image.url,
+        // Reference the storage object, NOT the base64 preview. The bytes were
+        // already uploaded to `images/${user}/${conv}/${id}`; persisting the
+        // data URL here would balloon `messages.parts` with the whole image.
+        // Display + model-feeding resolve the bytes from storage by id.
+        url: imageFilePartUrl(conversation.user_id, conversation.id, image.id),
         filename: `${image.id}.png`,
       });
     }

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { usePreview } from '@/hooks/usePreview';
+import { useImageData } from '@/hooks/useImageData';
 import { useMeshData } from '@/hooks/useMeshData';
 import { generatePreview, generateColoredPreview } from '@/utils/meshUtils';
 import { previewScadColoredViaToolWorker } from '@/worker/toolWorker';
@@ -28,6 +29,7 @@ import type { ChatMessage } from '@/lib/aiMessages';
 import type { ParametricArtifact } from '@shared/types';
 import type { TreeNode } from '@shared/Tree';
 import { isParametricArtifact } from '@shared/parametricParts';
+import { imageIdFromFilename } from '@shared/imageRefs';
 import type React from 'react';
 import {
   Box,
@@ -70,6 +72,40 @@ export function MessageBubble(props: MessageBubbleProps) {
     <UserBubble {...props} />
   ) : (
     <AssistantBubble {...props} />
+  );
+}
+
+/**
+ * Renders a user-attached image by downloading it from the private `images`
+ * bucket (via {@link useImageData}) rather than trusting the part's `url`.
+ * The persisted `url` is only a storage reference — the bucket is private, so
+ * a direct `<img src>` against it would 404. The image id comes from the file
+ * part's `filename` (`${id}.png`).
+ */
+function UploadedImage({ id, alt }: { id: string; alt: string }) {
+  const {
+    data: { isError: isDataError },
+    url: { data, isError: isUrlError },
+  } = useImageData(id);
+
+  if (data?.url) {
+    return (
+      <img
+        src={data.url}
+        alt={alt}
+        className="h-20 w-20 rounded-lg object-cover"
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-20 w-20 items-center justify-center rounded-lg bg-adam-neutral-900">
+      {isDataError || isUrlError ? (
+        <X className="h-5 w-5 text-adam-text-secondary" />
+      ) : (
+        <Loader2 className="h-5 w-5 animate-spin text-adam-text-secondary" />
+      )}
+    </div>
   );
 }
 
@@ -183,14 +219,29 @@ function UserBubble({
       >
         {hasAttachments ? (
           <div className="flex flex-wrap gap-1">
-            {imageParts.map((part, index) => (
-              <img
-                key={`img-${index}`}
-                src={part.url}
-                alt={part.filename ?? 'Uploaded image'}
-                className="h-20 w-20 rounded-lg object-cover"
-              />
-            ))}
+            {imageParts.map((part, index) => {
+              // Legacy/freshly-streamed parts may still carry an inline data
+              // URL — render those directly. Everything else is a storage
+              // reference resolved by image id (see UploadedImage).
+              const id = imageIdFromFilename(part.filename);
+              if (part.url?.startsWith('data:') || !id) {
+                return (
+                  <img
+                    key={`img-${index}`}
+                    src={part.url}
+                    alt={part.filename ?? 'Uploaded image'}
+                    className="h-20 w-20 rounded-lg object-cover"
+                  />
+                );
+              }
+              return (
+                <UploadedImage
+                  key={`img-${index}`}
+                  id={id}
+                  alt={part.filename ?? 'Uploaded image'}
+                />
+              );
+            })}
             {meshContextParts.map((part, index) => (
               <MeshContextChip
                 key={`mesh-${index}`}

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -3,6 +3,7 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { chatTools, type AppUIMessage, type AppTools } from '@shared/chatAi';
 import { getParametricText } from '@shared/parametricParts';
+import { imageIdFromFilename, imageStoragePath } from '@shared/imageRefs';
 import { normalizeConversationSuggestions } from '@shared/suggestions';
 import type { Conversation, Message, MeshFileType, Model } from '@shared/types';
 import {
@@ -672,7 +673,7 @@ async function downloadAsBase64(
   supabaseClient: SupabaseAnon,
   bucket: string,
   path: string,
-) {
+): Promise<{ base64: string; mediaType: string } | null> {
   const { data, error } = await supabaseClient.storage
     .from(bucket)
     .download(path);
@@ -684,7 +685,9 @@ async function downloadAsBase64(
   for (let index = 0; index < bytes.length; index += chunkSize) {
     binary += String.fromCharCode(...bytes.slice(index, index + chunkSize));
   }
-  return btoa(binary);
+  // Report the stored object's real content type so callers don't mislabel
+  // e.g. a JPEG upload as PNG — some providers reject a mime/bytes mismatch.
+  return { base64: btoa(binary), mediaType: data.type || 'image/png' };
 }
 
 function parametricTools({
@@ -709,21 +712,21 @@ function parametricTools({
         // ChatSession's `onToolCall`). If for any reason the upload
         // didn't land, `downloadAsBase64` returns null and we fall back
         // to text-only — never block the loop on a missing thumbnail.
-        const base64 = await downloadAsBase64(
+        const downloaded = await downloadAsBase64(
           supabaseClient,
           'images',
           previewPathForToolCall(toolCallId),
         );
 
-        if (base64) {
+        if (downloaded) {
           return {
             type: 'content' as const,
             value: [
               { type: 'text' as const, text: output.message },
               {
                 type: 'image-data' as const,
-                data: base64,
-                mediaType: 'image/png' as const,
+                data: downloaded.base64,
+                mediaType: downloaded.mediaType,
               },
             ],
           };
@@ -882,8 +885,50 @@ export async function handleAiChatRequest(req: Request) {
   // the very first user turn.
   const isFirstUserTurn = branchMessages.length === 1 && leafRole === 'user';
 
+  // Rehydrate image file parts before handing them to the model. The
+  // persisted `url` is a storage reference (or, for the oldest backfilled
+  // rows, a dead `/public/` path), neither of which the provider can fetch —
+  // `convertToModelMessages` passes `part.url` straight through as the file
+  // payload. So we download the bytes from the private `images` bucket and
+  // inline them as a base64 data URL. Parts that already carry a `data:` URL
+  // (legacy rows that inlined base64) pass through untouched; anything we
+  // can't resolve is dropped so a missing image never poisons the request
+  // with an unfetchable URL.
+  const hydratedMessages = await Promise.all(
+    branchMessages.map(async (message) => ({
+      ...message,
+      parts: (
+        await Promise.all(
+          message.parts.map(async (part) => {
+            if (
+              part.type !== 'file' ||
+              typeof part.mediaType !== 'string' ||
+              !part.mediaType.startsWith('image/') ||
+              part.url.startsWith('data:')
+            ) {
+              return part;
+            }
+            const imageId = imageIdFromFilename(part.filename);
+            if (!imageId) return null;
+            const downloaded = await downloadAsBase64(
+              supabaseClient,
+              'images',
+              imageStoragePath(conversation.user_id, conversation.id, imageId),
+            );
+            if (!downloaded) return null;
+            return {
+              ...part,
+              mediaType: downloaded.mediaType,
+              url: `data:${downloaded.mediaType};base64,${downloaded.base64}`,
+            };
+          }),
+        )
+      ).filter((part): part is NonNullable<typeof part> => part != null),
+    })),
+  );
+
   const modelMessages = await convertToModelMessages<AppUIMessage>(
-    branchMessages,
+    hydratedMessages,
     {
       tools,
       convertDataPart: (part) => {


### PR DESCRIPTION
## Problem

The AI SDK migration made a file part's `url` the single source of truth for image bytes — but that `url` is both persisted into `messages.parts` **and** fed straight to the model by `convertToModelMessages` (`data: part.url`). Two regressions resulted:

1. **New uploads store base64 in the DB.** `TextAreaChat.handleSubmit` copied the base64 preview (`image.url`, from `readAsDataURL`) into the persisted part. The bytes were *already* uploaded to the private `images` bucket at `${user}/${conv}/${id}`, so this inlined the entire image into `messages.parts` as pure bloat.
2. **Migrated images don't resolve.** The `20260518000000` backfill wrote `url = /storage/v1/object/public/images/<user>/<conv>/<id>` — a **public-bucket** path. But `images` is private (RLS / signed URLs only), so that path 404s. `MessageBubble` rendered `<img src={part.url}>` directly, showing a broken image, and continuing such a conversation fed the unfetchable URL to the model as file data.

## Fix

Restore the original contract: **persist a lightweight storage reference, resolve bytes from the private bucket by id at every boundary.** The file part's `filename` (`${id}.png`) already carries the id (the backfill preserved this correctly), so `url` becomes a non-load-bearing reference.

- **`shared/imageRefs.ts`** (new) — `imageIdFromFilename`, `imageStoragePath`, `imageFilePartUrl` helpers shared by client + server.
- **`TextAreaChat`** — persists a storage reference instead of the base64 preview (fixes #1; stops the bloat growing).
- **`MessageBubble`** — new `UploadedImage` subcomponent resolves the image by id via `useImageData` (signed download → data URL) with loading/error states, instead of rendering the dead `part.url`. Legacy inline `data:` URLs still render directly (fixes #2 for display).
- **`aiChat`** — before `convertToModelMessages`, image file parts are rehydrated: bytes downloaded from the private bucket → inlined as base64 with the stored object's **real** MIME (so a JPEG isn't mislabeled PNG). Unresolvable parts are dropped instead of poisoning the provider call. `downloadAsBase64` now reports the blob's content type; both call sites updated.

Both new uploads and backfilled rows now share one resolve-by-id path. Existing base64-polluted rows keep working (display branches on `data:`, server passes `data:` URLs through untouched).

## Not included

A one-shot cleanup migration to strip already-persisted base64 from existing rows was intentionally dropped: the prefilter scan timed out against the ~745k-row prod table and the `UPDATE` would take long row locks. It's pure DB-size hygiene and nothing depends on it. If we want to reclaim that space later, the right approach is a keyset-batched backfill run off-peak, not a migration.

## Testing

- New upload, locally: image renders in the bubble, `messages.parts` stores a `/storage/...` reference (not base64), the storage object exists, and the model's reply references the image.
- Migrated rows: verified against backfilled data — previously-broken images now render and conversation continuation no longer feeds a bad URL to the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist lightweight storage references for chat image parts and resolve bytes from the private images bucket at render and model boundaries. This removes DB bloat from inlined base64 and restores image display/model usage for migrated conversations.

- **Bug Fixes**
  - `TextAreaChat`: store a storage ref via `imageFilePartUrl` instead of the base64 preview.
  - `MessageBubble`: resolve images by id with `useImageData`; show loading/error; legacy `data:` URLs still render.
  - Server `aiChat`: rehydrate image file parts to inline base64 with the real MIME from the `images` bucket; drop unresolvable parts; `downloadAsBase64` now returns `{ base64, mediaType }`.
  - New `@shared/imageRefs`: helpers to extract image id and build storage paths/refs used by client and server.

<sup>Written for commit 2198151f6bb61061cd349b190b430de7104bb510. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

