### PR TITLE
Persist parameter edits and preserve AI-original defaults

### DIFF
--- a/shared/chatAi.ts
+++ b/shared/chatAi.ts
@@ -112,6 +112,17 @@ export type AppUIMessage = UIMessage<
   {
     model?: Model;
     billingTokens?: number;
+    // The model's original OpenSCAD for this message's artifact, captured
+    // lazily on the FIRST parameter edit (see `persistParameterEdit`).
+    // Parameter edits rewrite the live `tool-build_parametric_model` input
+    // code in place, which would otherwise move the derived `defaultValue`
+    // to the edited value on every reload. Stashing the original here —
+    // message metadata is UI-only and NOT sent to the model by
+    // `convertToModelMessages` — lets the client re-derive stable defaults
+    // (Reset / slider home / auto range) with no second code copy in the
+    // model's context, no migration, and no storage cost on the (common)
+    // never-edited artifacts.
+    originalCode?: string;
   },
   AppDataTypes,
   AppTools

--- a/src/components/parameter/ParameterSection.tsx
+++ b/src/components/parameter/ParameterSection.tsx
@@ -79,11 +79,24 @@ export function ParameterSection({
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingParametersRef = useRef<Parameter[] | null>(null);
 
-  // Cleanup debounce timer on unmount
+  // Always flush through the latest callback — the unmount flush below runs
+  // with `[]` deps, so without this ref it would call a stale closure.
+  const onParameterChangeRef = useRef(onParameterChange);
+  useEffect(() => {
+    onParameterChangeRef.current = onParameterChange;
+  }, [onParameterChange]);
+
+  // On unmount, flush any pending debounced edit instead of dropping it. The
+  // editor remounts on `key={conversation.id}`, so an edit made within the
+  // 200ms window just before navigating away would otherwise be lost.
   useEffect(() => {
     return () => {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
+      }
+      if (pendingParametersRef.current) {
+        onParameterChangeRef.current(pendingParametersRef.current);
+        pendingParametersRef.current = null;
       }
     };
   }, []);

--- a/src/components/parameter/ParameterSheetContent.tsx
+++ b/src/components/parameter/ParameterSheetContent.tsx
@@ -47,10 +47,24 @@ export function ParameterSheetContent({
     latestParametersRef.current = parameters;
   }, [parameters]);
 
+  // Always flush through the latest callback — the unmount flush below runs
+  // with `[]` deps, so without this ref it would call a stale closure.
+  const onParameterChangeRef = useRef(onParameterChange);
+  useEffect(() => {
+    onParameterChangeRef.current = onParameterChange;
+  }, [onParameterChange]);
+
+  // On unmount, flush any pending debounced edit instead of dropping it. The
+  // editor remounts on `key={conversation.id}`, so an edit made within the
+  // 200ms window just before navigating away would otherwise be lost.
   useEffect(() => {
     return () => {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
+      }
+      if (pendingParametersRef.current) {
+        onParameterChangeRef.current(pendingParametersRef.current);
+        pendingParametersRef.current = null;
       }
     };
   }, []);

--- a/src/services/messageService.ts
+++ b/src/services/messageService.ts
@@ -50,14 +50,25 @@ export async function persistAssistantParts({
   conversationId,
   messageId,
   parts,
+  metadata,
 }: {
   conversationId: string;
   messageId: string;
   parts: AppUIMessage['parts'];
+  // When provided, written atomically alongside `parts` in the same row
+  // update. Used by parameter edits to lazily stash `metadata.originalCode`
+  // on the first edit. Omitted by callers that only touch parts (tool
+  // output), leaving the existing metadata untouched.
+  metadata?: AppUIMessage['metadata'];
 }) {
   const { error } = await supabase
     .from('messages')
-    .update({ parts: JSON.parse(JSON.stringify(parts)) })
+    .update({
+      parts: JSON.parse(JSON.stringify(parts)),
+      ...(metadata !== undefined
+        ? { metadata: JSON.parse(JSON.stringify(metadata)) }
+        : {}),
+    })
     .eq('id', messageId)
     .eq('conversation_id', conversationId);
   if (error) throw error;

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -456,6 +456,14 @@ function ConversationEditor() {
     setMobilePreviewVersion((version) => version + 1);
   }, []);
 
+  // Serialize parameter writes (see `drainParameterWrites`): the newest
+  // queued snapshot, plus a flag so at most one persist is ever in flight.
+  const pendingWriteRef = useRef<{
+    messageId: string;
+    artifact: ParametricArtifact;
+  } | null>(null);
+  const writeInFlightRef = useRef(false);
+
   // Persist an in-place parameter edit back onto the assistant message's
   // `tool-build_parametric_model` part so it survives the `key={conversation.id}`
   // remount and a fresh `useMessagesQuery` fetch. Parameters are derived from
@@ -511,6 +519,25 @@ function ConversationEditor() {
     [conversation.id, dbMessages, queryClient],
   );
 
+  // Flush queued parameter writes one at a time. Each `changeParameters`
+  // rebuilds the full code from `baseCodeRef`, so coalescing to the latest
+  // queued snapshot never drops an edit — but two overlapping writes could
+  // commit out of order and leave stale code in the row, so we never let them
+  // run concurrently.
+  const drainParameterWrites = useCallback(async () => {
+    if (writeInFlightRef.current) return;
+    writeInFlightRef.current = true;
+    try {
+      while (pendingWriteRef.current) {
+        const next = pendingWriteRef.current;
+        pendingWriteRef.current = null;
+        await persistParameterEdit(next.messageId, next.artifact);
+      }
+    } finally {
+      writeInFlightRef.current = false;
+    }
+  }, [persistParameterEdit]);
+
   const changeParameters = useCallback(
     (nextParameters: Parameter[]) => {
       if (!baseCodeRef.current || activePreview?.type !== 'artifact') return;
@@ -532,10 +559,14 @@ function ConversationEditor() {
       // clobber (or be clobbered by) a concurrent parameter write. The live
       // preview above still updates regardless.
       if (!isChatStreaming) {
-        void persistParameterEdit(activePreview.messageId, updatedArtifact);
+        pendingWriteRef.current = {
+          messageId: activePreview.messageId,
+          artifact: updatedArtifact,
+        };
+        void drainParameterWrites();
       }
     },
-    [activePreview, isChatStreaming, persistParameterEdit],
+    [activePreview, isChatStreaming, drainParameterWrites],
   );
 
   const updatePrivacy = useCallback(

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -33,7 +33,10 @@ import {
 } from '@/services/messageService';
 import type { DxfExporter } from '@/utils/downloadUtils';
 import type { AppUIMessage } from '@shared/chatAi';
-import { isParametricArtifact } from '@shared/parametricParts';
+import {
+  isParametricArtifact,
+  replaceBuildParametricModelOutput,
+} from '@shared/parametricParts';
 import Tree from '@shared/Tree';
 import type {
   Conversation,
@@ -428,16 +431,23 @@ function ConversationEditor() {
   const handleViewArtifact = useCallback(
     (artifact: ParametricArtifact, messageId: string) => {
       baseCodeRef.current = artifact.code;
-      // Parameters are derived from the OpenSCAD source — same code
-      // always yields the same `<ParameterSection>`, no matter which
-      // model wrote it.
-      setParameters(parseParameters(artifact.code));
+      // Parameters are derived from the OpenSCAD source — same code always
+      // yields the same `<ParameterSection>`, no matter which model wrote
+      // it. The current values come from the (possibly edited) artifact
+      // code; the `defaultValue` (Reset target / slider home / auto range)
+      // comes from `metadata.originalCode` — the model's first-authored
+      // source — so an in-place parameter edit doesn't redefine the default
+      // on the next reload. Read from the cache to keep this callback stable.
+      const originalCode = queryClient
+        .getQueryData<Message[]>(['messages', conversation.id])
+        ?.find((row) => row.id === messageId)?.metadata?.originalCode;
+      setParameters(mergeParameterDefaults(artifact.code, originalCode));
       setCurrentOutput(undefined);
       setDxfExporter(() => null);
       setActivePreview({ type: 'artifact', messageId, artifact });
       setMobilePreviewVersion((version) => version + 1);
     },
-    [],
+    [conversation.id, queryClient],
   );
   const handleViewMesh = useCallback((meshId: string, messageId: string) => {
     setCurrentOutput(undefined);
@@ -445,6 +455,61 @@ function ConversationEditor() {
     setActivePreview({ type: 'mesh', messageId, meshId });
     setMobilePreviewVersion((version) => version + 1);
   }, []);
+
+  // Persist an in-place parameter edit back onto the assistant message's
+  // `tool-build_parametric_model` part so it survives the `key={conversation.id}`
+  // remount and a fresh `useMessagesQuery` fetch. Parameters are derived from
+  // the artifact code, so writing the updated code is all that's needed — no
+  // schema change. Mirrors `handleToolOutput`: DB write first, then cache, so a
+  // post-stream `['messages']` invalidation refetches the already-edited row
+  // instead of reverting. Reads `dbMessages` live (not a captured snapshot) so
+  // `replaceBuildParametricModelOutput` indexes into the current parts array.
+  const persistParameterEdit = useCallback(
+    async (messageId: string, artifact: ParametricArtifact) => {
+      const row = dbMessages.find((message) => message.id === messageId);
+      if (!row) return;
+      const nextParts = replaceBuildParametricModelOutput(row.parts, artifact);
+      // Lazily capture the model's original source the first time a
+      // parameter is edited. Before this feature edits never persisted, so a
+      // message lacking `originalCode` still holds the model's original in
+      // its stored code — which is exactly `baseCodeRef.current` (the code as
+      // loaded, pre-edit). Once stashed, later edits skip this. Anchors the
+      // derived `defaultValue` (Reset / slider home / range) without a
+      // migration or a duplicate copy on never-edited artifacts.
+      const needsOriginal =
+        !!baseCodeRef.current && !row.metadata?.originalCode;
+      const nextMetadata = needsOriginal
+        ? { ...row.metadata, originalCode: baseCodeRef.current ?? undefined }
+        : undefined;
+      try {
+        await persistAssistantParts({
+          conversationId: conversation.id,
+          messageId,
+          parts: nextParts,
+          metadata: nextMetadata,
+        });
+      } catch (error) {
+        // A failed write must never break the live preview — the edit stays
+        // in local state and the next change retries the persist.
+        console.warn('Failed to persist parameter edit:', error);
+        return;
+      }
+      queryClient.setQueryData(
+        ['messages', conversation.id],
+        (old: Message[] | undefined): Message[] =>
+          (old ?? []).map((message) =>
+            message.id === messageId
+              ? {
+                  ...message,
+                  parts: nextParts,
+                  ...(nextMetadata ? { metadata: nextMetadata } : {}),
+                }
+              : message,
+          ),
+      );
+    },
+    [conversation.id, dbMessages, queryClient],
+  );
 
   const changeParameters = useCallback(
     (nextParameters: Parameter[]) => {
@@ -454,15 +519,23 @@ function ConversationEditor() {
         nextCode = updateParameter(nextCode, parameter);
       }
       setParameters(nextParameters);
+      const updatedArtifact: ParametricArtifact = {
+        ...activePreview.artifact,
+        code: nextCode,
+      };
       setActivePreview({
         ...activePreview,
-        artifact: {
-          ...activePreview.artifact,
-          code: nextCode,
-        },
+        artifact: updatedArtifact,
       });
+      // Skip the DB write while a stream is landing on this branch —
+      // `handleToolOutput` owns the row's parts during a stream and would
+      // clobber (or be clobbered by) a concurrent parameter write. The live
+      // preview above still updates regardless.
+      if (!isChatStreaming) {
+        void persistParameterEdit(activePreview.messageId, updatedArtifact);
+      }
     },
-    [activePreview],
+    [activePreview, isChatStreaming, persistParameterEdit],
   );
 
   const updatePrivacy = useCallback(
@@ -672,6 +745,37 @@ function ConversationEditor() {
         />
       }
     />
+  );
+}
+
+/**
+ * Derive the parameter list from the live artifact code, but anchor each
+ * parameter's `defaultValue` to the model's original source when we have it.
+ *
+ * Without this, a parameter edit (which rewrites `name = value;` in the live
+ * code) would also become the parsed `defaultValue` on the next reload —
+ * making "Reset all parameters" a no-op and letting auto-computed slider
+ * ranges drift. `originalCode` is the model's first-authored OpenSCAD, stored
+ * in message metadata; values still track the edited code, defaults track the
+ * original. Falls back to the live code (legacy behavior) for older messages
+ * that predate the stash.
+ */
+function mergeParameterDefaults(
+  code: string,
+  originalCode: string | undefined,
+): Parameter[] {
+  const parameters = parseParameters(code);
+  if (!originalCode || originalCode === code) return parameters;
+  const defaults = new Map(
+    parseParameters(originalCode).map((param) => [
+      param.name,
+      param.defaultValue,
+    ]),
+  );
+  return parameters.map((param) =>
+    defaults.has(param.name)
+      ? { ...param, defaultValue: defaults.get(param.name)! }
+      : param,
   );
 }
 

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -456,12 +456,13 @@ function ConversationEditor() {
     setMobilePreviewVersion((version) => version + 1);
   }, []);
 
-  // Serialize parameter writes (see `drainParameterWrites`): the newest
-  // queued snapshot, plus a flag so at most one persist is ever in flight.
-  const pendingWriteRef = useRef<{
-    messageId: string;
-    artifact: ParametricArtifact;
-  } | null>(null);
+  // Serialize parameter writes (see `drainParameterWrites`): one queued
+  // snapshot per message id, plus a flag so at most one persist is ever in
+  // flight. Keying by message means switching artifacts mid-write can't drop
+  // the other artifact's pending edit.
+  const pendingWritesRef = useRef<
+    Map<string, { artifact: ParametricArtifact; originalCode: string | null }>
+  >(new Map());
   const writeInFlightRef = useRef(false);
 
   // Persist an in-place parameter edit back onto the assistant message's
@@ -473,22 +474,27 @@ function ConversationEditor() {
   // instead of reverting. Reads `dbMessages` live (not a captured snapshot) so
   // `replaceBuildParametricModelOutput` indexes into the current parts array.
   const persistParameterEdit = useCallback(
-    async (messageId: string, artifact: ParametricArtifact) => {
+    async (
+      messageId: string,
+      artifact: ParametricArtifact,
+      originalCode: string | null,
+    ) => {
       const row = dbMessages.find((message) => message.id === messageId);
       if (!row) return;
       const nextParts = replaceBuildParametricModelOutput(row.parts, artifact);
-      // Lazily capture the model's original source the first time a
-      // parameter is edited. Before this feature edits never persisted, so a
-      // message lacking `originalCode` still holds the model's original in
-      // its stored code — which is exactly `baseCodeRef.current` (the code as
-      // loaded, pre-edit). Once stashed, later edits skip this. Anchors the
-      // derived `defaultValue` (Reset / slider home / range) without a
-      // migration or a duplicate copy on never-edited artifacts.
-      const needsOriginal =
-        !!baseCodeRef.current && !row.metadata?.originalCode;
-      const nextMetadata = needsOriginal
-        ? { ...row.metadata, originalCode: baseCodeRef.current ?? undefined }
-        : undefined;
+      // Lazily capture the model's original source the first time a parameter
+      // is edited. Before this feature edits never persisted, so a message
+      // lacking `originalCode` still holds the model's original in its stored
+      // code — the pre-edit code, captured at enqueue time in
+      // `changeParameters`. Pinning it there (rather than reading `baseCodeRef`
+      // here) keeps an in-flight write from grabbing a *different* artifact's
+      // code after the user switches previews mid-drain. Anchors the derived
+      // `defaultValue` (Reset / slider home / range) with no migration or
+      // duplicate copy on never-edited artifacts.
+      const nextMetadata =
+        originalCode && !row.metadata?.originalCode
+          ? { ...row.metadata, originalCode }
+          : undefined;
       try {
         await persistAssistantParts({
           conversationId: conversation.id,
@@ -521,17 +527,23 @@ function ConversationEditor() {
 
   // Flush queued parameter writes one at a time. Each `changeParameters`
   // rebuilds the full code from `baseCodeRef`, so coalescing to the latest
-  // queued snapshot never drops an edit — but two overlapping writes could
-  // commit out of order and leave stale code in the row, so we never let them
-  // run concurrently.
+  // queued snapshot per message never drops an edit — but two overlapping
+  // writes could commit out of order and leave stale code in the row, so we
+  // never let them run concurrently.
   const drainParameterWrites = useCallback(async () => {
     if (writeInFlightRef.current) return;
     writeInFlightRef.current = true;
     try {
-      while (pendingWriteRef.current) {
-        const next = pendingWriteRef.current;
-        pendingWriteRef.current = null;
-        await persistParameterEdit(next.messageId, next.artifact);
+      while (pendingWritesRef.current.size > 0) {
+        const entry = pendingWritesRef.current.entries().next().value;
+        if (!entry) break;
+        const [messageId, write] = entry;
+        pendingWritesRef.current.delete(messageId);
+        await persistParameterEdit(
+          messageId,
+          write.artifact,
+          write.originalCode,
+        );
       }
     } finally {
       writeInFlightRef.current = false;
@@ -559,10 +571,13 @@ function ConversationEditor() {
       // clobber (or be clobbered by) a concurrent parameter write. The live
       // preview above still updates regardless.
       if (!isChatStreaming) {
-        pendingWriteRef.current = {
-          messageId: activePreview.messageId,
+        // Pin the original code at enqueue time — `baseCodeRef` is mutated by
+        // `handleViewArtifact` on preview switch, and an in-flight drain must
+        // not read a later artifact's code for this message's `originalCode`.
+        pendingWritesRef.current.set(activePreview.messageId, {
           artifact: updatedArtifact,
-        };
+          originalCode: baseCodeRef.current,
+        });
         void drainParameterWrites();
       }
     },


### PR DESCRIPTION
## Problem

Parameter edits didn't survive a reload. `changeParameters` rewrote the OpenSCAD via `updateParameter` but only updated local React state — it never wrote back to the DB. Since parameters are *derived* from the artifact code and the editor remounts on `key={conversation.id}`, every edit was re-derived away from the stored (original) code.

This regressed from the pre-AI-SDK editor, which persisted edits via `updateMessageOptimistic` and stored parameters explicitly on the artifact.

## Fix

**Persist edits in place.** `persistParameterEdit` writes the updated code onto the assistant message's `tool-build_parametric_model` part (`replaceBuildParametricModelOutput` → `persistAssistantParts` → cache), mirroring the existing `handleToolOutput` flow. Keeping the code in the tool **input** is deliberately best for the model: it's the single authoritative copy of the current artifact that the next turn reads, with no extra tokens (vs. duplicating it into the tool output).

**Preserve the AI-original default.** Rewriting the code in place would also move the parsed `defaultValue` to the edited value on the next reload — making "Reset all parameters" a no-op and letting auto-computed slider ranges drift. So `defaultValue` is anchored to the model's original source, stashed **lazily** in `metadata.originalCode` on the first edit. Metadata is model-invisible (`convertToModelMessages` ignores it), so there's no token or context cost.

The lazy capture is correct by construction: a message without `originalCode` has never had a persisted edit (edits didn't persist before this change), so its stored code *is* the original. No migration, no storage cost on never-edited artifacts, and old conversations self-heal on their first edit.

## Changes

- **`EditorView.tsx`** — `persistParameterEdit` (in-place write + lazy `originalCode` capture from `baseCodeRef`), a streaming guard so an in-flight stream can't clobber/be clobbered, and `mergeParameterDefaults` (value from live code, default from original).
- **`ParameterSection.tsx` / `ParameterSheetContent.tsx`** — flush a pending debounced edit on unmount, so a drag-then-navigate within the 200ms window isn't dropped (routed through a ref to avoid a stale callback).
- **`messageService.ts`** — `persistAssistantParts` takes optional `metadata`, written atomically alongside `parts`.
- **`chatAi.ts`** — add `originalCode` to the message metadata type.

## Result

| Concern | Behavior |
|---|---|
| Edited values survive reload | persisted into `part.input.code` |
| Model sees current values | single authoritative copy in tool `input` |
| "Reset all parameters" → AI original | `defaultValue` from `metadata.originalCode` |
| Slider home / auto-range stable | anchored to original default |
| Model token cost | unchanged (default lives in invisible metadata) |

## Notes / follow-ups

- Values dialed far beyond an *auto-computed* range pin the slider thumb at max while the number input shows the true value — same as legacy (stored default ≠ value), not a new regression.
- `ShareView` still derives defaults straight from `artifact.code` (doesn't read `originalCode`); fine for read-only sharing, easy parity follow-up if desired.

## Testing

- `npm run typecheck` and `eslint` clean.
- Manually verified: edit → reload restores edited values; "Reset all" returns the AI original; pre-existing conversation self-heals on first edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist parameter edits to the message and preserve the original defaults. Edits survive reloads; Reset and slider ranges use the first-authored defaults.

- **New Features**
  - Persist parameter changes by updating the `tool-build_parametric_model` input and cache.
  - Lazily capture the original source in `metadata.originalCode`; derive `defaultValue` from it while values come from live code.

- **Bug Fixes**
  - Single-flight, per-message queued persists to prevent out-of-order or dropped saves; coalesce to the latest snapshot and capture `originalCode` at enqueue time to avoid cross-artifact mix-ups.
  - Flush pending debounced edits on unmount so recent drags aren’t lost when navigating.
  - Skip DB writes while streaming to avoid races; live preview still updates.
  - `persistAssistantParts` can write `metadata` atomically with `parts`.

<sup>Written for commit ad5785126e064768663ac8191c8c365a568715ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

