### PR TITLE
Make parametric CAD agent loop structurally

### DIFF
--- a/shared/chatAi.ts
+++ b/shared/chatAi.ts
@@ -34,13 +34,13 @@ export const answerUserSchema = z.object({
 export const chatTools = {
   build_parametric_model: tool({
     description:
-      'Create or update the complete OpenSCAD CAD artifact for the user.',
+      'Create or update the complete OpenSCAD CAD artifact. After the browser compiles it, inspect the returned multi-view preview sheet and call this tool again if the model needs another revision.',
     inputSchema: parametricArtifactSchema,
     outputSchema: parametricCompileOutputSchema,
   }),
   answer_user: tool({
     description:
-      'Reply normally when the user is not asking to create, update, or fix a CAD model.',
+      'Send the final user-facing chat message. Use this for normal non-CAD replies, and after a CAD build when the multi-view preview satisfies the user request.',
     inputSchema: answerUserSchema,
     outputSchema: answerUserSchema,
   }),

--- a/shared/parametricParts.ts
+++ b/shared/parametricParts.ts
@@ -86,8 +86,7 @@ export function cleanAssistantText(text: string): string {
   const quoteEnd = draft.indexOf(quote, 1);
   if (quoteEnd === -1) return draft.slice(1).trim();
 
-  const finalText = draft.slice(quoteEnd + 1).trim();
-  return finalText || draft.slice(1, quoteEnd).trim();
+  return draft.slice(1, quoteEnd).trim();
 }
 
 export function getBuildParametricModelPart(parts: unknown) {

--- a/shared/parametricParts.ts
+++ b/shared/parametricParts.ts
@@ -69,7 +69,9 @@ export function cleanAssistantText(text: string): string {
       text,
     );
   if (attachmentLeak) {
-    text = text.slice(attachmentLeak.index + attachmentLeak[0].length);
+    text =
+      text.slice(0, attachmentLeak.index) +
+      text.slice(attachmentLeak.index + attachmentLeak[0].length);
   }
 
   const marker = /Drafting final message:\s*/i.exec(text);

--- a/shared/parametricParts.ts
+++ b/shared/parametricParts.ts
@@ -59,8 +59,33 @@ export function getMeshPreferencesPart(
 export function getParametricText(parts: unknown): string {
   return asParametricParts(parts)
     .filter((part) => part.type === 'text')
-    .map((part) => part.text)
+    .map((part) => cleanAssistantText(part.text))
     .join('');
+}
+
+export function cleanAssistantText(text: string): string {
+  const attachmentLeak =
+    /(?:^|\n)[^\n{}]*(?:alt=media|preview sheet attached automatically)[^\n{}]*[})]?\s*/i.exec(
+      text,
+    );
+  if (attachmentLeak) {
+    text = text.slice(attachmentLeak.index + attachmentLeak[0].length);
+  }
+
+  const marker = /Drafting final message:\s*/i.exec(text);
+  if (!marker) return text;
+
+  const draft = text.slice(marker.index + marker[0].length).trimStart();
+  if (!draft) return '';
+
+  const quote = draft[0];
+  if (quote !== '"' && quote !== "'") return draft;
+
+  const quoteEnd = draft.indexOf(quote, 1);
+  if (quoteEnd === -1) return draft.slice(1).trim();
+
+  const finalText = draft.slice(quoteEnd + 1).trim();
+  return finalText || draft.slice(1, quoteEnd).trim();
 }
 
 export function getBuildParametricModelPart(parts: unknown) {

--- a/src/components/TextAreaChat.tsx
+++ b/src/components/TextAreaChat.tsx
@@ -1524,8 +1524,8 @@ function TextAreaChat({
           }
         }}
       >
-        <div className="flex select-none items-center justify-between p-2">
-          <Avatar className="h-8 w-8">
+        <div className="flex select-none items-start justify-between p-2">
+          <Avatar className="mt-1 h-8 w-8">
             <div className="h-full w-full p-1.5">
               <img
                 src={`${import.meta.env.BASE_URL}/Adam-Logo.png`}
@@ -1548,7 +1548,7 @@ function TextAreaChat({
                 setInput(e.target.value);
               }}
               placeholder={placeholderAnim}
-              className="hide-scrollbar z-40 block h-auto min-h-0 w-full resize-none overflow-hidden whitespace-pre-line break-words border-none bg-adam-neutral-800 bg-transparent px-3 py-2 text-base text-adam-text-primary outline-none transition-all duration-500 placeholder:text-adam-text-secondary placeholder:opacity-[var(--placeholder-opacity)] placeholder:transition-all placeholder:duration-300 placeholder:ease-in-out hover:placeholder:blur-[0.2px] focus:border-0 focus:shadow-none focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:text-gray-200 sm:px-4 sm:text-sm"
+              className="hide-scrollbar z-40 block h-auto min-h-10 w-full resize-none overflow-hidden whitespace-pre-line break-words border-none bg-adam-neutral-800 bg-transparent px-3 py-2 text-base leading-6 text-adam-text-primary outline-none transition-all duration-500 placeholder:text-adam-text-secondary placeholder:opacity-[var(--placeholder-opacity)] placeholder:transition-all placeholder:duration-300 placeholder:ease-in-out hover:placeholder:blur-[0.2px] focus:border-0 focus:shadow-none focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:text-gray-200 sm:px-4 sm:text-sm"
               style={
                 {
                   '--placeholder-opacity': placeholderOpacity,
@@ -1558,7 +1558,7 @@ function TextAreaChat({
               rows={1}
             />
             <div
-              className="pointer-events-none col-start-1 row-start-1 w-full overflow-hidden whitespace-pre-wrap break-words px-3 py-2 text-sm opacity-0 sm:px-4"
+              className="pointer-events-none col-start-1 row-start-1 min-h-10 w-full overflow-hidden whitespace-pre-wrap break-words px-3 py-2 text-sm leading-6 opacity-0 sm:px-4"
               style={{ gridArea: '1 / -1' }}
             >
               <span>{input}</span>

--- a/src/components/chat/ChatReasoning.tsx
+++ b/src/components/chat/ChatReasoning.tsx
@@ -63,7 +63,10 @@ export function ChatReasoning({
   const thinkingVerb = useSharedSpinnerVerb(isStreaming);
 
   return (
-    <Reasoning isStreaming={isStreaming} className={cn('mb-0 mt-1', className)}>
+    <Reasoning
+      isStreaming={isStreaming}
+      className={cn('mb-0 mt-1 min-w-0 max-w-full overflow-hidden', className)}
+    >
       <ReasoningTrigger
         className="min-h-9 text-adam-text-secondary hover:text-adam-text-primary"
         showIcon={false}
@@ -107,7 +110,7 @@ function ChatReasoningBody({
   return (
     <CollapsibleContent
       className={cn(
-        'mt-4 text-sm text-adam-text-secondary outline-none',
+        'mt-4 min-w-0 max-w-full overflow-hidden text-sm text-adam-text-secondary outline-none',
         'data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2',
         'data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-2',
         'data-[state=open]:animate-in data-[state=closed]:animate-out',
@@ -120,7 +123,7 @@ function ChatReasoningBody({
           alone wouldn't work because the Viewport carries `h-full`. */}
       <ScrollArea
         ref={scrollRootRef}
-        className="w-full pr-3 [&_[data-radix-scroll-area-viewport]]:max-h-72"
+        className="min-w-0 max-w-full overflow-hidden pr-3 [&_[data-radix-scroll-area-viewport]]:max-h-72 [&_[data-radix-scroll-area-viewport]]:overflow-x-hidden"
       >
         <div className="chat-markdown min-w-0 max-w-full overflow-hidden">
           <Streamdown parseIncompleteMarkdown plugins={streamdownPlugins}>

--- a/src/components/chat/ChatSession.tsx
+++ b/src/components/chat/ChatSession.tsx
@@ -9,7 +9,11 @@ import { previewScadColoredViaToolWorker } from '@/worker/toolWorker';
 import { apiUrl } from '@/services/api';
 import { messageRowToChatMessage, type ChatMessage } from '@/lib/aiMessages';
 import { supabase } from '@/lib/supabase';
-import { generateColoredPreview, generatePreview } from '@/utils/meshUtils';
+import {
+  generateColoredPreview,
+  generateInspectionPreview,
+  generatePreview,
+} from '@/utils/meshUtils';
 import type {
   AppUIMessage,
   ConversationSuggestionsUpdate,
@@ -290,45 +294,65 @@ export function ChatSession({
       }
 
       try {
-        // Render + upload the preview as part of the tool's execution,
-        // BEFORE `addToolOutput` triggers the auto-continuation. The
-        // server reads it back by toolCallId (see `previewPathForToolCall`
-        // in `aiChat.ts`) and the MessageBubble's `<ParametricImagePreview>`
-        // pulls from the same canonical path via `usePreview`. No path is
-        // returned in the tool output — both consumers derive it.
-        // Mirror VisualCard / ParametricImagePreview's get-or-generate path:
-        // prefer the colored OFF render so the cached thumbnail matches what
-        // the rest of the app shows. Fall back to the gray STL render if OFF
-        // is unavailable or empty.
+        // Upload both images before auto-continuation:
+        // - preview-* is the single ISO thumbnail the chat UI displays.
+        // - inspection-preview-* is the multi-view sheet the agent receives.
         const { stl, off } = await previewScadColoredViaToolWorker(input.code);
+        let inspectionUploaded = false;
         try {
           if (user?.id) {
-            let previewDataUrl: string | null = null;
+            const inspectionDataUrl = await generateInspectionPreview({
+              stl,
+              off,
+            });
+            const inspectionBlob = await fetch(inspectionDataUrl).then(
+              (response) => response.blob(),
+            );
+            const inspectionPath = `${user.id}/${conversation.id}/inspection-preview-${toolCall.toolCallId}`;
+            await supabase.storage
+              .from('images')
+              .upload(inspectionPath, inspectionBlob, {
+                contentType: 'image/png',
+                upsert: true,
+              });
+            inspectionUploaded = true;
+          }
+        } catch (uploadError) {
+          console.warn(
+            'Failed to upload OpenSCAD inspection preview:',
+            uploadError,
+          );
+        }
+
+        try {
+          if (user?.id) {
+            let thumbnailDataUrl: string | null = null;
             if (off) {
-              previewDataUrl = await generateColoredPreview(off);
+              thumbnailDataUrl = await generateColoredPreview(off);
             }
-            if (!previewDataUrl) {
-              previewDataUrl = await generatePreview(stl, 'stl');
+            if (!thumbnailDataUrl) {
+              thumbnailDataUrl = await generatePreview(stl, 'stl');
             }
-            const previewBlob = await fetch(previewDataUrl).then((response) =>
-              response.blob(),
+            const thumbnailBlob = await fetch(thumbnailDataUrl).then(
+              (response) => response.blob(),
             );
             const previewPath = `${user.id}/${conversation.id}/preview-${toolCall.toolCallId}`;
             await supabase.storage
               .from('images')
-              .upload(previewPath, previewBlob, {
+              .upload(previewPath, thumbnailBlob, {
                 contentType: 'image/png',
                 upsert: true,
               });
           }
         } catch (uploadError) {
-          console.warn('Failed to upload OpenSCAD preview:', uploadError);
+          console.warn('Failed to upload OpenSCAD thumbnail:', uploadError);
         }
 
         const output = {
           status: 'success' as const,
-          message:
-            'Compilation successful. The 3D model is now displayed to the user.',
+          message: inspectionUploaded
+            ? 'Compilation successful. Inspect the multi-view render in this tool result against the user request from every visible angle. If anything is missing, wrong, too simple, disconnected, non-printable, hidden from some view, or visually unclear, call build_parametric_model again with a corrected complete OpenSCAD script. If all views satisfy the request, give a concise final response.'
+            : 'Compilation successful, but the multi-view preview sheet was not available. Review the OpenSCAD you wrote against the user request. If anything is missing, wrong, too simple, disconnected, non-printable, or visually unclear, call build_parametric_model again with a corrected complete OpenSCAD script. If it satisfies the request, give a concise final response.',
         };
 
         const successPart = {
@@ -695,11 +719,11 @@ export function ChatSession({
   return (
     <>
       <ScrollArea
-        className="relative w-full max-w-none flex-1 self-center px-3 py-0 md:min-h-0 md:p-4"
+        className="relative min-w-0 max-w-full flex-1 self-center overflow-x-hidden px-3 py-0 md:min-h-0 md:p-4 [&_[data-radix-scroll-area-viewport]]:overflow-x-hidden"
         ref={scrollRef}
       >
         <div className="pointer-events-none sticky left-0 top-0 z-50 h-3 bg-gradient-to-b from-adam-bg-secondary-dark/90 to-transparent md:hidden" />
-        <div className="mx-auto flex max-w-3xl flex-col gap-4 pb-6 md:gap-8 md:pb-0">
+        <div className="mx-auto flex w-full min-w-0 max-w-3xl flex-col gap-4 pb-6 md:gap-8 md:pb-4">
           {branchNodes.map((node, index) => {
             const isLastMessage = index === branchNodes.length - 1;
             return (

--- a/src/components/chat/ChatSession.tsx
+++ b/src/components/chat/ChatSession.tsx
@@ -309,12 +309,13 @@ export function ChatSession({
               (response) => response.blob(),
             );
             const inspectionPath = `${user.id}/${conversation.id}/inspection-preview-${toolCall.toolCallId}`;
-            await supabase.storage
+            const { error: inspectionUploadError } = await supabase.storage
               .from('images')
               .upload(inspectionPath, inspectionBlob, {
                 contentType: 'image/png',
                 upsert: true,
               });
+            if (inspectionUploadError) throw inspectionUploadError;
             inspectionUploaded = true;
           }
         } catch (uploadError) {
@@ -337,12 +338,13 @@ export function ChatSession({
               (response) => response.blob(),
             );
             const previewPath = `${user.id}/${conversation.id}/preview-${toolCall.toolCallId}`;
-            await supabase.storage
+            const { error: thumbnailUploadError } = await supabase.storage
               .from('images')
               .upload(previewPath, thumbnailBlob, {
                 contentType: 'image/png',
                 upsert: true,
               });
+            if (thumbnailUploadError) throw thumbnailUploadError;
           }
         } catch (uploadError) {
           console.warn('Failed to upload OpenSCAD thumbnail:', uploadError);

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -28,7 +28,10 @@ import { previewScadColoredViaToolWorker } from '@/worker/toolWorker';
 import type { ChatMessage } from '@/lib/aiMessages';
 import type { ParametricArtifact } from '@shared/types';
 import type { TreeNode } from '@shared/Tree';
-import { isParametricArtifact } from '@shared/parametricParts';
+import {
+  cleanAssistantText,
+  isParametricArtifact,
+} from '@shared/parametricParts';
 import { imageIdFromFilename } from '@shared/imageRefs';
 import type React from 'react';
 import {
@@ -410,8 +413,27 @@ function AssistantBubble({
     () =>
       message.parts
         .filter((p) => p.type === 'text')
-        .map((p) => p.text)
+        .map((p) => cleanAssistantText(p.text))
         .join(''),
+    [message.parts],
+  );
+  const hasAnswerUserMessage = useMemo(
+    () =>
+      message.parts.some((part) => {
+        if (part.type !== 'tool-answer_user') return false;
+        if (part.state === 'output-available') {
+          return !!part.output.message.trim();
+        }
+        if (
+          (part.state === 'input-streaming' ||
+            part.state === 'input-available') &&
+          part.input &&
+          typeof (part.input as { message?: unknown }).message === 'string'
+        ) {
+          return !!(part.input as { message: string }).message.trim();
+        }
+        return false;
+      }),
     [message.parts],
   );
   const branchIndex = message.siblings.findIndex((b) => b.id === message.id);
@@ -435,8 +457,8 @@ function AssistantBubble({
   };
 
   return (
-    <div className="flex min-w-0 justify-start">
-      <div className="mr-2 mt-1">
+    <div className="flex min-w-0 max-w-full justify-start overflow-hidden">
+      <div className="mr-2 mt-1 shrink-0">
         <Avatar className="h-9 w-9 border border-adam-neutral-700 bg-adam-neutral-950">
           <div style={{ padding: '0.6rem 0.5rem 0.5rem 0.55rem' }}>
             <AvatarImage
@@ -446,16 +468,17 @@ function AssistantBubble({
           </div>
         </Avatar>
       </div>
-      <div className="flex w-[80%] min-w-0 flex-col gap-2">
+      <div className="flex min-w-0 max-w-[calc(100%-3rem)] flex-1 flex-col gap-2">
         {message.parts.map((part, index) => {
           if (part.type === 'text') {
-            if (!part.text) return null;
+            const visibleText = cleanAssistantText(part.text);
+            if (hasAnswerUserMessage || !visibleText) return null;
             return (
               <div
                 key={index}
                 className="chat-markdown min-w-0 max-w-full overflow-hidden rounded-lg bg-adam-neutral-800 px-3 py-2 text-sm text-adam-text-primary"
               >
-                <Streamdown parseIncompleteMarkdown>{part.text}</Streamdown>
+                <Streamdown parseIncompleteMarkdown>{visibleText}</Streamdown>
               </div>
             );
           }
@@ -567,16 +590,17 @@ function AssistantBubble({
           }
 
           if (part.type === 'tool-answer_user') {
-            if (text) return null;
             const answerMessage =
               part.state === 'output-available'
-                ? part.output.message
+                ? cleanAssistantText(part.output.message)
                 : (part.state === 'input-streaming' ||
                       part.state === 'input-available') &&
                     part.input &&
                     typeof (part.input as { message?: unknown }).message ===
                       'string'
-                  ? (part.input as { message: string }).message
+                  ? cleanAssistantText(
+                      (part.input as { message: string }).message,
+                    )
                   : '';
             if (!answerMessage.trim()) return null;
             return (
@@ -875,8 +899,10 @@ function ToolBlock({
   children?: React.ReactNode;
 }) {
   return (
-    <div className="group min-w-0 overflow-hidden rounded-lg border border-adam-neutral-700 bg-adam-neutral-900 text-sm text-adam-text-primary">
-      {previewBody ? <div>{previewBody}</div> : null}
+    <div className="group min-w-0 max-w-full overflow-hidden rounded-lg border border-adam-neutral-700 bg-adam-neutral-900 text-sm text-adam-text-primary">
+      {previewBody ? (
+        <div className="min-w-0 max-w-full overflow-hidden">{previewBody}</div>
+      ) : null}
       <div
         className={cn(
           'flex w-full items-stretch hover:bg-adam-neutral-800',
@@ -918,7 +944,7 @@ function ToolBlock({
         ) : null}
       </div>
       {expanded && children ? (
-        <div className="min-w-0 border-t border-adam-neutral-700">
+        <div className="min-w-0 max-w-full overflow-hidden border-t border-adam-neutral-700">
           {children}
         </div>
       ) : null}

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -88,6 +88,21 @@ function getStringField(value: unknown, key: string): string | undefined {
   return typeof field === 'string' ? field : undefined;
 }
 
+function answerUserMessageText(
+  part: ChatMessage['parts'][number],
+): string | undefined {
+  if (part.type !== 'tool-answer_user') return undefined;
+
+  const message =
+    part.state === 'output-available'
+      ? part.output.message
+      : part.state === 'input-streaming' || part.state === 'input-available'
+        ? getStringField(part.input, 'message')
+        : undefined;
+  const cleaned = message ? cleanAssistantText(message).trim() : '';
+  return cleaned || undefined;
+}
+
 /**
  * Renders a user-attached image by downloading it from the private `images`
  * bucket (via {@link useImageData}) rather than trusting the part's `url`.
@@ -427,22 +442,13 @@ function AssistantBubble({
         .join(''),
     [message.parts],
   );
+  const answerText = useMemo(
+    () => message.parts.map(answerUserMessageText).filter(Boolean).join(''),
+    [message.parts],
+  );
+  const copyText = answerText || text;
   const hasAnswerUserMessage = useMemo(
-    () =>
-      message.parts.some((part) => {
-        if (part.type !== 'tool-answer_user') return false;
-        if (part.state === 'output-available') {
-          return !!part.output.message.trim();
-        }
-        if (
-          (part.state === 'input-streaming' ||
-            part.state === 'input-available') &&
-          getStringField(part.input, 'message')?.trim()
-        ) {
-          return true;
-        }
-        return false;
-      }),
+    () => message.parts.some((part) => !!answerUserMessageText(part)?.trim()),
     [message.parts],
   );
   const branchIndex = message.siblings.findIndex((b) => b.id === message.id);
@@ -597,17 +603,7 @@ function AssistantBubble({
           }
 
           if (part.type === 'tool-answer_user') {
-            const partialAnswer =
-              part.state === 'input-streaming' ||
-              part.state === 'input-available'
-                ? getStringField(part.input, 'message')
-                : undefined;
-            const answerMessage =
-              part.state === 'output-available'
-                ? cleanAssistantText(part.output.message)
-                : partialAnswer
-                  ? cleanAssistantText(partialAnswer)
-                  : '';
+            const answerMessage = answerUserMessageText(part) ?? '';
             if (!answerMessage.trim()) return null;
             return (
               <div
@@ -685,14 +681,14 @@ function AssistantBubble({
               </div>
             )}
 
-            {text && (
+            {copyText && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
                     variant="outline"
                     size="icon"
                     className="h-6 w-6 rounded-lg p-0"
-                    onClick={() => navigator.clipboard.writeText(text)}
+                    onClick={() => navigator.clipboard.writeText(copyText)}
                     aria-label="Copy"
                   >
                     <Copy className="h-3 w-3 text-adam-neutral-100" />

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -78,6 +78,16 @@ export function MessageBubble(props: MessageBubbleProps) {
   );
 }
 
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getStringField(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  return typeof field === 'string' ? field : undefined;
+}
+
 /**
  * Renders a user-attached image by downloading it from the private `images`
  * bucket (via {@link useImageData}) rather than trusting the part's `url`.
@@ -427,10 +437,9 @@ function AssistantBubble({
         if (
           (part.state === 'input-streaming' ||
             part.state === 'input-available') &&
-          part.input &&
-          typeof (part.input as { message?: unknown }).message === 'string'
+          getStringField(part.input, 'message')?.trim()
         ) {
-          return !!(part.input as { message: string }).message.trim();
+          return true;
         }
         return false;
       }),
@@ -514,10 +523,8 @@ function AssistantBubble({
             // `part.input` is a partial object during streaming — pull off
             // whatever `code` has arrived so far.
             const partialCode =
-              part.state === 'input-streaming' &&
-              part.input &&
-              typeof (part.input as { code?: unknown }).code === 'string'
-                ? (part.input as { code: string }).code
+              part.state === 'input-streaming'
+                ? (getStringField(part.input, 'code') ?? '')
                 : '';
             if (part.state === 'input-streaming') {
               return (
@@ -590,17 +597,16 @@ function AssistantBubble({
           }
 
           if (part.type === 'tool-answer_user') {
+            const partialAnswer =
+              part.state === 'input-streaming' ||
+              part.state === 'input-available'
+                ? getStringField(part.input, 'message')
+                : undefined;
             const answerMessage =
               part.state === 'output-available'
                 ? cleanAssistantText(part.output.message)
-                : (part.state === 'input-streaming' ||
-                      part.state === 'input-available') &&
-                    part.input &&
-                    typeof (part.input as { message?: unknown }).message ===
-                      'string'
-                  ? cleanAssistantText(
-                      (part.input as { message: string }).message,
-                    )
+                : partialAnswer
+                  ? cleanAssistantText(partialAnswer)
                   : '';
             if (!answerMessage.trim()) return null;
             return (

--- a/src/components/chat/StreamingCodeBlock.tsx
+++ b/src/components/chat/StreamingCodeBlock.tsx
@@ -54,7 +54,7 @@ export function StreamingCodeBlock({
   }, [visibleCode, showCaret]);
 
   return (
-    <div className="w-full overflow-hidden rounded-lg border border-white/[0.06] bg-adam-neutral-950/90 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+    <div className="min-w-0 max-w-full overflow-hidden rounded-lg border border-white/[0.06] bg-adam-neutral-950/90 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
       <div className="flex h-7 items-center justify-between gap-3 border-b border-white/[0.06] px-3">
         <div className="flex min-w-0 flex-1 items-center gap-1.5 text-[10.5px] font-medium uppercase tracking-[0.08em] text-adam-neutral-400">
           <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-adam-blue/80" />
@@ -79,7 +79,7 @@ export function StreamingCodeBlock({
             work because the Viewport carries `h-full`. */}
         <ScrollArea
           ref={scrollRootRef}
-          className="w-full font-mono text-[11.5px] leading-[1.55] text-adam-text-primary/95 [&_[data-radix-scroll-area-viewport]]:max-h-[180px]"
+          className="min-w-0 max-w-full font-mono text-[11.5px] leading-[1.55] text-adam-text-primary/95 [&_[data-radix-scroll-area-viewport]]:max-h-[180px] [&_[data-radix-scroll-area-viewport]]:overflow-x-hidden"
         >
           <pre className="m-0 whitespace-pre-wrap break-words px-3 py-2.5">
             <code>{visibleCode}</code>

--- a/src/index.css
+++ b/src/index.css
@@ -160,8 +160,14 @@ input::placeholder {
 
 @layer components {
   .chat-markdown {
+    min-width: 0;
+    max-width: 100%;
     overflow-wrap: anywhere;
     word-break: break-word;
+  }
+
+  .chat-markdown :where(*) {
+    max-width: 100%;
   }
 
   .chat-markdown :where(p, li, blockquote, h1, h2, h3, h4, h5, h6) {
@@ -195,22 +201,25 @@ input::placeholder {
 
   .chat-markdown :where(pre) {
     max-width: 100%;
-    overflow-x: auto;
+    min-width: 0;
+    overflow-x: hidden;
     overflow-y: hidden;
     border-radius: 0.75rem;
     border: 1px solid rgba(255, 255, 255, 0.08);
     background: rgba(18, 18, 18, 0.92) !important;
     color: #e8e8e8 !important;
     padding: 0.75rem;
-    white-space: pre;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   .chat-markdown :where(pre code) {
     display: block;
-    min-width: max-content;
-    white-space: pre;
-    overflow-wrap: normal;
-    word-break: normal;
+    min-width: 0;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
     background: transparent !important;
     color: inherit !important;
     padding: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -202,7 +202,7 @@ input::placeholder {
   .chat-markdown :where(pre) {
     max-width: 100%;
     min-width: 0;
-    overflow-x: hidden;
+    overflow-x: auto;
     overflow-y: hidden;
     border-radius: 0.75rem;
     border: 1px solid rgba(255, 255, 255, 0.08);

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -288,7 +288,8 @@ function shouldUseLocalOpenRouter(modelId: string): boolean {
   return (
     env('ENVIRONMENT') === 'local' &&
     !!env('OPENROUTER_API_KEY') &&
-    (modelId.startsWith('anthropic/') || modelId.startsWith('google/'))
+    ((modelId.startsWith('anthropic/') && !env('ANTHROPIC_API_KEY')) ||
+      (modelId.startsWith('google/') && !env('GOOGLE_API_KEY')))
   );
 }
 
@@ -1088,7 +1089,6 @@ export async function handleAiChatRequest(req: Request) {
           ) ?? false;
       if (
         conversation.type === 'parametric' &&
-        leafRole === 'user' &&
         (stepNumber === 0 || previousStepCalledBuild)
       ) {
         // Parametric turns stay structured: first choose build vs answer;

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -2,7 +2,7 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { chatTools, type AppUIMessage, type AppTools } from '@shared/chatAi';
-import { getParametricText } from '@shared/parametricParts';
+import { cleanAssistantText, getParametricText } from '@shared/parametricParts';
 import { imageIdFromFilename, imageStoragePath } from '@shared/imageRefs';
 import { normalizeConversationSuggestions } from '@shared/suggestions';
 import type { Conversation, Message, MeshFileType, Model } from '@shared/types';
@@ -12,6 +12,7 @@ import {
   createUIMessageStream,
   createUIMessageStreamResponse,
   generateText,
+  hasToolCall,
   Output,
   smoothStream,
   stepCountIs,
@@ -81,11 +82,11 @@ const FALLBACK_MODEL_PRICE = { input: 15, output: 75 };
  */
 const USD_PER_BILLING_TOKEN = 0.01;
 
-const PARAMETRIC_AGENT_PROMPT = `You are Adam, an AI CAD editor that creates and modifies OpenSCAD models. The user can see a live preview of the model on the right while you work.
+const PARAMETRIC_AGENT_PROMPT = `You are Adam, an agentic AI CAD editor that creates and modifies OpenSCAD models. The user can see a live preview of the model on the right while you work.
 
-On each user turn, choose exactly one path:
+Start each user turn by choosing exactly one path:
 - Use build_parametric_model whenever the user asks for a CAD model, an edit to a CAD model, or a fix for OpenSCAD code. Speak back briefly (one or two sentences) and let the tool carry the change — never paste OpenSCAD into your reply text.
-- Use answer_user only for greetings, thanks, app/capability questions, or informational questions that do not ask you to create or change a model.
+- Use answer_user for greetings, thanks, app/capability questions, informational questions that do not ask you to create or change a model, and the final user-facing message after a CAD build succeeds.
 
 Never say you created, designed, generated, updated, or fixed a model unless you used build_parametric_model in that turn.
 
@@ -97,8 +98,22 @@ The build_parametric_model tool input is the artifact shown to the user:
 - code: complete raw OpenSCAD code, no markdown, no code fences
 
 After you call build_parametric_model, the browser compiles the OpenSCAD and
-returns whether compilation succeeded. If it fails, fix the code with another
-build_parametric_model call.
+returns a multi-view preview sheet covering isometric, front, back, left,
+right, top, and bottom views. Inspect every view against the user's request. If
+the code fails to compile, or any view shows missing, wrong, disconnected,
+non-printable, too-simple, hidden, or visually unclear geometry, call
+build_parametric_model again with a corrected complete script. Keep looping
+through write → multi-view screenshot inspection → rewrite until the model is
+good or you hit the turn limit. Do not stop after the first successful compile
+unless the preview sheet shows that the model satisfies the request from every
+view. When all views satisfy the request, call answer_user with the concise
+final response instead of writing normal assistant text.
+
+Final responses must be only the short user-facing message. Do not include
+analysis, draft notes, screenshot observations, storage URLs, filenames,
+attachment labels, or phrases like "preview sheet attached automatically".
+After a successful build, speak in past tense (for example, "Done — I made...")
+instead of future tense ("I'll make...").
 
 # OpenSCAD code rules
 
@@ -269,7 +284,16 @@ const THINKING_BUDGET_TOKENS = 9000;
 
 type ChatProvider = 'anthropic' | 'google' | 'openrouter';
 
+function shouldUseLocalOpenRouter(modelId: string): boolean {
+  return (
+    env('ENVIRONMENT') === 'local' &&
+    !!env('OPENROUTER_API_KEY') &&
+    (modelId.startsWith('anthropic/') || modelId.startsWith('google/'))
+  );
+}
+
 function providerFor(modelId: string): ChatProvider {
+  if (shouldUseLocalOpenRouter(modelId)) return 'openrouter';
   if (modelId.startsWith('anthropic/')) return 'anthropic';
   if (modelId.startsWith('google/')) return 'google';
   return 'openrouter';
@@ -314,15 +338,27 @@ function createChatProviders(): ChatProviders {
  * Map a `<provider>/<model>` ID to a configured LanguageModel + the
  * provider-specific options the AI SDK expects at the streamText boundary.
  *
- * Anthropic and Google are hit directly via their respective AI SDK providers.
- * Everything else (OpenAI, MoonshotAI, …) keeps going through OpenRouter so we
- * don't have to wire a dedicated provider per vendor.
+ * Anthropic and Google are hit directly via their respective AI SDK providers
+ * unless local development is configured with only OpenRouter. Everything else
+ * (OpenAI, MoonshotAI, …) keeps going through OpenRouter so we don't have to
+ * wire a dedicated provider per vendor.
  */
 function buildChatModel(
   modelId: string,
   providers: ChatProviders,
   thinking: boolean,
 ): { model: LanguageModel; providerOptions?: ProviderOptions } {
+  if (providerFor(modelId) === 'openrouter') {
+    return {
+      model: providers.openrouter().chat(modelId, {
+        ...(thinking
+          ? { reasoning: { max_tokens: THINKING_BUDGET_TOKENS } }
+          : {}),
+        usage: { include: true },
+      }),
+    };
+  }
+
   if (modelId.startsWith('anthropic/')) {
     // Anthropic's API uses dashes everywhere ("claude-haiku-4-5"), while the
     // OpenRouter alias uses dots ("claude-haiku-4.5"). Normalize both.
@@ -364,14 +400,7 @@ function buildChatModel(
     };
   }
 
-  return {
-    model: providers.openrouter().chat(modelId, {
-      ...(thinking
-        ? { reasoning: { max_tokens: THINKING_BUDGET_TOKENS } }
-        : {}),
-      usage: { include: true },
-    }),
-  };
+  throw new Error(`Unsupported chat model ${modelId}`);
 }
 
 function priceFor(modelId: string) {
@@ -455,7 +484,16 @@ function finalizeStreamingParts(
       (part.type === 'reasoning' || part.type === 'text') &&
       part.state === 'streaming'
     ) {
-      return { ...part, state: 'done' as const };
+      return {
+        ...part,
+        state: 'done' as const,
+        ...(part.type === 'text'
+          ? { text: cleanAssistantText(part.text) }
+          : {}),
+      };
+    }
+    if (part.type === 'text') {
+      return { ...part, text: cleanAssistantText(part.text) };
     }
     return part;
   });
@@ -736,11 +774,11 @@ function parametricTools({
         toolCallId: string;
         output: AppTools['build_parametric_model']['output'];
       }) {
-        // The client uploads a render of the compiled SCAD to a path
+        // The client uploads a multi-view render of the compiled SCAD to a path
         // derived from toolCallId BEFORE sending the tool result (see
         // ChatSession's `onToolCall`). If for any reason the upload
         // didn't land, `downloadAsBase64` returns null and we fall back
-        // to text-only — never block the loop on a missing thumbnail.
+        // to text-only — never block the loop on a missing inspection sheet.
         const downloaded = await downloadAsBase64(
           supabaseClient,
           'images',
@@ -865,7 +903,7 @@ export async function handleAiChatRequest(req: Request) {
       : parametricTools({
           supabaseClient,
           previewPathForToolCall: (toolCallId) =>
-            `${user.id}/${conversation.id}/preview-${toolCallId}`,
+            `${user.id}/${conversation.id}/inspection-preview-${toolCallId}`,
         });
 
   let branchMessages: AppUIMessage[];
@@ -1041,17 +1079,27 @@ export async function handleAiChatRequest(req: Request) {
     system: systemPrompt(conversation),
     messages: modelMessages,
     tools,
-    prepareStep: ({ stepNumber }) =>
-      conversation.type === 'parametric' &&
-      leafRole === 'user' &&
-      stepNumber === 0
-        ? {
-            // Parametric user turns must take one structured path first:
-            // either create/update CAD or explicitly answer normally.
-            toolChoice: 'required',
-          }
-        : {},
-    stopWhen: stepCountIs(5),
+    prepareStep: ({ stepNumber, steps }) => {
+      const previousStepCalledBuild =
+        steps
+          .at(-1)
+          ?.toolCalls.some(
+            (toolCall) => toolCall.toolName === 'build_parametric_model',
+          ) ?? false;
+      if (
+        conversation.type === 'parametric' &&
+        leafRole === 'user' &&
+        (stepNumber === 0 || previousStepCalledBuild)
+      ) {
+        // Parametric turns stay structured: first choose build vs answer;
+        // after each build, choose revise vs final answer_user.
+        return {
+          toolChoice: 'required' as const,
+        };
+      }
+      return {};
+    },
+    stopWhen: [stepCountIs(5), hasToolCall('answer_user')],
     maxOutputTokens: rawBody.thinking ? 20000 : 16000,
     abortSignal: req.signal,
     // Decouple our render cadence from the provider's native chunking.

--- a/src/utils/meshUtils.ts
+++ b/src/utils/meshUtils.ts
@@ -423,7 +423,12 @@ export const generateInspectionPreview = async ({
   let scene: THREE.Scene | null = null;
 
   if (off) {
-    const group = buildColoredGroupFromOff(await off.text(), fallbackColor);
+    let group: THREE.Group | null = null;
+    try {
+      group = buildColoredGroupFromOff(await off.text(), fallbackColor);
+    } catch {
+      group = null;
+    }
     if (group) {
       const rotated = new THREE.Group();
       rotated.rotation.x = -Math.PI / 2;

--- a/src/utils/meshUtils.ts
+++ b/src/utils/meshUtils.ts
@@ -158,10 +158,28 @@ export function isValidSTL(file: File): boolean {
   return validMimeTypes.includes(file.type) || file.type === '';
 }
 
-// Render any prebuilt THREE.Scene to a 1000×1000 PNG data URL using the same
-// camera framing (top-right-front isometric), HDR environment, and lighting
-// that both `generatePreview` and `generateColoredPreview` rely on.
-function renderSceneToDataUrl(scene: THREE.Scene): string {
+const INSPECTION_VIEWS = [
+  { name: 'ISO', direction: new THREE.Vector3(1, 1, 1) },
+  { name: 'FRONT', direction: new THREE.Vector3(0, 0, 1) },
+  { name: 'BACK', direction: new THREE.Vector3(0, 0, -1) },
+  { name: 'LEFT', direction: new THREE.Vector3(-1, 0, 0) },
+  { name: 'RIGHT', direction: new THREE.Vector3(1, 0, 0) },
+  { name: 'TOP', direction: new THREE.Vector3(0, 1, 0) },
+  { name: 'BOTTOM', direction: new THREE.Vector3(0, -1, 0) },
+] as const;
+
+function createPreviewRenderer(size: number) {
+  const renderer = new THREE.WebGLRenderer({
+    antialias: true,
+    preserveDrawingBuffer: true,
+  });
+  renderer.setSize(size, size);
+  renderer.toneMapping = THREE.NoToneMapping;
+  renderer.setPixelRatio(window.devicePixelRatio);
+  return renderer;
+}
+
+function frameScene(scene: THREE.Scene) {
   const box = new THREE.Box3().setFromObject(scene);
   const center = new THREE.Vector3();
   const size = new THREE.Vector3();
@@ -172,23 +190,17 @@ function renderSceneToDataUrl(scene: THREE.Scene): string {
   // padding) and as the camera's stand-off distance from `center`. Ortho has
   // no foreshortening, so distance only needs to keep the model inside the
   // near/far planes.
-  const diagonal = Math.sqrt(
-    size.x * size.x + size.y * size.y + size.z * size.z,
-  );
+  const diagonal =
+    Math.sqrt(size.x * size.x + size.y * size.y + size.z * size.z) || 1;
   const halfExtent = (diagonal / 2) * 1.1;
+  return { center, diagonal, halfExtent };
+}
 
-  const renderer = new THREE.WebGLRenderer({
-    antialias: true,
-    preserveDrawingBuffer: true,
-  });
-  renderer.setSize(1000, 1000);
-  renderer.toneMapping = THREE.NoToneMapping;
-  renderer.setPixelRatio(window.devicePixelRatio);
-
-  // Orthographic gives the clean technical-drawing look you want for thumbnails
-  // — parallel edges stay parallel, scale comparison reads correctly across
-  // different artifacts. Aspect is 1:1 since we render to a 1000×1000 PNG.
-  const camera = new THREE.OrthographicCamera(
+function createPreviewCamera(halfExtent: number, diagonal: number) {
+  // Orthographic gives the clean technical-drawing look you want for previews:
+  // parallel edges stay parallel, scale comparison reads correctly across
+  // different artifacts.
+  return new THREE.OrthographicCamera(
     -halfExtent,
     halfExtent,
     halfExtent,
@@ -196,15 +208,9 @@ function renderSceneToDataUrl(scene: THREE.Scene): string {
     0.1,
     diagonal * 10,
   );
-  // Top-right-front isometric framing — matches the live viewer's gizmo TFR
-  // corner instead of staring straight down +Z, which on a Z-up OpenSCAD
-  // STL/OFF produced a flat top-down view.
-  const isoOffset = new THREE.Vector3(1, 1, 1)
-    .normalize()
-    .multiplyScalar(diagonal * 2);
-  camera.position.copy(center).add(isoOffset);
-  camera.lookAt(center);
+}
 
+function createPreviewScene(renderer: THREE.WebGLRenderer, scene: THREE.Scene) {
   const pmremGenerator = new THREE.PMREMGenerator(renderer);
   const renderScene = new THREE.Scene();
   renderScene.background = new THREE.Color(0x3b3b3b);
@@ -218,6 +224,48 @@ function renderSceneToDataUrl(scene: THREE.Scene): string {
   renderScene.add(directionalLight);
 
   renderScene.add(scene);
+  return { renderScene, pmremGenerator };
+}
+
+function renderView({
+  camera,
+  center,
+  diagonal,
+  direction,
+}: {
+  camera: THREE.OrthographicCamera;
+  center: THREE.Vector3;
+  diagonal: number;
+  direction: THREE.Vector3;
+}) {
+  camera.position.copy(center).add(
+    direction
+      .clone()
+      .normalize()
+      .multiplyScalar(diagonal * 2),
+  );
+  camera.lookAt(center);
+  camera.updateProjectionMatrix();
+}
+
+// Render any prebuilt THREE.Scene to a 1000×1000 PNG data URL using the same
+// camera framing (top-right-front isometric), HDR environment, and lighting
+// that both `generatePreview` and `generateColoredPreview` rely on.
+function renderSceneToDataUrl(scene: THREE.Scene): string {
+  const { center, diagonal, halfExtent } = frameScene(scene);
+  const renderer = createPreviewRenderer(1000);
+  const camera = createPreviewCamera(halfExtent, diagonal);
+  const { renderScene, pmremGenerator } = createPreviewScene(renderer, scene);
+
+  // Top-right-front isometric framing — matches the live viewer's gizmo TFR
+  // corner instead of staring straight down +Z, which on a Z-up OpenSCAD
+  // STL/OFF produced a flat top-down view.
+  renderView({
+    camera,
+    center,
+    diagonal,
+    direction: INSPECTION_VIEWS[0].direction,
+  });
 
   renderer.render(renderScene, camera);
   const image = renderer.domElement.toDataURL('image/png');
@@ -225,6 +273,55 @@ function renderSceneToDataUrl(scene: THREE.Scene): string {
   pmremGenerator.dispose();
   renderer.dispose();
   return image;
+}
+
+function renderInspectionSceneToDataUrl(scene: THREE.Scene): string {
+  const tileSize = 512;
+  const columns = 3;
+  const rows = 3;
+  const sheet = document.createElement('canvas');
+  sheet.width = tileSize * columns;
+  sheet.height = tileSize * rows;
+  const context = sheet.getContext('2d');
+  if (!context) throw new Error('Failed to create inspection canvas');
+
+  const { center, diagonal, halfExtent } = frameScene(scene);
+  const renderer = createPreviewRenderer(tileSize);
+  const camera = createPreviewCamera(halfExtent, diagonal);
+  const { renderScene, pmremGenerator } = createPreviewScene(renderer, scene);
+
+  try {
+    context.fillStyle = '#2b2b2b';
+    context.fillRect(0, 0, sheet.width, sheet.height);
+    context.font =
+      '600 28px system-ui, -apple-system, BlinkMacSystemFont, sans-serif';
+    context.textBaseline = 'top';
+
+    for (let index = 0; index < INSPECTION_VIEWS.length; index += 1) {
+      const view = INSPECTION_VIEWS[index];
+      const x = (index % columns) * tileSize;
+      const y = Math.floor(index / columns) * tileSize;
+
+      renderView({
+        camera,
+        center,
+        diagonal,
+        direction: view.direction,
+      });
+      renderer.render(renderScene, camera);
+      context.drawImage(renderer.domElement, x, y, tileSize, tileSize);
+
+      context.fillStyle = 'rgba(0, 0, 0, 0.62)';
+      context.fillRect(x + 16, y + 16, 126, 42);
+      context.fillStyle = '#ffffff';
+      context.fillText(view.name, x + 28, y + 23);
+    }
+  } finally {
+    pmremGenerator.dispose();
+    renderer.dispose();
+  }
+
+  return sheet.toDataURL('image/png');
 }
 
 export const generatePreview = async (
@@ -312,6 +409,56 @@ export const generateColoredPreview = async (
   scene.add(rotated);
 
   return renderSceneToDataUrl(scene);
+};
+
+export const generateInspectionPreview = async ({
+  stl,
+  off,
+  fallbackColor = 0x00a6ff,
+}: {
+  stl: Blob;
+  off?: Blob | null;
+  fallbackColor?: number;
+}): Promise<string> => {
+  let scene: THREE.Scene | null = null;
+
+  if (off) {
+    const group = buildColoredGroupFromOff(await off.text(), fallbackColor);
+    if (group) {
+      const rotated = new THREE.Group();
+      rotated.rotation.x = -Math.PI / 2;
+
+      const box = new THREE.Box3().setFromObject(group);
+      if (!box.isEmpty()) {
+        const center = box.getCenter(new THREE.Vector3());
+        group.position.sub(center);
+      }
+      rotated.add(group);
+
+      scene = new THREE.Scene();
+      scene.add(rotated);
+    }
+  }
+
+  if (!scene) {
+    const arrayBuffer = await stl.arrayBuffer();
+    const loader = new STLLoader();
+    const geometry = loader.parse(arrayBuffer);
+    geometry.rotateX(-Math.PI / 2);
+    geometry.center();
+    geometry.computeVertexNormals();
+
+    const material = new THREE.MeshStandardMaterial({
+      color: fallbackColor,
+      metalness: 0.6,
+      roughness: 0.3,
+      envMapIntensity: 0.3,
+    });
+    scene = new THREE.Scene();
+    scene.add(new THREE.Mesh(geometry, material));
+  }
+
+  return renderInspectionSceneToDataUrl(scene);
 };
 
 export const applyMaterialAdjustments = (


### PR DESCRIPTION
## Summary
- make parametric CAD turns loop through build/inspect/revise until final answer
- provide the model a multi-view inspection sheet while keeping the chat thumbnail ISO-only
- constrain chat/reasoning/code overflow inside the chat panel
- route local Anthropic/Google model IDs through OpenRouter when only local OpenRouter credentials are configured

## Why
CADAM was stopping after a single compile and sometimes surfaced provider/tool metadata or scratchpad text in the visible chat. The CAD flow now uses a structured final answer boundary and keeps inspection screenshots internal to the agent loop.

## Validation
- npm run typecheck
- npm run build
- git diff --check
- local dev server returned HTTP 200 at /cadam/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The parametric CAD agent now loops through build → multi‑view inspect → revise until it sends a final `answer_user`, using a labeled 7‑view inspection sheet kept in the tool result while the chat shows one ISO thumbnail. The chat and tool UI clamp widths to prevent horizontal overflow, and local `anthropic/*` and `google/*` IDs route via OpenRouter when only `OPENROUTER_API_KEY` is set.

- **New Features**
  - Structured CAD loop: use `build_parametric_model`, inspect the 7‑view sheet, revise as needed, then finish with `answer_user`.
  - Upload `inspection-preview-*` for the agent and `preview-*` as the chat thumbnail; tool output instructs the agent to inspect all views and either revise or finish.
  - Server requires a tool at step 0 and after each build; auto‑stops when `answer_user` is called.

- **Bug Fixes**
  - Prevent horizontal overflow across chat, reasoning, code blocks, tool cards, and scroll areas; code blocks wrap instead of scrolling long lines.
  - Strip attachment labels and scratchpad/draft text with `cleanAssistantText` across streamed and finalized content.
  - Show only the final `answer_user` content when present; hide interim assistant text.

<sup>Written for commit a92af35d608b3ecc10bbfbe72530a79c373d3fce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

