### PR TITLE
Stop stuck-tool recovery from clobbering live streams and warning on …

### DIFF
--- a/src/components/chat/ChatSession.tsx
+++ b/src/components/chat/ChatSession.tsx
@@ -693,10 +693,16 @@ export function ChatSession({
     // `chat.status` is read once per chat+mount on purpose: a cached Chat
     // that is mid-generation when ChatSession (re)mounts is not "stuck from
     // a previous session", and collectStuckToolRecovery skips it entirely.
+    //
+    // The scan is structurally typed (dependency-free for its unit tests),
+    // so its map comes back as `RecoveryPartLike[]` values. Every rewrite
+    // spreads the original part and only narrows tool/text `state`, so
+    // re-narrowing to our part union is sound — this is the one place the
+    // structural boundary is crossed.
     const stuckByMessageId = collectStuckToolRecovery({
       status: chat.status,
-      messages: chat.messages as AppUIMessage[],
-    });
+      messages: chat.messages,
+    }) as Map<string, AppUIMessage['parts']>;
 
     if (stuckByMessageId.size === 0) return;
 

--- a/src/components/chat/ChatSession.tsx
+++ b/src/components/chat/ChatSession.tsx
@@ -8,6 +8,8 @@ import { useToast } from '@/hooks/use-toast';
 import { previewScadColoredViaToolWorker } from '@/worker/toolWorker';
 import { apiUrl } from '@/services/api';
 import { messageRowToChatMessage, type ChatMessage } from '@/lib/aiMessages';
+import { collectStuckToolRecovery } from '@/components/chat/stuckToolRecovery';
+import { AssistantRowMissingError } from '@/services/messageService';
 import { supabase } from '@/lib/supabase';
 import {
   generateColoredPreview,
@@ -688,35 +690,13 @@ export function ChatSession({
     if (recoveredChatRef.current === chat) return;
     recoveredChatRef.current = chat;
 
-    const stuckByMessageId = new Map<string, AppUIMessage['parts']>();
-    for (const msg of chat.messages as AppUIMessage[]) {
-      if (msg.role !== 'assistant') continue;
-      let dirty = false;
-      const nextParts = msg.parts.map((p) => {
-        if (
-          (p.type.startsWith('tool-') || p.type === 'dynamic-tool') &&
-          'state' in p &&
-          (p.state === 'input-streaming' || p.state === 'input-available')
-        ) {
-          dirty = true;
-          return {
-            ...p,
-            state: 'output-error' as const,
-            errorText:
-              'Tool execution did not complete in the previous session.',
-          };
-        }
-        if (
-          (p.type === 'reasoning' || p.type === 'text') &&
-          p.state === 'streaming'
-        ) {
-          dirty = true;
-          return { ...p, state: 'done' as const };
-        }
-        return p;
-      }) as AppUIMessage['parts'];
-      if (dirty) stuckByMessageId.set(msg.id, nextParts);
-    }
+    // `chat.status` is read once per chat+mount on purpose: a cached Chat
+    // that is mid-generation when ChatSession (re)mounts is not "stuck from
+    // a previous session", and collectStuckToolRecovery skips it entirely.
+    const stuckByMessageId = collectStuckToolRecovery({
+      status: chat.status,
+      messages: chat.messages as AppUIMessage[],
+    });
 
     if (stuckByMessageId.size === 0) return;
 
@@ -730,6 +710,17 @@ export function ChatSession({
 
     for (const [messageId, nextParts] of stuckByMessageId) {
       void onToolOutput(messageId, nextParts).catch((err) => {
+        if (err instanceof AssistantRowMissingError) {
+          // The interruption happened before the server's `onFinish` INSERT,
+          // so this assistant exists only in the cached in-memory chat. The
+          // DB branch (leaf = the user message) has no dangling tool call to
+          // repair, and the setMessages above already fixed the UI.
+          console.info(
+            'Stuck-tool recovery: assistant row was never persisted; ' +
+              'nothing to repair in DB (benign).',
+          );
+          return;
+        }
         console.warn('Failed to persist stuck-tool recovery:', err);
       });
     }

--- a/src/components/chat/stuckToolRecovery.test.ts
+++ b/src/components/chat/stuckToolRecovery.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  collectStuckToolRecovery,
+  STUCK_TOOL_ERROR_TEXT,
+} from './stuckToolRecovery.ts';
+
+const stuckBuildMessage = {
+  id: 'a1',
+  role: 'assistant',
+  parts: [
+    { type: 'text', text: 'Building…', state: 'done' },
+    {
+      type: 'tool-build_parametric_model',
+      state: 'input-streaming',
+      toolCallId: 'call-1',
+    },
+  ],
+};
+
+describe('collectStuckToolRecovery', () => {
+  // Regression: a cached Chat that is mid-generation when ChatSession
+  // (re)mounts (PromptView handoff, switching back to a conversation while
+  // it streams) must NOT be treated as stuck — rewriting a live
+  // `input-streaming` tool call kills the in-flight build, and the server's
+  // `onFinish` INSERT hasn't landed yet so the recovery persist can never
+  // match a row.
+  it('skips recovery entirely while the chat is actively running', () => {
+    for (const status of ['streaming', 'submitted']) {
+      const result = collectStuckToolRecovery({
+        status,
+        messages: [stuckBuildMessage],
+      });
+      assert.equal(result.size, 0, `status=${status} should be skipped`);
+    }
+  });
+
+  it('rewrites stuck tool calls to output-error on an idle chat', () => {
+    for (const status of ['ready', 'error']) {
+      const result = collectStuckToolRecovery({
+        status,
+        messages: [stuckBuildMessage],
+      });
+      assert.equal(result.size, 1, `status=${status} should recover`);
+      const parts = result.get('a1')!;
+      // text part untouched (same reference)
+      assert.equal(parts[0], stuckBuildMessage.parts[0]);
+      assert.deepEqual(parts[1], {
+        type: 'tool-build_parametric_model',
+        state: 'output-error',
+        toolCallId: 'call-1',
+        errorText: STUCK_TOOL_ERROR_TEXT,
+      });
+    }
+  });
+
+  it('handles dynamic-tool and input-available the same way', () => {
+    const result = collectStuckToolRecovery({
+      status: 'ready',
+      messages: [
+        {
+          id: 'a2',
+          role: 'assistant',
+          parts: [{ type: 'dynamic-tool', state: 'input-available' }],
+        },
+      ],
+    });
+    assert.deepEqual(result.get('a2'), [
+      {
+        type: 'dynamic-tool',
+        state: 'output-error',
+        errorText: STUCK_TOOL_ERROR_TEXT,
+      },
+    ]);
+  });
+
+  it('finishes streaming text and reasoning parts', () => {
+    const result = collectStuckToolRecovery({
+      status: 'ready',
+      messages: [
+        {
+          id: 'a3',
+          role: 'assistant',
+          parts: [
+            { type: 'reasoning', state: 'streaming' },
+            { type: 'text', text: 'partial', state: 'streaming' },
+          ],
+        },
+      ],
+    });
+    assert.deepEqual(result.get('a3'), [
+      { type: 'reasoning', state: 'done' },
+      { type: 'text', text: 'partial', state: 'done' },
+    ]);
+  });
+
+  it('ignores resolved tools, user messages, and clean assistants', () => {
+    const result = collectStuckToolRecovery({
+      status: 'ready',
+      messages: [
+        {
+          id: 'u1',
+          role: 'user',
+          // A user message can never be "stuck" even with odd part states.
+          parts: [{ type: 'text', text: 'hi', state: 'streaming' }],
+        },
+        {
+          id: 'a4',
+          role: 'assistant',
+          parts: [
+            { type: 'text', text: 'done', state: 'done' },
+            { type: 'tool-build_parametric_model', state: 'output-available' },
+            { type: 'tool-answer_user', state: 'output-error' },
+          ],
+        },
+      ],
+    });
+    assert.equal(result.size, 0);
+  });
+});

--- a/src/components/chat/stuckToolRecovery.test.ts
+++ b/src/components/chat/stuckToolRecovery.test.ts
@@ -75,18 +75,17 @@ describe('collectStuckToolRecovery', () => {
   });
 
   it('finishes streaming text and reasoning parts', () => {
+    const streamingTextMessage = {
+      id: 'a3',
+      role: 'assistant',
+      parts: [
+        { type: 'reasoning', state: 'streaming' },
+        { type: 'text', text: 'partial', state: 'streaming' },
+      ],
+    };
     const result = collectStuckToolRecovery({
       status: 'ready',
-      messages: [
-        {
-          id: 'a3',
-          role: 'assistant',
-          parts: [
-            { type: 'reasoning', state: 'streaming' },
-            { type: 'text', text: 'partial', state: 'streaming' },
-          ],
-        },
-      ],
+      messages: [streamingTextMessage],
     });
     assert.deepEqual(result.get('a3'), [
       { type: 'reasoning', state: 'done' },
@@ -95,25 +94,24 @@ describe('collectStuckToolRecovery', () => {
   });
 
   it('ignores resolved tools, user messages, and clean assistants', () => {
+    const userMessage = {
+      id: 'u1',
+      role: 'user',
+      // A user message can never be "stuck" even with odd part states.
+      parts: [{ type: 'text', text: 'hi', state: 'streaming' }],
+    };
+    const cleanAssistantMessage = {
+      id: 'a4',
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'done', state: 'done' },
+        { type: 'tool-build_parametric_model', state: 'output-available' },
+        { type: 'tool-answer_user', state: 'output-error' },
+      ],
+    };
     const result = collectStuckToolRecovery({
       status: 'ready',
-      messages: [
-        {
-          id: 'u1',
-          role: 'user',
-          // A user message can never be "stuck" even with odd part states.
-          parts: [{ type: 'text', text: 'hi', state: 'streaming' }],
-        },
-        {
-          id: 'a4',
-          role: 'assistant',
-          parts: [
-            { type: 'text', text: 'done', state: 'done' },
-            { type: 'tool-build_parametric_model', state: 'output-available' },
-            { type: 'tool-answer_user', state: 'output-error' },
-          ],
-        },
-      ],
+      messages: [userMessage, cleanAssistantMessage],
     });
     assert.equal(result.size, 0);
   });

--- a/src/components/chat/stuckToolRecovery.ts
+++ b/src/components/chat/stuckToolRecovery.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure logic for the load-time stuck-tool recovery in `<ChatSession>`, kept
+ * dependency-free so it's unit-testable in isolation (`deno test
+ * src/components/chat/stuckToolRecovery.test.ts`). See the recovery effect in
+ * `ChatSession.tsx` for the call site, and `src/server/chatToolPersistence.ts`
+ * for the server-side twin of this sanitizer.
+ */
+
+/** Minimal structural shape of a message part — all we need to reason about. */
+export type RecoveryPartLike = { type: string; state?: string };
+
+export type RecoveryMessageLike<T extends RecoveryPartLike> = {
+  id: string;
+  role: string;
+  parts: readonly T[];
+};
+
+export const STUCK_TOOL_ERROR_TEXT =
+  'Tool execution did not complete in the previous session.';
+
+/**
+ * Scan a chat's messages for parts that never finished in a previous session
+ * and return the rewritten `parts` arrays keyed by message id (empty map →
+ * nothing to recover). Tool calls stuck at `input-streaming` /
+ * `input-available` become `output-error`; `streaming` text / reasoning
+ * becomes `done`.
+ *
+ * Returns empty when the chat is ACTIVELY running (`streaming` /
+ * `submitted`): a cached Chat instance survives ChatSession remounts
+ * (PromptView handoff, switching back to a conversation mid-generation), and
+ * a live stream legitimately holds `input-streaming` parts. Rewriting those
+ * would kill an in-flight tool call — and the server's `onFinish` INSERT for
+ * that row hasn't landed yet, so the recovery persist could never match it.
+ * The live session's own handlers (`finishWithError`, `onError`) own
+ * failures from here; recovery is only for chats that LOADED broken.
+ */
+export function collectStuckToolRecovery<T extends RecoveryPartLike>({
+  status,
+  messages,
+}: {
+  status: string;
+  messages: ReadonlyArray<RecoveryMessageLike<T>>;
+}): Map<string, T[]> {
+  const stuckByMessageId = new Map<string, T[]>();
+  if (status === 'streaming' || status === 'submitted') {
+    return stuckByMessageId;
+  }
+
+  for (const msg of messages) {
+    if (msg.role !== 'assistant') continue;
+    let dirty = false;
+    const nextParts = msg.parts.map((p) => {
+      if (
+        (p.type.startsWith('tool-') || p.type === 'dynamic-tool') &&
+        'state' in p &&
+        (p.state === 'input-streaming' || p.state === 'input-available')
+      ) {
+        dirty = true;
+        return {
+          ...p,
+          state: 'output-error',
+          errorText: STUCK_TOOL_ERROR_TEXT,
+        } as unknown as T;
+      }
+      if (
+        (p.type === 'reasoning' || p.type === 'text') &&
+        p.state === 'streaming'
+      ) {
+        dirty = true;
+        return { ...p, state: 'done' } as unknown as T;
+      }
+      return p;
+    });
+    if (dirty) stuckByMessageId.set(msg.id, nextParts);
+  }
+
+  return stuckByMessageId;
+}

--- a/src/components/chat/stuckToolRecovery.ts
+++ b/src/components/chat/stuckToolRecovery.ts
@@ -9,10 +9,10 @@
 /** Minimal structural shape of a message part — all we need to reason about. */
 export type RecoveryPartLike = { type: string; state?: string };
 
-export type RecoveryMessageLike<T extends RecoveryPartLike> = {
+export type RecoveryMessageLike = {
   id: string;
   role: string;
-  parts: readonly T[];
+  parts: readonly RecoveryPartLike[];
 };
 
 export const STUCK_TOOL_ERROR_TEXT =
@@ -23,7 +23,9 @@ export const STUCK_TOOL_ERROR_TEXT =
  * and return the rewritten `parts` arrays keyed by message id (empty map →
  * nothing to recover). Tool calls stuck at `input-streaming` /
  * `input-available` become `output-error`; `streaming` text / reasoning
- * becomes `done`.
+ * becomes `done`. Every rewrite spreads the original part, so all
+ * caller-specific fields survive — the caller re-narrows the structural
+ * return to its own part type.
  *
  * Returns empty when the chat is ACTIVELY running (`streaming` /
  * `submitted`): a cached Chat instance survives ChatSession remounts
@@ -34,14 +36,14 @@ export const STUCK_TOOL_ERROR_TEXT =
  * The live session's own handlers (`finishWithError`, `onError`) own
  * failures from here; recovery is only for chats that LOADED broken.
  */
-export function collectStuckToolRecovery<T extends RecoveryPartLike>({
+export function collectStuckToolRecovery({
   status,
   messages,
 }: {
   status: string;
-  messages: ReadonlyArray<RecoveryMessageLike<T>>;
-}): Map<string, T[]> {
-  const stuckByMessageId = new Map<string, T[]>();
+  messages: readonly RecoveryMessageLike[];
+}): Map<string, RecoveryPartLike[]> {
+  const stuckByMessageId = new Map<string, RecoveryPartLike[]>();
   if (status === 'streaming' || status === 'submitted') {
     return stuckByMessageId;
   }
@@ -60,14 +62,14 @@ export function collectStuckToolRecovery<T extends RecoveryPartLike>({
           ...p,
           state: 'output-error',
           errorText: STUCK_TOOL_ERROR_TEXT,
-        } as unknown as T;
+        };
       }
       if (
         (p.type === 'reasoning' || p.type === 'text') &&
         p.state === 'streaming'
       ) {
         dirty = true;
-        return { ...p, state: 'done' } as unknown as T;
+        return { ...p, state: 'done' };
       }
       return p;
     });

--- a/src/services/messageService.ts
+++ b/src/services/messageService.ts
@@ -41,6 +41,17 @@ export async function persistUserMessage({
 }
 
 /**
+ * Thrown when `persistAssistantParts` matched no row even after retries —
+ * the assistant row was never INSERTed (the stream was interrupted before
+ * the server's `onFinish` ran). Callers that merely mirror in-memory state
+ * onto an existing row (load-time stuck-tool recovery) can treat this as
+ * benign: with no row, the DB branch has no dangling tool call to repair.
+ * Callers persisting NEW tool output must still surface it — the server
+ * continues from the DB branch, so a lost write means a stale continuation.
+ */
+export class AssistantRowMissingError extends Error {}
+
+/**
  * Persist updated `parts` on an existing assistant row. Used after the
  * client compiles a `build_parametric_model` tool call locally — we need
  * the DB row to reflect the completed tool output before the server reads
@@ -91,7 +102,7 @@ export async function persistAssistantParts({
       await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
     }
   }
-  throw new Error(
+  throw new AssistantRowMissingError(
     `persistAssistantParts matched no row after ${MAX_ATTEMPTS} attempts ` +
       `(messageId=${messageId}). The assistant message was never persisted.`,
   );


### PR DESCRIPTION
…missing rows

The load-time stuck-tool recovery in ChatSession assumed (a) the chat is never actively streaming when the effect runs and (b) the assistant row always exists in DB. Cached Chat instances (useCachedAiChat) violate both:

- Remounting mid-generation (PromptView handoff, switching back to a conversation while a build streams) made recovery mistake the live input-streaming tool part for a stale leftover, rewrite it to output-error mid-flight, and persist against a row the server's onFinish hadn't inserted yet.
- Interrupted streams (stop, network drop, model error) leave an in-memory assistant with no DB row at all — persistAssistantParts is UPDATE-only, so recovery retried 6x and warned on every revisit, for a condition that is benign (the DB leaf is still the user message, so there is no dangling tool call to repair).

Fix: extract the recovery scan to a pure collectStuckToolRecovery that skips entirely while chat.status is streaming/submitted, and type the zero-row throw as AssistantRowMissingError so recovery can downgrade it to an informational log while real persist failures still warn. The live tool-output path keeps its loud failure + pause behavior.

Regression test proves the guard bites (fails without it). tsc, eslint, and the existing chatToolPersistence tests are green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stuck-tool recovery from overriding live, in-flight streams and from warning on benign missing DB rows. Recovery now only runs on idle chats and logs missing assistant rows as info.

- **Bug Fixes**
  - Skip recovery when `chat.status` is `streaming` or `submitted` to avoid rewriting live tool calls.
  - Treat zero-row updates in `persistAssistantParts` as `AssistantRowMissingError`; log and skip DB writes instead of warning.

- **Refactors**
  - Extracted a pure `collectStuckToolRecovery` with structural return types; removed `as` casts and narrow at the `ChatSession` call site.
  - Added regression test for the streaming guard and recovery rules.

<sup>Written for commit 137f2cea789cc53f53a3d7ff185f282c2ebb1efe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

