### PR TITLE
Sniff real image media type instead of trusting stored content-type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "embla-carousel-react": "^8.6.0",
         "fflate": "^0.8.2",
         "framer-motion": "^12.16.0",
+        "image-type": "^6.1.0",
         "input-otp": "^1.2.4",
         "lottie-react": "^2.4.1",
         "lucide-react": "^0.446.0",
@@ -649,6 +650,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/@braintree/sanitize-url": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
@@ -696,7 +707,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -708,7 +718,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -719,7 +728,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1186,7 +1194,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2859,7 +2866,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2876,7 +2882,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2893,7 +2898,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2910,7 +2914,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2927,7 +2930,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2944,7 +2946,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2961,7 +2962,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2978,7 +2978,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2995,7 +2994,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3012,7 +3010,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3029,7 +3026,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3046,7 +3042,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3063,7 +3058,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3082,7 +3076,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3099,7 +3092,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4159,11 +4151,33 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6346,9 +6360,10 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -7097,6 +7112,24 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/fill-range": {
@@ -7900,6 +7933,21 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-type": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/image-type/-/image-type-6.1.0.tgz",
+      "integrity": "sha512-SBKn3TelGQdOLAROwl99gN7HUWWozZCHQIH5PmvpJUA/u5+BJBCsVz7lSO+Q3Kl2K/uw9QU6GDcksA16RtuzSw==",
+      "license": "MIT",
+      "dependencies": {
+        "file-type": "^21.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/immediate": {
@@ -10249,24 +10297,6 @@
         }
       }
     },
-    "node_modules/nitro/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/nitro/node_modules/db0": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
@@ -10300,34 +10330,6 @@
         "sqlite3": {
           "optional": true
         }
-      }
-    },
-    "node_modules/nitro/node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/nitro/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/nitro/node_modules/unstorage": {
@@ -12382,6 +12384,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -12790,6 +12808,24 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -12968,6 +13004,18 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "license": "MIT"
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/undici": {
       "version": "7.25.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "embla-carousel-react": "^8.6.0",
     "fflate": "^0.8.2",
     "framer-motion": "^12.16.0",
+    "image-type": "^6.1.0",
     "input-otp": "^1.2.4",
     "lottie-react": "^2.4.1",
     "lucide-react": "^0.446.0",

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -21,6 +21,7 @@ import {
   type UIMessageStreamWriter,
 } from 'ai';
 import type { ProviderOptions } from '@ai-sdk/provider-utils';
+import imageType from 'image-type';
 import { z } from 'zod';
 import { billing, BillingClientError } from './billingClient';
 import { corsHeaders, isRecord } from './api';
@@ -669,6 +670,29 @@ function creativeTools({
   };
 }
 
+// The only image media types Anthropic (and our other providers) accept. We
+// gate `image-type`'s broader detection to this set so we never hand the model
+// a sniffed-but-unsupported mime (HEIC, AVIF, …) that it would reject anyway.
+const ACCEPTED_IMAGE_MEDIA_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
+
+/**
+ * Sniff an image's real media type from its leading magic bytes. The stored
+ * object's content-type metadata is NOT trustworthy: uploads don't pin a
+ * content type and file parts hardcode a `.png` filename, so a JPEG routinely
+ * ends up labeled `image/png` in storage. Providers like Anthropic reject a
+ * declared-mime/actual-bytes mismatch ("specified image/png … appears to be
+ * image/jpeg"), so we derive the type from the bytes themselves.
+ */
+async function sniffImageMediaType(bytes: Uint8Array): Promise<string | null> {
+  const sniffed = (await imageType(bytes))?.mime;
+  return sniffed && ACCEPTED_IMAGE_MEDIA_TYPES.has(sniffed) ? sniffed : null;
+}
+
 async function downloadAsBase64(
   supabaseClient: SupabaseAnon,
   bucket: string,
@@ -685,9 +709,11 @@ async function downloadAsBase64(
   for (let index = 0; index < bytes.length; index += chunkSize) {
     binary += String.fromCharCode(...bytes.slice(index, index + chunkSize));
   }
-  // Report the stored object's real content type so callers don't mislabel
-  // e.g. a JPEG upload as PNG — some providers reject a mime/bytes mismatch.
-  return { base64: btoa(binary), mediaType: data.type || 'image/png' };
+  // Trust the bytes over the stored content type: the metadata mislabels
+  // JPEG/WebP uploads as PNG, and providers reject a mime/bytes mismatch.
+  const mediaType =
+    (await sniffImageMediaType(bytes)) ?? data.type ?? 'image/png';
+  return { base64: btoa(binary), mediaType };
 }
 
 function parametricTools({

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -711,8 +711,11 @@ async function downloadAsBase64(
   }
   // Trust the bytes over the stored content type: the metadata mislabels
   // JPEG/WebP uploads as PNG, and providers reject a mime/bytes mismatch.
+  // `||` (not `??`) on purpose: a Blob with no Content-Type header reports
+  // `data.type` as `''`, which must fall through to the PNG default rather
+  // than emit an empty media type.
   const mediaType =
-    (await sniffImageMediaType(bytes)) ?? data.type ?? 'image/png';
+    (await sniffImageMediaType(bytes)) || data.type || 'image/png';
   return { base64: btoa(binary), mediaType };
 }
 


### PR DESCRIPTION
## Problem

After the image-refs fix (#173 follow-up), chat requests with an attached image could fail with:

```
[chat] Error: messages.4.content.1.image.source.base64: The image was specified
using the image/png media type, but the image appears to be a image/jpeg image
```

We assumed every uploaded image was PNG. When rehydrating image file parts for the model, `downloadAsBase64` relabeled the bytes with the storage object's **content-type metadata** — but that metadata is unreliable:

- the upload path (`TextAreaChat.tsx`) doesn't pin a `contentType`, and
- file parts hardcode a `.png` filename / `image/png` media type.

So a JPEG routinely lands in storage labeled `image/png`. Inlining those bytes as `data:image/png;base64,…` then trips Anthropic's mime/bytes validation.

## Fix

Derive the media type from the **bytes themselves** via the [`image-type`](https://github.com/sindresorhus/image-type) package, gated to the four formats the providers accept (`png`/`jpeg`/`gif`/`webp`) so a sniffed-but-unsupported type (HEIC/AVIF/…) can't trade one rejection for another. Fall back to the stored content-type, then PNG, only when the signature is unrecognized.

Both boundaries that call `downloadAsBase64` are fixed by the single change:
- image-part rehydration before `convertToModelMessages`, and
- the parametric preview `toModelOutput`.

## Notes

- Adds `image-type@^6.1.0` (pure ESM, operates on `Uint8Array`; fine under the Vite-bundled API route). The lockfile also picks up some unrelated npm reconciliation that was already pending at `master`.
- Left the upload side untouched: the server now sniffs at the model boundary and browsers sniff `<img>` regardless of content-type, so storage metadata being wrong is no longer load-bearing.

## Testing

- `tsc --noEmit` and `eslint` clean.
- Verified `image-type` detection against real PNG/JPEG/GIF/WebP buffers and confirmed unrecognized bytes return `undefined` (→ fallback path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect the real image media type from the file bytes instead of storage metadata to stop mime/bytes mismatch errors in chat image uploads. Prevents Anthropic rejections when JPEG/WebP were mislabeled as PNG.

- **Bug Fixes**
  - Sniff media type from bytes using `image-type`; allow only `image/png`, `image/jpeg`, `image/gif`, `image/webp`.
  - Fallback order: sniffed type → stored content-type → PNG; use `||` so empty `data.type` doesn’t emit an empty media type.
  - Applied at the model boundary for image rehydration and the param preview path.

- **Dependencies**
  - Add `image-type@^6.1.0`.

<sup>Written for commit 785c7d15f097f39b13f050d2d8db9623d7c45612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

