### PR TITLE
Stop persisting dangling tool calls that brick follow-up sends

### DIFF
--- a/src/components/chat/ChatSession.tsx
+++ b/src/components/chat/ChatSession.tsx
@@ -232,6 +232,13 @@ export function ChatSession({
   // Latest `chat.messages` snapshot for use inside `onToolCall` (callbacks
   // baked at Chat-init time would otherwise close over the initial array).
   const messagesRef = useRef<AppUIMessage[]>(initialBranch);
+  // Set when persisting a tool's `output-available` to the DB fails. The
+  // server reads the branch from the DB (never from client-sent messages), so
+  // auto-resubmitting after a failed persist would continue against a stale
+  // branch — at best a wasted round-trip the server has to recover from. While
+  // this is set, `sendAutomaticallyWhen` returns false so the loop pauses and
+  // the user can retry. Reset at the top of each `handleToolCall`.
+  const persistFailedRef = useRef(false);
 
   const handleToolCall = useCallback(
     async ({
@@ -251,6 +258,9 @@ export function ChatSession({
       }
       const chat = chatRef.current;
       if (!chat) return;
+
+      // Fresh tool call → clear any prior persist-failure pause.
+      persistFailedRef.current = false;
 
       // Prefer the SDK's live `chat.messages` — it's always current.
       // `messagesRef.current` is a React-mirrored copy that lags one
@@ -273,11 +283,37 @@ export function ChatSession({
       if (toolCall.toolName === 'answer_user') {
         const output = answerUserInput(toolCall.input);
         if (!output) {
+          const errorText = 'answer_user input was missing a message.';
+          // Persist the error so the DB row isn't left with a dangling
+          // `input-available` tool call (which would 500 the next send before
+          // the server-side sanitizer rewrites it).
+          if (assistant) {
+            const nextParts = assistant.parts.map((existing) =>
+              existing.type === 'tool-answer_user' &&
+              existing.toolCallId === toolCall.toolCallId
+                ? ({
+                    type: 'tool-answer_user',
+                    toolCallId: toolCall.toolCallId,
+                    state: 'output-error',
+                    input: toolCall.input,
+                    errorText,
+                  } as AppUIMessage['parts'][number])
+                : existing,
+            ) as AppUIMessage['parts'];
+            try {
+              await onToolOutput(assistant.id, nextParts);
+            } catch (persistError) {
+              console.warn(
+                'Failed to persist answer_user error to DB:',
+                persistError,
+              );
+            }
+          }
           chat.addToolOutput({
             state: 'output-error',
             tool: 'answer_user',
             toolCallId: toolCall.toolCallId,
-            errorText: 'answer_user input was missing a message.',
+            errorText,
           });
           return;
         }
@@ -314,6 +350,12 @@ export function ChatSession({
               'Failed to persist answer_user output to DB:',
               persistError,
             );
+            toast({
+              title: "Couldn't save the reply",
+              description:
+                'Your message is shown but may not survive a refresh. Please retry if it disappears.',
+              variant: 'destructive',
+            });
           }
         }
 
@@ -366,28 +408,37 @@ export function ChatSession({
       // stuck `input-available` state, which would break every
       // subsequent send because the server can't continue a
       // conversation with an unresolved tool call).
+      //
+      // Persist BEFORE `addToolOutput` — same ordering as the success path.
+      // `addToolOutput` is what triggers `sendAutomaticallyWhen`, and the
+      // server continues from the DB branch, so the resolved (error) parts
+      // must be on disk before the resubmit can fire. A compile error SHOULD
+      // auto-continue (the model fixes it), so we don't pause here on a failed
+      // persist; the server-side sanitizer backstops a stale read.
       const finishWithError = async (errorText: string) => {
+        if (assistant) {
+          const errorPart = {
+            type: 'tool-build_parametric_model',
+            toolCallId: toolCall.toolCallId,
+            state: 'output-error',
+            input: toolCall.input,
+            errorText,
+          } as AppUIMessage['parts'][number];
+          const nextParts = buildNextParts(errorPart);
+          if (nextParts) {
+            try {
+              await onToolOutput(assistant.id, nextParts);
+            } catch (persistError) {
+              console.warn('Failed to persist tool error to DB:', persistError);
+            }
+          }
+        }
         chat.addToolOutput({
           state: 'output-error',
           tool: 'build_parametric_model',
           toolCallId: toolCall.toolCallId,
           errorText,
         });
-        if (!assistant) return;
-        const errorPart = {
-          type: 'tool-build_parametric_model',
-          toolCallId: toolCall.toolCallId,
-          state: 'output-error',
-          input: toolCall.input,
-          errorText,
-        } as AppUIMessage['parts'][number];
-        const nextParts = buildNextParts(errorPart);
-        if (!nextParts) return;
-        try {
-          await onToolOutput(assistant.id, nextParts);
-        } catch (persistError) {
-          console.warn('Failed to persist tool error to DB:', persistError);
-        }
       };
 
       const input = isParametricArtifact(toolCall.input)
@@ -490,6 +541,17 @@ export function ChatSession({
             await onToolOutput(assistant.id, nextParts);
           } catch (persistError) {
             console.warn('Failed to persist tool output to DB:', persistError);
+            // The server continues from the DB branch. If this build's output
+            // never landed, auto-resubmitting would run against a stale branch
+            // and discard a model the user can already see. Pause the loop and
+            // let them retry.
+            persistFailedRef.current = true;
+            toast({
+              title: "Couldn't save this step",
+              description:
+                "The model is shown but the build wasn't saved, so Adam paused. Please retry.",
+              variant: 'destructive',
+            });
           }
         }
 
@@ -504,7 +566,7 @@ export function ChatSession({
         );
       }
     },
-    [conversation.id, onToolOutput, onViewArtifact, user?.id],
+    [conversation.id, onToolOutput, onViewArtifact, toast, user?.id],
   );
 
   // ───────────────────────────────────────────────────────────────────────
@@ -517,10 +579,14 @@ export function ChatSession({
     messages: initialBranch,
     transport,
     onToolCall: handleToolCall,
-    sendAutomaticallyWhen:
-      conversation.type === 'parametric'
-        ? lastAssistantMessageIsCompleteWithParametricBuild
-        : lastAssistantMessageIsCompleteWithToolCalls,
+    // Pause the loop if a tool-output persist failed — resubmitting would run
+    // the server against a stale DB branch (see `persistFailedRef`).
+    sendAutomaticallyWhen: (ctx) => {
+      if (persistFailedRef.current) return false;
+      return conversation.type === 'parametric'
+        ? lastAssistantMessageIsCompleteWithParametricBuild(ctx)
+        : lastAssistantMessageIsCompleteWithToolCalls(ctx);
+    },
     // Out-of-band conversation-level signals (title + suggestions) arrive
     // here as transient data parts — they never land in `messages.parts`,
     // so we patch the conversation query cache directly. See
@@ -628,7 +694,8 @@ export function ChatSession({
       let dirty = false;
       const nextParts = msg.parts.map((p) => {
         if (
-          p.type === 'tool-build_parametric_model' &&
+          (p.type.startsWith('tool-') || p.type === 'dynamic-tool') &&
+          'state' in p &&
           (p.state === 'input-streaming' || p.state === 'input-available')
         ) {
           dirty = true;

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -27,6 +27,12 @@ import { billing, BillingClientError } from './billingClient';
 import { corsHeaders, isRecord } from './api';
 import { env, requiredEnv } from './env';
 import { logError } from './serverLog';
+import {
+  decidePersistAction,
+  hasPendingClientToolCall,
+  isDanglingToolPart,
+  resolveDanglingToolParts,
+} from './chatToolPersistence';
 import { handleMeshRequest } from './mesh';
 import { getAnonSupabaseClient } from './supabaseClient';
 
@@ -526,7 +532,40 @@ function dropTextFromParametricBuildMessage(
   return parts.filter((part) => part.type !== 'text') as AppUIMessage['parts'];
 }
 
-function messageRowToUIMessage(row: BranchMessageRow): AppUIMessage {
+function messageRowToUIMessage(
+  row: BranchMessageRow,
+  conversationId: string,
+): AppUIMessage {
+  const rawParts = Array.isArray(row.parts)
+    ? (row.parts as AppUIMessage['parts'])
+    : [];
+
+  const dangling = rawParts.filter(isDanglingToolPart);
+  if (dangling.length > 0) {
+    logError(
+      new Error(
+        `Resolved ${dangling.length} dangling tool call(s) in persisted branch. ` +
+          'Expected to be rare (genuine interruptions only) now that the onFinish ' +
+          'clobber guard holds — investigate the write path if this is frequent.',
+      ),
+      {
+        functionName: 'ai-chat',
+        statusCode: 200,
+        conversationId,
+        additionalContext: {
+          operation: 'resolve_dangling_tool_parts',
+          messageId: row.id,
+          role: row.role,
+          tools: dangling.map((part) => ({
+            type: part.type,
+            toolCallId: 'toolCallId' in part ? part.toolCallId : undefined,
+            state: 'state' in part ? part.state : undefined,
+          })),
+        },
+      },
+    );
+  }
+
   return {
     id: row.id,
     role: row.role,
@@ -534,7 +573,7 @@ function messageRowToUIMessage(row: BranchMessageRow): AppUIMessage {
       row.metadata && typeof row.metadata === 'object'
         ? (row.metadata as AppUIMessage['metadata'])
         : ({} as AppUIMessage['metadata']),
-    parts: Array.isArray(row.parts) ? (row.parts as AppUIMessage['parts']) : [],
+    parts: resolveDanglingToolParts(rawParts),
   };
 }
 
@@ -598,7 +637,7 @@ async function loadBranchFromDb({
   }
 
   return {
-    branch: path.map(messageRowToUIMessage),
+    branch: path.map((row) => messageRowToUIMessage(row, conversationId)),
     leafRole: path[path.length - 1].role,
   };
 }
@@ -1244,35 +1283,54 @@ export async function handleAiChatRequest(req: Request) {
               parts: JSON.parse(JSON.stringify(finalizedParts)),
             };
 
-            // `isContinuation` fires when the response stream extended an
-            // existing assistant message (the leaf was an assistant with a
-            // pending tool call). In that case the row already exists — we
-            // just update its parts in place and the leaf stays where it
-            // is.
+            // Does this turn end awaiting a CLIENT-side tool result? Our
+            // parametric tools (`build_parametric_model`, `answer_user`) have
+            // no server `execute` — the browser compiles / answers and is the
+            // sole authority for their result. The server only ever sees them
+            // `input-available` (pending).
+            const hasPendingToolCall = hasPendingClientToolCall(finalizedParts);
+
+            // What to do with this row — see `decidePersistAction`:
+            //   insert → new assistant row.
+            //   update → continuation with everything resolved / pure text.
+            //   skip   → continuation still ending in a pending CLIENT tool.
+            //            The browser persists the `output-available` version
+            //            itself (`onToolOutput`); a server write here — delayed
+            //            behind `result.totalUsage` + `billing.consume` — would
+            //            land last and clobber it back to `input-available`,
+            //            leaving a dangling tool call that 500s the next send.
+            //            Mid-loop builds dodge the race because the client's
+            //            compile takes seconds; the terminal `answer_user` is
+            //            instant, so the server reliably wins. Defer to client.
             //
-            // Otherwise we insert a NEW assistant whose parent is whatever
-            // the leaf was when the request came in. For a fresh user turn
-            // that's the user message we generated this response for; for
-            // a retry (client repointed the leaf back at the parent user
-            // message) it's the same parent, so the new assistant becomes
-            // a sibling of the one being re-rolled — which is what makes
-            // BranchNavigation light up. The `update_leaf_trigger` on
-            // `public.messages` automatically advances
-            // `current_message_leaf_id` to the new row, so we don't need a
-            // separate conversations update.
-            const { error } = isContinuation
-              ? await supabaseClient
-                  .from('messages')
-                  .update(serializedMessage)
-                  .eq('id', responseMessage.id)
-                  .eq('conversation_id', conversation.id)
-              : await supabaseClient.from('messages').insert({
-                  id: responseMessage.id,
-                  conversation_id: conversation.id,
-                  role: responseMessage.role,
-                  ...serializedMessage,
-                  parent_message_id: leafMessageId,
-                });
+            // Insert places a NEW assistant under whatever the leaf was: for a
+            // fresh user turn that's the user message; for a retry (client
+            // repointed the leaf back at the parent user message) it's the same
+            // parent, so the new assistant becomes a sibling — which is what
+            // makes BranchNavigation light up. The `update_leaf_trigger` on
+            // `public.messages` auto-advances `current_message_leaf_id`, so we
+            // don't touch the conversation row here.
+            const persistAction = decidePersistAction({
+              isContinuation,
+              hasPendingToolCall,
+            });
+            let error: { message: string } | null = null;
+            if (persistAction === 'update') {
+              ({ error } = await supabaseClient
+                .from('messages')
+                .update(serializedMessage)
+                .eq('id', responseMessage.id)
+                .eq('conversation_id', conversation.id));
+            } else if (persistAction === 'insert') {
+              ({ error } = await supabaseClient.from('messages').insert({
+                id: responseMessage.id,
+                conversation_id: conversation.id,
+                role: responseMessage.role,
+                ...serializedMessage,
+                parent_message_id: leafMessageId,
+              }));
+            }
+            // persistAction === 'skip' → client owns this row's parts.
 
             if (error) {
               logError(error, {
@@ -1290,11 +1348,6 @@ export async function handleAiChatRequest(req: Request) {
             // continuation `onFinish` will fire suggestions for the real
             // final state. Avoids a wasted Haiku call AND prevents
             // mid-turn placeholder pills.
-            const hasPendingToolCall = finalizedParts.some(
-              (part) =>
-                part.type.startsWith('tool-') &&
-                (part as { state?: string }).state === 'input-available',
-            );
             if (!hasPendingToolCall && env('ANTHROPIC_API_KEY')) {
               // MUST be awaited (not `void`). `createUIMessageStream`
               // closes the SSE controller as soon as the merged stream

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -1329,8 +1329,19 @@ export async function handleAiChatRequest(req: Request) {
                 ...serializedMessage,
                 parent_message_id: leafMessageId,
               }));
+            } else {
+              // persistAction === 'skip': the client owns this row's `parts`
+              // (it persists the resolved tool output). Still record this
+              // turn's billing metadata via a metadata-ONLY update — it touches
+              // a different column than the client's `parts` write, and
+              // Postgres re-evaluates concurrent same-row updates, so the
+              // client's parts are never clobbered.
+              ({ error } = await supabaseClient
+                .from('messages')
+                .update({ metadata: serializedMessage.metadata })
+                .eq('id', responseMessage.id)
+                .eq('conversation_id', conversation.id));
             }
-            // persistAction === 'skip' → client owns this row's parts.
 
             if (error) {
               logError(error, {

--- a/src/server/chatToolPersistence.test.ts
+++ b/src/server/chatToolPersistence.test.ts
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  DANGLING_TOOL_ERROR_TEXT,
+  decidePersistAction,
+  hasPendingClientToolCall,
+  isDanglingToolPart,
+  resolveDanglingToolParts,
+} from './chatToolPersistence.ts';
+
+describe('isDanglingToolPart', () => {
+  it('flags tool calls awaiting a result', () => {
+    assert.equal(
+      isDanglingToolPart({
+        type: 'tool-answer_user',
+        state: 'input-available',
+      }),
+      true,
+    );
+    assert.equal(
+      isDanglingToolPart({
+        type: 'tool-build_parametric_model',
+        state: 'input-streaming',
+      }),
+      true,
+    );
+    assert.equal(
+      isDanglingToolPart({ type: 'dynamic-tool', state: 'input-available' }),
+      true,
+    );
+  });
+
+  it('leaves resolved tool calls alone', () => {
+    assert.equal(
+      isDanglingToolPart({
+        type: 'tool-build_parametric_model',
+        state: 'output-available',
+      }),
+      false,
+    );
+    assert.equal(
+      isDanglingToolPart({ type: 'tool-answer_user', state: 'output-error' }),
+      false,
+    );
+  });
+
+  it('ignores non-tool parts', () => {
+    assert.equal(
+      isDanglingToolPart({ type: 'text', state: 'streaming' }),
+      false,
+    );
+    assert.equal(isDanglingToolPart({ type: 'reasoning' }), false);
+    assert.equal(isDanglingToolPart({ type: 'step-start' }), false);
+  });
+});
+
+describe('resolveDanglingToolParts', () => {
+  it('rewrites only dangling tool calls to output-error and preserves the rest', () => {
+    const parts = [
+      { type: 'text', text: 'hi', state: 'done' },
+      {
+        type: 'tool-build_parametric_model',
+        state: 'output-available',
+        foo: 1,
+      },
+      { type: 'tool-answer_user', state: 'input-available', toolCallId: 'abc' },
+    ];
+
+    const result = resolveDanglingToolParts(parts);
+
+    // text untouched (same reference)
+    assert.equal(result[0], parts[0]);
+    // resolved build untouched (same reference)
+    assert.equal(result[1], parts[1]);
+    // dangling answer_user rewritten
+    assert.deepEqual(result[2], {
+      type: 'tool-answer_user',
+      state: 'output-error',
+      toolCallId: 'abc',
+      errorText: DANGLING_TOOL_ERROR_TEXT,
+    });
+  });
+
+  it('is a no-op when nothing dangles', () => {
+    const parts = [
+      { type: 'tool-build_parametric_model', state: 'output-available' },
+      { type: 'tool-answer_user', state: 'output-available' },
+    ];
+    const result = resolveDanglingToolParts(parts);
+    assert.deepEqual(result, parts);
+  });
+});
+
+describe('hasPendingClientToolCall', () => {
+  it('detects a terminal pending tool call', () => {
+    assert.equal(
+      hasPendingClientToolCall([
+        { type: 'tool-build_parametric_model', state: 'output-available' },
+        { type: 'tool-answer_user', state: 'input-available' },
+      ]),
+      true,
+    );
+  });
+
+  it('is false once everything is resolved', () => {
+    assert.equal(
+      hasPendingClientToolCall([
+        { type: 'tool-build_parametric_model', state: 'output-available' },
+        { type: 'tool-answer_user', state: 'output-available' },
+      ]),
+      false,
+    );
+  });
+
+  it('is false for pure-text turns', () => {
+    assert.equal(
+      hasPendingClientToolCall([{ type: 'text', state: 'done' }]),
+      false,
+    );
+  });
+});
+
+describe('decidePersistAction — the clobber guard', () => {
+  // The whole bug in one table: a continuation that still ends with a pending
+  // client tool must NOT be written by the server, or it clobbers the client's
+  // resolution and 500s the next send.
+  it('inserts a fresh assistant row (leaf was a user message)', () => {
+    // First parametric turn: build is pending, but we still must create the row.
+    assert.equal(
+      decidePersistAction({ isContinuation: false, hasPendingToolCall: true }),
+      'insert',
+    );
+    assert.equal(
+      decidePersistAction({ isContinuation: false, hasPendingToolCall: false }),
+      'insert',
+    );
+  });
+
+  it('skips the terminal answer_user continuation (the actual bug)', () => {
+    assert.equal(
+      decidePersistAction({ isContinuation: true, hasPendingToolCall: true }),
+      'skip',
+    );
+  });
+
+  it('updates a continuation once everything is resolved / pure text', () => {
+    assert.equal(
+      decidePersistAction({ isContinuation: true, hasPendingToolCall: false }),
+      'update',
+    );
+  });
+});
+
+describe('end-to-end: a normal first turn never persists a dangling tool call', () => {
+  // Walk the real sequence of onFinish decisions for: user → build → answer_user.
+  it('insert(build pending) → skip(answer_user pending), so the row never gets clobbered', () => {
+    // Turn 1, step 0: leaf is the user message, model emits build (pending).
+    const buildPending = [
+      { type: 'tool-build_parametric_model', state: 'input-available' },
+    ];
+    assert.equal(
+      decidePersistAction({
+        isContinuation: false,
+        hasPendingToolCall: hasPendingClientToolCall(buildPending),
+      }),
+      'insert',
+      'first build turn must create the row',
+    );
+
+    // Client resolves the build and resubmits; server continues and emits
+    // answer_user (pending). This is the turn that used to clobber.
+    const answerPending = [
+      { type: 'tool-build_parametric_model', state: 'output-available' },
+      { type: 'tool-answer_user', state: 'input-available' },
+    ];
+    assert.equal(
+      decidePersistAction({
+        isContinuation: true,
+        hasPendingToolCall: hasPendingClientToolCall(answerPending),
+      }),
+      'skip',
+      'terminal answer_user turn must defer to the client',
+    );
+
+    // The client persists the fully-resolved parts. On the NEXT send the
+    // server reads this branch — nothing dangles, so no MissingToolResultsError.
+    const persistedByClient = [
+      { type: 'tool-build_parametric_model', state: 'output-available' },
+      { type: 'tool-answer_user', state: 'output-available' },
+    ];
+    assert.deepEqual(
+      resolveDanglingToolParts(persistedByClient),
+      persistedByClient,
+      'a healthy branch passes through the sanitizer untouched',
+    );
+  });
+});

--- a/src/server/chatToolPersistence.test.ts
+++ b/src/server/chatToolPersistence.test.ts
@@ -118,6 +118,20 @@ describe('hasPendingClientToolCall', () => {
       false,
     );
   });
+
+  it('treats a pending dynamic-tool as client-owned (symmetric with isDanglingToolPart)', () => {
+    assert.equal(
+      hasPendingClientToolCall([
+        { type: 'dynamic-tool', state: 'input-available' },
+      ]),
+      true,
+    );
+    // Symmetry guard: anything dangling that is a tool part is also pending.
+    assert.equal(
+      isDanglingToolPart({ type: 'dynamic-tool', state: 'input-available' }),
+      true,
+    );
+  });
 });
 
 describe('decidePersistAction — the clobber guard', () => {

--- a/src/server/chatToolPersistence.ts
+++ b/src/server/chatToolPersistence.ts
@@ -21,15 +21,22 @@ export const DANGLING_TOOL_ERROR_TEXT =
   'Tool execution did not complete (the previous request was interrupted).';
 
 /**
+ * A message part that carries a tool call — either a statically-typed `tool-*`
+ * part or the SDK's `dynamic-tool` part. Shared by the dangling check and the
+ * pending check so the two can never drift out of sync (an asymmetry would let
+ * a pending `dynamic-tool` take the clobbering write path).
+ */
+function isToolPart(part: ToolPartLike): boolean {
+  return part.type === 'dynamic-tool' || part.type.startsWith('tool-');
+}
+
+/**
  * A tool-call part persisted without a result (stuck at `input-streaming` /
- * `input-available`). Covers both statically-typed `tool-*` parts and the
- * SDK's `dynamic-tool` part.
+ * `input-available`).
  */
 export function isDanglingToolPart(part: ToolPartLike): boolean {
-  const isToolPart =
-    part.type === 'dynamic-tool' || part.type.startsWith('tool-');
   return (
-    isToolPart &&
+    isToolPart(part) &&
     (part.state === 'input-streaming' || part.state === 'input-available')
   );
 }
@@ -63,7 +70,7 @@ export function hasPendingClientToolCall(
   parts: readonly ToolPartLike[],
 ): boolean {
   return parts.some(
-    (part) => part.type.startsWith('tool-') && part.state === 'input-available',
+    (part) => isToolPart(part) && part.state === 'input-available',
   );
 }
 

--- a/src/server/chatToolPersistence.ts
+++ b/src/server/chatToolPersistence.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure logic for the chat persistence boundary, kept free of `@shared` and SDK
+ * imports so it's unit-testable in isolation (`deno test
+ * src/server/chatToolPersistence.test.ts`). The two concerns here are the only
+ * things standing between a normal multi-step parametric turn and a
+ * permanently-bricked conversation, so they're worth isolating and testing
+ * directly. See `aiChat.ts` for the call sites.
+ *
+ * Background: the parametric tools (`build_parametric_model`, `answer_user`)
+ * have no server `execute` — the browser is the sole authority for their
+ * result. The server only ever sees them `input-available` (pending). If a
+ * pending tool call ends up persisted in the branch, `convertToLanguageModelPrompt`
+ * (inside `streamText` / the title+suggestion `generateText` calls) throws
+ * `MissingToolResultsError` on the NEXT send and 500s it.
+ */
+
+/** Minimal structural shape of a message part — all we need to reason about. */
+export type ToolPartLike = { type: string; state?: string };
+
+export const DANGLING_TOOL_ERROR_TEXT =
+  'Tool execution did not complete (the previous request was interrupted).';
+
+/**
+ * A tool-call part persisted without a result (stuck at `input-streaming` /
+ * `input-available`). Covers both statically-typed `tool-*` parts and the
+ * SDK's `dynamic-tool` part.
+ */
+export function isDanglingToolPart(part: ToolPartLike): boolean {
+  const isToolPart =
+    part.type === 'dynamic-tool' || part.type.startsWith('tool-');
+  return (
+    isToolPart &&
+    (part.state === 'input-streaming' || part.state === 'input-available')
+  );
+}
+
+/**
+ * Rewrite dangling tool calls to `output-error` so the history is valid — the
+ * model receives a "tool did not complete" result and can recover. SAFETY NET
+ * for genuine interruptions (tab close / crash / failed persist); the common
+ * cause (the `onFinish` clobber) is prevented at the write side.
+ */
+export function resolveDanglingToolParts<T extends ToolPartLike>(
+  parts: readonly T[],
+): T[] {
+  return parts.map((part) =>
+    isDanglingToolPart(part)
+      ? ({
+          ...part,
+          state: 'output-error',
+          errorText: DANGLING_TOOL_ERROR_TEXT,
+        } as unknown as T)
+      : part,
+  );
+}
+
+/**
+ * Does this turn end awaiting a CLIENT-side tool result? `input-available`
+ * means the model finished emitting the call but no result is attached — for
+ * our client-resolved tools that means the browser still owns it.
+ */
+export function hasPendingClientToolCall(
+  parts: readonly ToolPartLike[],
+): boolean {
+  return parts.some(
+    (part) => part.type.startsWith('tool-') && part.state === 'input-available',
+  );
+}
+
+export type PersistAction = 'insert' | 'update' | 'skip';
+
+/**
+ * Decide what the server's `onFinish` should do with the response message.
+ *
+ * - `insert`  — new assistant row (the leaf was a user message). Always write,
+ *   even with a pending tool call: the row must exist for the client's
+ *   `onToolOutput` UPDATE to land, and the client resolves it before the
+ *   auto-resubmit re-reads the branch.
+ * - `update`  — continuation with everything resolved (or pure text / no
+ *   tools). Safe to write; the client isn't persisting this turn.
+ * - `skip`    — continuation that still ends with a pending CLIENT tool. The
+ *   browser resolves and persists the `output-available` version itself; a
+ *   server write here (delayed behind `result.totalUsage` + `billing.consume`)
+ *   would land last and clobber it back to `input-available`, leaving a
+ *   dangling tool call that 500s the next send. Defer to the client.
+ */
+export function decidePersistAction({
+  isContinuation,
+  hasPendingToolCall,
+}: {
+  isContinuation: boolean;
+  hasPendingToolCall: boolean;
+}): PersistAction {
+  if (!isContinuation) return 'insert';
+  return hasPendingToolCall ? 'skip' : 'update';
+}

--- a/src/services/messageService.ts
+++ b/src/services/messageService.ts
@@ -61,17 +61,40 @@ export async function persistAssistantParts({
   // output), leaving the existing metadata untouched.
   metadata?: AppUIMessage['metadata'];
 }) {
-  const { error } = await supabase
-    .from('messages')
-    .update({
-      parts: JSON.parse(JSON.stringify(parts)),
-      ...(metadata !== undefined
-        ? { metadata: JSON.parse(JSON.stringify(metadata)) }
-        : {}),
-    })
-    .eq('id', messageId)
-    .eq('conversation_id', conversationId);
-  if (error) throw error;
+  const payload = {
+    parts: JSON.parse(JSON.stringify(parts)),
+    ...(metadata !== undefined
+      ? { metadata: JSON.parse(JSON.stringify(metadata)) }
+      : {}),
+  };
+
+  // A matched-nothing update is silent in PostgREST. The usual cause is benign
+  // and self-healing: the client resolved a tool call before the server's
+  // `onFinish` INSERT for this assistant row landed. The server walks the
+  // branch from the DB on continuation, so we must NOT report success on a
+  // no-op (the tool output would be lost and the server would continue from a
+  // stale/absent branch). Retry briefly to let the INSERT land, then throw so
+  // the caller can pause/surface it. ~1.7s total covers the insert latency
+  // (stream close + `result.totalUsage` + `billing.consume`) without hanging.
+  const MAX_ATTEMPTS = 6;
+  const RETRY_DELAY_MS = 350;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const { data, error } = await supabase
+      .from('messages')
+      .update(payload)
+      .eq('id', messageId)
+      .eq('conversation_id', conversationId)
+      .select('id');
+    if (error) throw error;
+    if (data && data.length > 0) return;
+    if (attempt < MAX_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+    }
+  }
+  throw new Error(
+    `persistAssistantParts matched no row after ${MAX_ATTEMPTS} attempts ` +
+      `(messageId=${messageId}). The assistant message was never persisted.`,
+  );
 }
 
 export const useMessagesQuery = () => {


### PR DESCRIPTION
A parametric conversation consistently 500'd on the second user message with `MissingToolResultsError: Tool result is missing for tool call ...`.

Root cause: the parametric tools (`build_parametric_model`, `answer_user`) are client-resolved (no server `execute`). On the terminal `answer_user` turn, the server's `onFinish` UPDATE — delayed behind `result.totalUsage`
+ `billing.consume` — reliably lands after the client's `output-available` persist and clobbers it back to `input-available`. Unlike mid-loop builds (which dodge the race because the client's compile takes seconds), the terminal tool has no continuation to repair it, so the DB keeps a dangling tool call. The next send re-reads that branch (the server is the sole reader; it never trusts client-sent messages) and `streamText`'s prompt conversion throws on the unresolved call.

Fix (write side): `onFinish` now skips the parts write on a continuation that still ends with a pending client-side tool call — the browser owns that row's parts and persists the resolved version itself. Inserts and fully-resolved continuations still write.

Safety net (read side): the DB→model boundary rewrites any genuinely dangling tool call (tab close / crash / failed persist — unpreventable client-side) to `output-error` so the model recovers instead of 500ing, and logs each occurrence so we can see if the write-side guard ever leaks.

The bug-critical logic is extracted to `chatToolPersistence.ts` (pure, no deps) and unit-tested, including an end-to-end walk of the failing turn sequence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents 500s on follow‑up sends by stopping server writes that leave client-resolved tool calls dangling, and hardens persistence to avoid stale branches or silent no‑ops.

- **Bug Fixes**
  - Write-side clobber guard: on assistant continuations that still end with a pending client tool call, the server skips parts updates and performs a metadata-only update to preserve billing data without risking clobbers.
  - Read-side safety net: any persisted dangling `tool-*` or `dynamic-tool` parts are rewritten to `output-error` before prompting, and each case is logged.
  - Client/persistence hardening: pause auto-resubmit on tool-output persist failure with a toast; persist error before updating UI; invalid `answer_user` input now persists `output-error`; `persistAssistantParts` retries zero-row updates and then throws to prevent silent success on a missing row.

- **Refactors**
  - Expanded `src/server/chatToolPersistence.ts` with a shared helper aligning pending/dangling detection and added tests (dynamic-tool symmetry and end-to-end coverage).

<sup>Written for commit 54fc307ee9be7573e19058b6035e1d5fb2f75872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

