### PR TITLE
Replace Claude Opus 4.8 with Claude Fable 5 in model picker

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -246,8 +246,8 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'anthropic/claude-opus-4.8',
-    name: 'Claude Opus 4.8',
+    id: 'anthropic/claude-fable-5',
+    name: 'Claude Fable 5',
     description: 'Most powerful Anthropic model for complex reasoning',
     provider: 'Anthropic',
     supportsTools: true,

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -52,7 +52,7 @@ const MODEL_PRICES: Record<
   { input: number; output: number; cacheRead?: number; cacheWrite?: number }
 > = {
   // Anthropic
-  'anthropic/claude-opus-4.8': { input: 5, output: 25 },
+  'anthropic/claude-fable-5': { input: 10, output: 50 },
   'anthropic/claude-opus-4': { input: 15, output: 75 },
   'anthropic/claude-sonnet-4.6': { input: 3, output: 15 },
   'anthropic/claude-sonnet-4.5': { input: 3, output: 15 },

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -421,6 +421,9 @@ function buildChatModel(
 }
 
 function usesAdaptiveAnthropicThinking(modelId: string) {
+  // The Claude 5 generation (Fable, Mythos) uses adaptive thinking, as do
+  // Claude Opus/Sonnet 4.6+. Older 4.x models take the fixed-budget path.
+  if (/^claude-(?:fable|mythos)-5\b/.test(modelId)) return true;
   const match = /^claude-(?:opus|sonnet)-4-(\d+)/.exec(modelId);
   return match ? Number(match[1]) >= 6 : false;
 }


### PR DESCRIPTION
Swap the parametric model picker entry to Claude Fable 5, routing to the real `claude-fable-5` Anthropic API id and pricing it at $10/$50 per million input/output tokens.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Claude Opus 4.8 in the model picker with Claude Fable 5, routing to `anthropic/claude-fable-5` and pricing at $10/$50 per million input/output tokens. Also updated adaptive thinking detection so Claude 5 models (Fable, Mythos) follow the adaptive path instead of the fixed-budget path.

<sup>Written for commit 0f55b8b8c8d9dfd15208a49359a7750028d2e879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

