### PR TITLE
Fix parametric agent loop

### DIFF
--- a/shared/chatAi.ts
+++ b/shared/chatAi.ts
@@ -25,6 +25,14 @@ export const parametricArtifactSchema = z.object({
 export const parametricCompileOutputSchema = z.object({
   status: z.literal('success'),
   message: z.string(),
+  inspection: z
+    .object({
+      views: z.array(
+        z.enum(['ISO', 'FRONT', 'BACK', 'LEFT', 'RIGHT', 'TOP', 'BOTTOM']),
+      ),
+      imageAttached: z.boolean(),
+    })
+    .optional(),
 });
 
 export const answerUserSchema = z.object({

--- a/shared/parametricParts.test.ts
+++ b/shared/parametricParts.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { cleanAssistantText } from './parametricParts.ts';
+
+describe('parametric assistant text cleanup', () => {
+  it('removes leaked view metadata before final prose', () => {
+    assert.equal(
+      cleanAssistantText(
+        ', viewpoint_state:{"distance":624},"zoom_info":A fallback automatic framing was used instead.}ளர்This 12 DOF robot arm is ready.',
+      ),
+      'This 12 DOF robot arm is ready.',
+    );
+  });
+
+  it('removes metadata-only fragments', () => {
+    assert.equal(
+      cleanAssistantText(',title:Detailed San Francisco,version:v1}'),
+      '',
+    );
+  });
+});

--- a/shared/parametricParts.ts
+++ b/shared/parametricParts.ts
@@ -64,6 +64,22 @@ export function getParametricText(parts: unknown): string {
 }
 
 export function cleanAssistantText(text: string): string {
+  text = text.replace(/!\[[^\]]*]\([^)]+\)/g, '');
+
+  const metadataLeak =
+    /(?:^|\n)\s*,?\s*(?:"?(?:viewpoint_state|zoom_info|title|version)"?\s*:)/i.exec(
+      text,
+    );
+  if (metadataLeak) {
+    const before = text.slice(0, metadataLeak.index);
+    const leaked = text.slice(metadataLeak.index);
+    const proseStart =
+      /\b(?:Done|Here(?:'s| is)?|This|I(?:'ve| created| updated| made| added| fixed)|The model)\b/i.exec(
+        leaked,
+      );
+    text = before + (proseStart ? leaked.slice(proseStart.index) : '');
+  }
+
   const attachmentLeak =
     /(?:^|\n)[^\n{}]*(?:alt=media|preview sheet attached automatically)[^\n{}]*[})]?\s*/i.exec(
       text,
@@ -73,6 +89,11 @@ export function cleanAssistantText(text: string): string {
       text.slice(0, attachmentLeak.index) +
       text.slice(attachmentLeak.index + attachmentLeak[0].length);
   }
+
+  text = text.replace(
+    /(?:^|\n)\s*[^{}\n]*(?:\.png|\.jpe?g|\.webp|\.gif)[^{}\n]*[})]?\s*/gi,
+    '\n',
+  );
 
   const marker = /Drafting final message:\s*/i.exec(text);
   if (!marker) return text;

--- a/src/components/ai-elements/reasoning.tsx
+++ b/src/components/ai-elements/reasoning.tsx
@@ -110,7 +110,8 @@ export const Reasoning = memo(
         hasEverStreamedRef.current &&
         !isStreaming &&
         isOpen &&
-        !hasAutoClosed
+        !hasAutoClosed &&
+        !isExplicitlyClosed
       ) {
         const timer = setTimeout(() => {
           setIsOpen(false);
@@ -119,7 +120,7 @@ export const Reasoning = memo(
 
         return () => clearTimeout(timer);
       }
-    }, [isStreaming, isOpen, setIsOpen, hasAutoClosed]);
+    }, [isStreaming, isOpen, setIsOpen, hasAutoClosed, isExplicitlyClosed]);
 
     const handleOpenChange = useCallback(
       (newOpen: boolean) => {

--- a/src/components/chat/ChatReasoning.tsx
+++ b/src/components/chat/ChatReasoning.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Streamdown } from 'streamdown';
 import { cjk } from '@streamdown/cjk';
 import { code } from '@streamdown/code';
@@ -61,9 +61,17 @@ export function ChatReasoning({
   className,
 }: ChatReasoningProps) {
   const thinkingVerb = useSharedSpinnerVerb(isStreaming);
+  const [isDetailsOpen, setIsDetailsOpen] = useState(false);
+
+  useEffect(() => {
+    if (isStreaming) setIsDetailsOpen(false);
+  }, [isStreaming]);
 
   return (
     <Reasoning
+      defaultOpen={false}
+      open={isDetailsOpen}
+      onOpenChange={setIsDetailsOpen}
       isStreaming={isStreaming}
       className={cn('mb-0 mt-1 min-w-0 max-w-full overflow-hidden', className)}
     >
@@ -80,7 +88,9 @@ export function ChatReasoning({
           return <p>Thought for {duration} seconds</p>;
         }}
       />
-      <ChatReasoningBody isStreaming={isStreaming}>{text}</ChatReasoningBody>
+      {isDetailsOpen ? (
+        <ChatReasoningBody isStreaming={isStreaming}>{text}</ChatReasoningBody>
+      ) : null}
     </Reasoning>
   );
 }

--- a/src/components/chat/ChatSession.tsx
+++ b/src/components/chat/ChatSession.tsx
@@ -76,6 +76,53 @@ interface ChatSessionProps {
   onLoadingChange?: (isLoading: boolean) => void;
 }
 
+type ToolMessagePart = Extract<
+  AppUIMessage['parts'][number],
+  { state: string }
+>;
+
+function isToolMessagePart(
+  part: AppUIMessage['parts'][number],
+): part is ToolMessagePart {
+  return part.type.startsWith('tool-') && 'state' in part;
+}
+
+function lastAssistantMessageIsCompleteWithParametricBuild({
+  messages,
+}: {
+  messages: AppUIMessage[];
+}) {
+  const message = messages[messages.length - 1];
+  if (!message || message.role !== 'assistant') return false;
+  if (message.parts.some((part) => part.type === 'tool-answer_user')) {
+    return false;
+  }
+
+  const lastStepStartIndex = message.parts.reduce(
+    (lastIndex, part, index) =>
+      part.type === 'step-start' ? index : lastIndex,
+    -1,
+  );
+  const toolParts = message.parts
+    .slice(lastStepStartIndex + 1)
+    .filter(isToolMessagePart);
+
+  return (
+    toolParts.some((part) => part.type === 'tool-build_parametric_model') &&
+    !toolParts.some((part) => part.type === 'tool-answer_user') &&
+    toolParts.every(
+      (part) =>
+        part.state === 'output-available' || part.state === 'output-error',
+    )
+  );
+}
+
+function answerUserInput(input: unknown): { message: string } | null {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return null;
+  const message = (input as { message?: unknown }).message;
+  return typeof message === 'string' && message.trim() ? { message } : null;
+}
+
 /**
  * Owns the AI-SDK Chat lifecycle for a conversation. Everything that touches
  * `chat.sendMessage` / `chat.regenerate` / `chat.setMessages` /
@@ -179,7 +226,7 @@ export function ChatSession({
   // input completes. We compile the OpenSCAD locally, upload the preview,
   // persist the assistant's parts to DB (so the server reads the right
   // thing on auto-continuation), and only then call `chat.addToolOutput`
-  // which triggers `sendAutomaticallyWhen` → next stream.
+  // which lets `sendAutomaticallyWhen` continue the CAD build/review loop.
   // ───────────────────────────────────────────────────────────────────────
   const chatRef = useRef<ReturnType<typeof useCachedAiChat> | null>(null);
   // Latest `chat.messages` snapshot for use inside `onToolCall` (callbacks
@@ -196,7 +243,12 @@ export function ChatSession({
         input: unknown;
       };
     }) => {
-      if (toolCall.toolName !== 'build_parametric_model') return;
+      if (
+        toolCall.toolName !== 'build_parametric_model' &&
+        toolCall.toolName !== 'answer_user'
+      ) {
+        return;
+      }
       const chat = chatRef.current;
       if (!chat) return;
 
@@ -209,13 +261,69 @@ export function ChatSession({
             msg.role === 'assistant' &&
             msg.parts.some(
               (p) =>
-                p.type === 'tool-build_parametric_model' &&
+                p.type === `tool-${toolCall.toolName}` &&
+                'toolCallId' in p &&
                 p.toolCallId === toolCall.toolCallId,
             ),
         );
       const assistant =
         findAssistant(chat.messages as AppUIMessage[]) ??
         findAssistant(messagesRef.current);
+
+      if (toolCall.toolName === 'answer_user') {
+        const output = answerUserInput(toolCall.input);
+        if (!output) {
+          chat.addToolOutput({
+            state: 'output-error',
+            tool: 'answer_user',
+            toolCallId: toolCall.toolCallId,
+            errorText: 'answer_user input was missing a message.',
+          });
+          return;
+        }
+
+        const successPart = {
+          type: 'tool-answer_user',
+          toolCallId: toolCall.toolCallId,
+          state: 'output-available',
+          input: output,
+          output,
+        } as AppUIMessage['parts'][number];
+
+        if (assistant) {
+          const nextParts = assistant.parts.map((existing) => {
+            if (
+              existing.type === 'tool-answer_user' &&
+              existing.toolCallId === toolCall.toolCallId
+            ) {
+              return successPart;
+            }
+            if (
+              (existing.type === 'reasoning' || existing.type === 'text') &&
+              existing.state === 'streaming'
+            ) {
+              return { ...existing, state: 'done' as const };
+            }
+            return existing;
+          }) as AppUIMessage['parts'];
+
+          try {
+            await onToolOutput(assistant.id, nextParts);
+          } catch (persistError) {
+            console.warn(
+              'Failed to persist answer_user output to DB:',
+              persistError,
+            );
+          }
+        }
+
+        chat.addToolOutput({
+          tool: 'answer_user',
+          toolCallId: toolCall.toolCallId,
+          output,
+        });
+        return;
+      }
 
       // Build the next parts array for `assistant`, replacing the
       // matching tool part with `replacement` and normalising any
@@ -350,10 +458,17 @@ export function ChatSession({
           console.warn('Failed to upload OpenSCAD thumbnail:', uploadError);
         }
 
+        const inspectionViews: Array<
+          'ISO' | 'FRONT' | 'BACK' | 'LEFT' | 'RIGHT' | 'TOP' | 'BOTTOM'
+        > = ['ISO', 'FRONT', 'BACK', 'LEFT', 'RIGHT', 'TOP', 'BOTTOM'];
         const output = {
           status: 'success' as const,
+          inspection: {
+            views: inspectionViews,
+            imageAttached: inspectionUploaded,
+          },
           message: inspectionUploaded
-            ? 'Compilation successful. Inspect the multi-view render in this tool result against the user request from every visible angle. If anything is missing, wrong, too simple, disconnected, non-printable, hidden from some view, or visually unclear, call build_parametric_model again with a corrected complete OpenSCAD script. If all views satisfy the request, give a concise final response.'
+            ? 'Compilation successful. Inspect the multi-view render in this tool result against the user request from every visible angle. If any required feature is missing, wrong, too simple, disconnected, non-printable, hidden from some view, or visually unclear, call build_parametric_model again with a corrected complete OpenSCAD script. If all views satisfy the request, give a concise final response.'
             : 'Compilation successful, but the multi-view preview sheet was not available. Review the OpenSCAD you wrote against the user request. If anything is missing, wrong, too simple, disconnected, non-printable, or visually unclear, call build_parametric_model again with a corrected complete OpenSCAD script. If it satisfies the request, give a concise final response.',
         };
 
@@ -365,6 +480,10 @@ export function ChatSession({
           output,
         } as AppUIMessage['parts'][number];
         const nextParts = buildNextParts(successPart);
+
+        if (assistant) {
+          onViewArtifact(input, assistant.id);
+        }
 
         if (nextParts && assistant) {
           try {
@@ -385,7 +504,7 @@ export function ChatSession({
         );
       }
     },
-    [conversation.id, onToolOutput, user?.id],
+    [conversation.id, onToolOutput, onViewArtifact, user?.id],
   );
 
   // ───────────────────────────────────────────────────────────────────────
@@ -398,7 +517,10 @@ export function ChatSession({
     messages: initialBranch,
     transport,
     onToolCall: handleToolCall,
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    sendAutomaticallyWhen:
+      conversation.type === 'parametric'
+        ? lastAssistantMessageIsCompleteWithParametricBuild
+        : lastAssistantMessageIsCompleteWithToolCalls,
     // Out-of-band conversation-level signals (title + suggestions) arrive
     // here as transient data parts — they never land in `messages.parts`,
     // so we patch the conversation query cache directly. See
@@ -721,7 +843,7 @@ export function ChatSession({
   return (
     <>
       <ScrollArea
-        className="relative min-w-0 max-w-full flex-1 self-center overflow-x-hidden px-3 py-0 md:min-h-0 md:p-4 [&_[data-radix-scroll-area-viewport]]:overflow-x-hidden"
+        className="relative w-full min-w-0 max-w-full flex-1 self-center overflow-x-hidden px-3 py-0 md:min-h-0 md:p-4 [&_[data-radix-scroll-area-viewport]]:overflow-x-hidden"
         ref={scrollRef}
       >
         <div className="pointer-events-none sticky left-0 top-0 z-50 h-3 bg-gradient-to-b from-adam-bg-secondary-dark/90 to-transparent md:hidden" />

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -236,7 +236,7 @@ function UserBubble({
     isEditing;
 
   return (
-    <div className="flex justify-start">
+    <div className="flex w-full min-w-0 max-w-full justify-start">
       <div className="mr-2 mt-1">
         <UserAvatar className="h-9 w-9 border border-adam-neutral-700 bg-adam-neutral-950 p-0" />
       </div>
@@ -433,14 +433,32 @@ function AssistantBubble({
   const modelOptions =
     conversation.type === 'creative' ? CREATIVE_MODELS : PARAMETRIC_MODELS;
   const [expandedTools, setExpandedTools] = useState<Set<number>>(new Set());
+  const lastParametricBuildIndex = useMemo(() => {
+    if (conversation.type !== 'parametric') return -1;
+    let buildIndex = -1;
+    message.parts.forEach((part, index) => {
+      if (part.type === 'tool-build_parametric_model') buildIndex = index;
+    });
+    return buildIndex;
+  }, [conversation.type, message.parts]);
 
   const text = useMemo(
     () =>
-      message.parts
-        .filter((p) => p.type === 'text')
-        .map((p) => cleanAssistantText(p.text))
-        .join(''),
-    [message.parts],
+      conversation.type === 'parametric' && lastParametricBuildIndex !== -1
+        ? ''
+        : message.parts
+            .filter(
+              (
+                p,
+              ): p is Extract<
+                (typeof message.parts)[number],
+                { type: 'text' }
+              > => p.type === 'text',
+            )
+            .map((p) => cleanAssistantText(p.text))
+            .filter((visibleText) => !!visibleText)
+            .join(''),
+    [conversation.type, message.parts, lastParametricBuildIndex],
   );
   const answerText = useMemo(
     () => message.parts.map(answerUserMessageText).filter(Boolean).join(''),
@@ -486,8 +504,16 @@ function AssistantBubble({
       <div className="flex min-w-0 max-w-[calc(100%-3rem)] flex-1 flex-col gap-2">
         {message.parts.map((part, index) => {
           if (part.type === 'text') {
+            if (
+              conversation.type === 'parametric' &&
+              lastParametricBuildIndex !== -1
+            ) {
+              return null;
+            }
             const visibleText = cleanAssistantText(part.text);
-            if (hasAnswerUserMessage || !visibleText) return null;
+            if (hasAnswerUserMessage || !visibleText) {
+              return null;
+            }
             return (
               <div
                 key={index}
@@ -513,16 +539,12 @@ function AssistantBubble({
           }
 
           if (part.type === 'tool-build_parametric_model') {
+            if (index !== lastParametricBuildIndex) return null;
             const artifact =
               part.state !== 'input-streaming' &&
               isParametricArtifact(part.input)
                 ? part.input
                 : undefined;
-            const outputMessage =
-              part.state === 'output-available'
-                ? part.output.message
-                : undefined;
-
             // While the model is mid-stream, render the SCAD code in a
             // typewriter-style block so the user sees something happening
             // (matches legacy AssistantMessage's StreamingCodeBlock branch).
@@ -549,7 +571,9 @@ function AssistantBubble({
             // generated client-side by `usePreview` — either way the
             // thumbnail keys off `toolCallId` and the artifact's `code`.
             const showThumbnail =
-              part.state === 'output-available' && !!artifact;
+              index === lastParametricBuildIndex &&
+              part.state === 'output-available' &&
+              !!artifact;
             return (
               <ToolBlock
                 key={index}
@@ -585,10 +609,6 @@ function AssistantBubble({
                 {part.state === 'output-error' ? (
                   <div className="border-b border-adam-neutral-700 p-3 text-xs text-red-300">
                     {part.errorText}
-                  </div>
-                ) : outputMessage ? (
-                  <div className="border-b border-adam-neutral-700 p-3 text-xs text-adam-neutral-300">
-                    {outputMessage}
                   </div>
                 ) : null}
                 {artifact?.code ? (

--- a/src/hooks/useCachedAiChat.ts
+++ b/src/hooks/useCachedAiChat.ts
@@ -12,6 +12,9 @@ type CallbackRefs = {
   onFinish: { current: ReactChatInit['onFinish'] };
   onData: { current: ReactChatInit['onData'] };
   onToolCall: { current: ReactChatInit['onToolCall'] };
+  sendAutomaticallyWhen: {
+    current: ReactChatInit['sendAutomaticallyWhen'];
+  };
 };
 
 const callbackRefs = new Map<string, CallbackRefs>();
@@ -24,6 +27,7 @@ function refsFor(id: string): CallbackRefs {
       onFinish: { current: undefined },
       onData: { current: undefined },
       onToolCall: { current: undefined },
+      sendAutomaticallyWhen: { current: undefined },
     };
     callbackRefs.set(id, refs);
   }
@@ -61,6 +65,7 @@ export function useCachedAiChat({
   onFinish,
   onData,
   onToolCall,
+  sendAutomaticallyWhen,
   ...rest
 }: CachedAiChatOptions) {
   const refs = refsFor(id);
@@ -74,6 +79,7 @@ export function useCachedAiChat({
     refs.onFinish.current = onFinish;
     refs.onData.current = onData;
     refs.onToolCall.current = onToolCall;
+    refs.sendAutomaticallyWhen.current = sendAutomaticallyWhen;
   });
 
   return useMemo(() => {
@@ -93,6 +99,8 @@ export function useCachedAiChat({
       onFinish: (ctx) => refs.onFinish.current?.(ctx),
       onData: (ctx) => refs.onData.current?.(ctx),
       onToolCall: (ctx) => refs.onToolCall.current?.(ctx),
+      sendAutomaticallyWhen: (ctx) =>
+        refs.sendAutomaticallyWhen.current?.(ctx) ?? false,
     });
 
     chatCache.set(id, chat);
@@ -109,8 +117,9 @@ export function createAndCacheAiChat(
     id: string;
   },
 ) {
-  const { id, ...rest } = options;
+  const { id, sendAutomaticallyWhen, ...rest } = options;
   const refs = refsFor(id);
+  refs.sendAutomaticallyWhen.current = sendAutomaticallyWhen;
   const chat = new Chat<AppUIMessage>({
     ...rest,
     id,
@@ -118,6 +127,8 @@ export function createAndCacheAiChat(
     onFinish: (ctx) => refs.onFinish.current?.(ctx),
     onData: (ctx) => refs.onData.current?.(ctx),
     onToolCall: (ctx) => refs.onToolCall.current?.(ctx),
+    sendAutomaticallyWhen: (ctx) =>
+      refs.sendAutomaticallyWhen.current?.(ctx) ?? false,
   });
 
   chatCache.set(id, chat);

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -12,7 +12,6 @@ import {
   createUIMessageStream,
   createUIMessageStreamResponse,
   generateText,
-  hasToolCall,
   Output,
   smoothStream,
   stepCountIs,
@@ -84,9 +83,7 @@ const USD_PER_BILLING_TOKEN = 0.01;
 
 const PARAMETRIC_AGENT_PROMPT = `You are Adam, an agentic AI CAD editor that creates and modifies OpenSCAD models. The user can see a live preview of the model on the right while you work.
 
-Start each user turn by choosing exactly one path:
-- Use build_parametric_model whenever the user asks for a CAD model, an edit to a CAD model, or a fix for OpenSCAD code. Speak back briefly (one or two sentences) and let the tool carry the change — never paste OpenSCAD into your reply text.
-- Use answer_user for greetings, thanks, app/capability questions, informational questions that do not ask you to create or change a model, and the final user-facing message after a CAD build succeeds.
+Use build_parametric_model whenever the user asks for a CAD model, an edit to a CAD model, or a fix for OpenSCAD code. The tool input is the model shown to the user, so do not paste OpenSCAD into normal reply text. Use answer_user for final user-facing text and for normal non-CAD replies.
 
 Never say you created, designed, generated, updated, or fixed a model unless you used build_parametric_model in that turn.
 
@@ -107,9 +104,27 @@ through write → multi-view screenshot inspection → rewrite until the model i
 good or you hit the turn limit. Do not stop after the first successful compile
 unless the preview sheet shows that the model satisfies the request from every
 view. When all views satisfy the request, call answer_user with the concise
-final response instead of writing normal assistant text.
+final response.
 
-Final responses must be only the short user-facing message. Do not include
+Iteration rule:
+- After every build_parametric_model call, silently inspect the returned views
+  before speaking to the user.
+- If any view shows missing, wrong, disconnected, non-printable, too-simple,
+  hidden, or visually unclear geometry, call build_parametric_model again with
+  a corrected complete OpenSCAD script.
+- If the views show the model satisfies the user's request from every required
+  angle, call answer_user with the final text.
+- Do not finalize just because OpenSCAD compiled. Finalize only because the
+  views look right.
+
+Multi-feature checklist before stopping:
+- Phone case → hollow phone pocket, wrap-over lip, camera cutout, charging-port
+  opening, side button cutouts, printable wall thickness, all cuts visible.
+- Mug → body, hollow interior, rim, base, handle, printable wall thickness.
+- Vehicle / character / prop → recognizable silhouette, main appendages or
+  components, surface details, colors, no disconnected floating parts.
+
+answer_user.message must be only the short user-facing message. Do not include
 analysis, draft notes, screenshot observations, storage URLs, filenames,
 attachment labels, or phrases like "preview sheet attached automatically".
 After a successful build, speak in past tense (for example, "Done — I made...")
@@ -281,6 +296,7 @@ function jsonResponse(body: unknown, status: number) {
 }
 
 const THINKING_BUDGET_TOKENS = 9000;
+const PARAMETRIC_THINKING_BUDGET_TOKENS = 1024;
 
 type ChatProvider = 'anthropic' | 'google' | 'openrouter';
 
@@ -348,12 +364,15 @@ function buildChatModel(
   modelId: string,
   providers: ChatProviders,
   thinking: boolean,
+  thinkingBudget: number = THINKING_BUDGET_TOKENS,
 ): { model: LanguageModel; providerOptions?: ProviderOptions } {
+  const isCappedThinking = thinkingBudget !== THINKING_BUDGET_TOKENS;
+
   if (providerFor(modelId) === 'openrouter') {
     return {
       model: providers.openrouter().chat(modelId, {
-        ...(thinking
-          ? { reasoning: { max_tokens: THINKING_BUDGET_TOKENS } }
+        ...(thinking || isCappedThinking
+          ? { reasoning: { max_tokens: thinkingBudget } }
           : {}),
         usage: { include: true },
       }),
@@ -364,18 +383,30 @@ function buildChatModel(
     // Anthropic's API uses dashes everywhere ("claude-haiku-4-5"), while the
     // OpenRouter alias uses dots ("claude-haiku-4.5"). Normalize both.
     const id = modelId.slice('anthropic/'.length).replace(/\./g, '-');
+    const adaptiveThinking = usesAdaptiveAnthropicThinking(id);
     return {
       model: providers.anthropic()(id),
-      providerOptions: thinking
-        ? {
-            anthropic: {
-              thinking: {
-                type: 'enabled',
-                budgetTokens: THINKING_BUDGET_TOKENS,
+      providerOptions:
+        thinking || isCappedThinking
+          ? {
+              anthropic: {
+                ...(adaptiveThinking
+                  ? {
+                      thinking: {
+                        type: 'adaptive' as const,
+                        display: 'summarized' as const,
+                      },
+                      effort: isCappedThinking ? 'low' : 'high',
+                    }
+                  : {
+                      thinking: {
+                        type: 'enabled' as const,
+                        budgetTokens: thinkingBudget,
+                      },
+                    }),
               },
-            },
-          }
-        : undefined,
+            }
+          : undefined,
     };
   }
 
@@ -383,18 +414,11 @@ function buildChatModel(
     const id = modelId.slice('google/'.length);
     return {
       model: providers.google()(id),
-      // Gemini 3 Pro (and most current Google reasoning models) always
-      // think internally — `thinkingBudget` only controls how MUCH, not
-      // whether. `includeThoughts` is what actually surfaces those
-      // thoughts in the stream as `reasoning-delta` parts. So we always
-      // ask for thoughts; the user's "thinking" toggle just bumps the
-      // budget. Without this, Google streams look as if the model isn't
-      // reasoning at all even though it is.
       providerOptions: {
         google: {
           thinkingConfig: {
             includeThoughts: true,
-            ...(thinking ? { thinkingBudget: THINKING_BUDGET_TOKENS } : {}),
+            ...(thinking || isCappedThinking ? { thinkingBudget } : {}),
           },
         },
       },
@@ -402,6 +426,11 @@ function buildChatModel(
   }
 
   throw new Error(`Unsupported chat model ${modelId}`);
+}
+
+function usesAdaptiveAnthropicThinking(modelId: string) {
+  const match = /^claude-(?:opus|sonnet)-4-(\d+)/.exec(modelId);
+  return match ? Number(match[1]) >= 6 : false;
 }
 
 function priceFor(modelId: string) {
@@ -498,6 +527,17 @@ function finalizeStreamingParts(
     }
     return part;
   });
+}
+
+function dropTextFromParametricBuildMessage(
+  parts: AppUIMessage['parts'],
+): AppUIMessage['parts'] {
+  const hasBuild = parts.some(
+    (part) => part.type === 'tool-build_parametric_model',
+  );
+  if (!hasBuild) return parts;
+
+  return parts.filter((part) => part.type !== 'text') as AppUIMessage['parts'];
 }
 
 function messageRowToUIMessage(row: BranchMessageRow): AppUIMessage {
@@ -785,12 +825,16 @@ function parametricTools({
           'images',
           previewPathForToolCall(toolCallId),
         );
+        const views =
+          output.inspection?.views.join(', ') ??
+          'ISO, FRONT, BACK, LEFT, RIGHT, TOP, BOTTOM';
+        const text = `${output.message}\nRendered inspection views: ${views}.\nMulti-view inspection image attached: ${downloaded ? 'yes' : 'no'}.`;
 
         if (downloaded) {
           return {
             type: 'content' as const,
             value: [
-              { type: 'text' as const, text: output.message },
+              { type: 'text' as const, text },
               {
                 type: 'image-data' as const,
                 data: downloaded.base64,
@@ -800,13 +844,10 @@ function parametricTools({
           };
         }
 
-        return { type: 'text' as const, value: output.message };
+        return { type: 'text' as const, value: text };
       },
     },
-    answer_user: {
-      ...chatTools.answer_user,
-      execute: async (input: AppTools['answer_user']['input']) => input,
-    },
+    answer_user: chatTools.answer_user,
   };
 }
 
@@ -1033,6 +1074,13 @@ export async function handleAiChatRequest(req: Request) {
   // not the one the user requested.
   const actualModelId = chatModel(conversation, rawBody.model);
   const resolvedProvider = providerFor(actualModelId);
+  const baseLogContext = {
+    userId: user.id,
+    conversationId: conversation.id,
+    modelId: actualModelId,
+    requestedModelId: rawBody.model,
+    provider: resolvedProvider,
+  };
 
   let chatLanguageModel: LanguageModel;
   let chatProviderOptions: ProviderOptions | undefined;
@@ -1041,6 +1089,9 @@ export async function handleAiChatRequest(req: Request) {
       actualModelId,
       providers,
       rawBody.thinking ?? false,
+      conversation.type === 'parametric'
+        ? PARAMETRIC_THINKING_BUDGET_TOKENS
+        : THINKING_BUDGET_TOKENS,
     );
     chatLanguageModel = built.model;
     chatProviderOptions = built.providerOptions;
@@ -1051,9 +1102,8 @@ export async function handleAiChatRequest(req: Request) {
       userId: user.id,
       conversationId: conversation.id,
       additionalContext: {
+        ...baseLogContext,
         operation: 'build_chat_model',
-        modelId: actualModelId,
-        provider: resolvedProvider,
       },
     });
     return jsonResponse(
@@ -1062,15 +1112,8 @@ export async function handleAiChatRequest(req: Request) {
     );
   }
 
-  // Common context attached to every error we log out of this request —
-  // makes it trivial to tell "Anthropic rejected the model ID" apart from
-  // "Google rate-limited us" apart from "OpenRouter returned 502" in logs.
   const logContext = {
-    userId: user.id,
-    conversationId: conversation.id,
-    modelId: actualModelId,
-    requestedModelId: rawBody.model,
-    provider: resolvedProvider,
+    ...baseLogContext,
     thinking: rawBody.thinking ?? false,
   };
 
@@ -1080,26 +1123,7 @@ export async function handleAiChatRequest(req: Request) {
     system: systemPrompt(conversation),
     messages: modelMessages,
     tools,
-    prepareStep: ({ stepNumber, steps }) => {
-      const previousStepCalledBuild =
-        steps
-          .at(-1)
-          ?.toolCalls.some(
-            (toolCall) => toolCall.toolName === 'build_parametric_model',
-          ) ?? false;
-      if (
-        conversation.type === 'parametric' &&
-        (stepNumber === 0 || previousStepCalledBuild)
-      ) {
-        // Parametric turns stay structured: first choose build vs answer;
-        // after each build, choose revise vs final answer_user.
-        return {
-          toolChoice: 'required' as const,
-        };
-      }
-      return {};
-    },
-    stopWhen: [stepCountIs(5), hasToolCall('answer_user')],
+    stopWhen: stepCountIs(conversation.type === 'parametric' ? 60 : 5),
     maxOutputTokens: rawBody.thinking ? 20000 : 16000,
     abortSignal: req.signal,
     // Decouple our render cadence from the provider's native chunking.
@@ -1144,10 +1168,10 @@ export async function handleAiChatRequest(req: Request) {
       logError(error, {
         functionName: 'ai-chat',
         statusCode: 500,
-        userId: logContext.userId,
-        conversationId: logContext.conversationId,
+        userId: baseLogContext.userId,
+        conversationId: baseLogContext.conversationId,
         additionalContext: {
-          ...logContext,
+          ...baseLogContext,
           operation: 'ui_message_stream',
         },
       });
@@ -1204,9 +1228,13 @@ export async function handleAiChatRequest(req: Request) {
               });
             }
 
-            const finalizedParts = finalizeStreamingParts(
-              responseMessage.parts,
-            );
+            const finalizedParts =
+              conversation.type === 'parametric'
+                ? dropTextFromParametricBuildMessage(
+                    finalizeStreamingParts(responseMessage.parts),
+                  )
+                : finalizeStreamingParts(responseMessage.parts);
+
             const serializedMessage = {
               metadata: JSON.parse(JSON.stringify(metadata)),
               parts: JSON.parse(JSON.stringify(finalizedParts)),

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -300,17 +300,7 @@ const PARAMETRIC_THINKING_BUDGET_TOKENS = 1024;
 
 type ChatProvider = 'anthropic' | 'google' | 'openrouter';
 
-function shouldUseLocalOpenRouter(modelId: string): boolean {
-  return (
-    env('ENVIRONMENT') === 'local' &&
-    !!env('OPENROUTER_API_KEY') &&
-    ((modelId.startsWith('anthropic/') && !env('ANTHROPIC_API_KEY')) ||
-      (modelId.startsWith('google/') && !env('GOOGLE_API_KEY')))
-  );
-}
-
 function providerFor(modelId: string): ChatProvider {
-  if (shouldUseLocalOpenRouter(modelId)) return 'openrouter';
   if (modelId.startsWith('anthropic/')) return 'anthropic';
   if (modelId.startsWith('google/')) return 'google';
   return 'openrouter';
@@ -355,10 +345,9 @@ function createChatProviders(): ChatProviders {
  * Map a `<provider>/<model>` ID to a configured LanguageModel + the
  * provider-specific options the AI SDK expects at the streamText boundary.
  *
- * Anthropic and Google are hit directly via their respective AI SDK providers
- * unless local development is configured with only OpenRouter. Everything else
- * (OpenAI, MoonshotAI, …) keeps going through OpenRouter so we don't have to
- * wire a dedicated provider per vendor.
+ * Anthropic and Google are hit directly via their respective AI SDK providers.
+ * Everything else (OpenAI, MoonshotAI, …) keeps going through OpenRouter so we
+ * don't have to wire a dedicated provider per vendor.
  */
 function buildChatModel(
   modelId: string,

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -366,14 +366,13 @@ function buildChatModel(
   thinking: boolean,
   thinkingBudget: number = THINKING_BUDGET_TOKENS,
 ): { model: LanguageModel; providerOptions?: ProviderOptions } {
-  const isCappedThinking = thinkingBudget !== THINKING_BUDGET_TOKENS;
+  const hasCappedThinkingBudget =
+    thinking && thinkingBudget !== THINKING_BUDGET_TOKENS;
 
   if (providerFor(modelId) === 'openrouter') {
     return {
       model: providers.openrouter().chat(modelId, {
-        ...(thinking || isCappedThinking
-          ? { reasoning: { max_tokens: thinkingBudget } }
-          : {}),
+        ...(thinking ? { reasoning: { max_tokens: thinkingBudget } } : {}),
         usage: { include: true },
       }),
     };
@@ -386,27 +385,26 @@ function buildChatModel(
     const adaptiveThinking = usesAdaptiveAnthropicThinking(id);
     return {
       model: providers.anthropic()(id),
-      providerOptions:
-        thinking || isCappedThinking
-          ? {
-              anthropic: {
-                ...(adaptiveThinking
-                  ? {
-                      thinking: {
-                        type: 'adaptive' as const,
-                        display: 'summarized' as const,
-                      },
-                      effort: isCappedThinking ? 'low' : 'high',
-                    }
-                  : {
-                      thinking: {
-                        type: 'enabled' as const,
-                        budgetTokens: thinkingBudget,
-                      },
-                    }),
-              },
-            }
-          : undefined,
+      providerOptions: thinking
+        ? {
+            anthropic: {
+              ...(adaptiveThinking
+                ? {
+                    thinking: {
+                      type: 'adaptive' as const,
+                      display: 'summarized' as const,
+                    },
+                    effort: hasCappedThinkingBudget ? 'low' : 'high',
+                  }
+                : {
+                    thinking: {
+                      type: 'enabled' as const,
+                      budgetTokens: thinkingBudget,
+                    },
+                  }),
+            },
+          }
+        : undefined,
     };
   }
 
@@ -418,7 +416,7 @@ function buildChatModel(
         google: {
           thinkingConfig: {
             includeThoughts: true,
-            ...(thinking || isCappedThinking ? { thinkingBudget } : {}),
+            ...(thinking ? { thinkingBudget } : {}),
           },
         },
       },

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -296,7 +296,7 @@ function jsonResponse(body: unknown, status: number) {
 }
 
 const THINKING_BUDGET_TOKENS = 9000;
-const PARAMETRIC_THINKING_BUDGET_TOKENS = 1024;
+const PARAMETRIC_MAX_OUTPUT_TOKENS = 64000;
 
 type ChatProvider = 'anthropic' | 'google' | 'openrouter';
 
@@ -405,7 +405,6 @@ function buildChatModel(
         google: {
           thinkingConfig: {
             includeThoughts: true,
-            ...(thinking ? { thinkingBudget } : {}),
           },
         },
       },
@@ -1076,9 +1075,6 @@ export async function handleAiChatRequest(req: Request) {
       actualModelId,
       providers,
       rawBody.thinking ?? false,
-      conversation.type === 'parametric'
-        ? PARAMETRIC_THINKING_BUDGET_TOKENS
-        : THINKING_BUDGET_TOKENS,
     );
     chatLanguageModel = built.model;
     chatProviderOptions = built.providerOptions;
@@ -1118,13 +1114,21 @@ export async function handleAiChatRequest(req: Request) {
       ) {
         return {
           activeTools: ['build_parametric_model' as never],
-          toolChoice: 'required' as const,
+          toolChoice: {
+            type: 'tool' as const,
+            toolName: 'build_parametric_model' as never,
+          },
         };
       }
       return {};
     },
     stopWhen: stepCountIs(conversation.type === 'parametric' ? 60 : 5),
-    maxOutputTokens: rawBody.thinking ? 20000 : 16000,
+    maxOutputTokens:
+      conversation.type === 'parametric'
+        ? PARAMETRIC_MAX_OUTPUT_TOKENS
+        : rawBody.thinking
+          ? 20000
+          : 16000,
     abortSignal: req.signal,
     // Decouple our render cadence from the provider's native chunking.
     // OpenRouter (and the underlying provider) sometimes emits text in

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -1121,6 +1121,19 @@ export async function handleAiChatRequest(req: Request) {
     system: systemPrompt(conversation),
     messages: modelMessages,
     tools,
+    prepareStep: ({ stepNumber }) => {
+      if (
+        conversation.type === 'parametric' &&
+        leafRole === 'user' &&
+        stepNumber === 0
+      ) {
+        return {
+          activeTools: ['build_parametric_model' as never],
+          toolChoice: 'required' as const,
+        };
+      }
+      return {};
+    },
     stopWhen: stepCountIs(conversation.type === 'parametric' ? 60 : 5),
     maxOutputTokens: rawBody.thinking ? 20000 : 16000,
     abortSignal: req.signal,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns the parametric CAD agent with a Fusion‑style loop: build → silently inspect multi‑view renders → iterate, finalizing only with `answer_user` when the views are right. Hides intermediate prose so users see only the latest build and a clean final reply.

- **Agent Behavior**
  - Prompt enforces build → inspect → rewrite; finalize via `answer_user` only when all views satisfy the request; server requires the first parametric step to call `build_parametric_model`; adds concise multi‑feature checklists; no OpenSCAD in normal text; parametric stop limit set to 60.
  - Parametric auto‑continuation: `sendAutomaticallyWhen` waits for a completed `build_parametric_model` without `answer_user`; `useCachedAiChat` forwards `sendAutomaticallyWhen`.
  - On successful compile, tool output includes an `inspection` block (views + imageAttached) and the server echoes this in the tool result; `onViewArtifact` fires after a successful compile.
  - Client‑side `answer_user` handling: validate input, persist output, and mark streaming text/reasoning as done.
  - Server drops assistant `text` parts whenever a parametric build exists in the message.
  - Thinking and limits: parametric max output set to 64k tokens; Anthropic uses adaptive thinking on supported models; Gemini always includes thoughts with no extra budget cap; Anthropic and Google are hit directly with no Gemini → OpenRouter fallback; budgets passed to OpenRouter for other models.

- **Bug Fixes**
  - Text cleanup: strip leaked view/title/version/zoom metadata before prose; drop metadata‑only fragments; remove markdown images and bare image‑filename lines; tests added.
  - UI: hide assistant prose when a parametric build exists and render only the last build block/thumbnail; reasoning panel is controlled, defaults closed, respects manual toggle, defers body render until opened, and auto‑closes after streaming; fix chat and bubble widths.

<sup>Written for commit 247e3fce9ae912919e100738ae6abf2950edc40f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

