### PR TITLE
Enable adaptive thinking by default for Claude 5 / 4.6+ models

### DIFF
--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -424,9 +424,13 @@ function buildChatModel(
 // or the bare Anthropic ID — strip the prefix here so every gate is called the
 // same way regardless of which form the caller has on hand.
 function bareModelId(modelId: string): string {
-  return modelId.startsWith('anthropic/')
+  const id = modelId.startsWith('anthropic/')
     ? modelId.slice('anthropic/'.length)
     : modelId;
+  // Anthropic's API uses dashes ("claude-opus-4-6"); the OpenRouter alias
+  // uses dots ("claude-opus-4.6"). Normalize so the version regexes match
+  // either form.
+  return id.replace(/\./g, '-');
 }
 
 function usesAdaptiveAnthropicThinking(modelId: string) {
@@ -1128,14 +1132,22 @@ export async function handleAiChatRequest(req: Request) {
     provider: resolvedProvider,
   };
 
+  // Adaptive-thinking Anthropic models (Claude 5 — Fable/Mythos — and
+  // Opus/Sonnet 4.6+) get thinking enabled unconditionally: adaptive thinking
+  // lets the model decide when and how much to think, and on Fable 5 omitting
+  // it disables thinking entirely — no reasoning ever streams, and complex
+  // parametric turns degrade (especially combined with the auto tool-choice
+  // fallback). The client never sends `thinking: true` today, so without this
+  // the Anthropic thinking branch is dead code.
+  const thinkingEnabled =
+    (rawBody.thinking ?? false) ||
+    (resolvedProvider === 'anthropic' &&
+      usesAdaptiveAnthropicThinking(actualModelId));
+
   let chatLanguageModel: LanguageModel;
   let chatProviderOptions: ProviderOptions | undefined;
   try {
-    const built = buildChatModel(
-      actualModelId,
-      providers,
-      rawBody.thinking ?? false,
-    );
+    const built = buildChatModel(actualModelId, providers, thinkingEnabled);
     chatLanguageModel = built.model;
     chatProviderOptions = built.providerOptions;
   } catch (error) {
@@ -1157,7 +1169,7 @@ export async function handleAiChatRequest(req: Request) {
 
   const logContext = {
     ...baseLogContext,
-    thinking: rawBody.thinking ?? false,
+    thinking: thinkingEnabled,
   };
 
   // Parametric step 0 normally pins `build_parametric_model` via a forced
@@ -1204,7 +1216,7 @@ export async function handleAiChatRequest(req: Request) {
     maxOutputTokens:
       conversation.type === 'parametric'
         ? PARAMETRIC_MAX_OUTPUT_TOKENS
-        : rawBody.thinking
+        : thinkingEnabled
           ? 20000
           : 16000,
     abortSignal: req.signal,

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -433,21 +433,30 @@ function bareModelId(modelId: string): string {
   return id.replace(/\./g, '-');
 }
 
+// The Claude 5 generation swaps the opus/sonnet/haiku tiers for code names
+// ("claude-fable-5", "claude-mythos-5", …). Match the `claude-<codename>-5`
+// shape rather than enumerating code names so future Claude 5 variants
+// inherit the same capability gates without a list update. Versioned 4.x ids
+// ("claude-opus-4-5", "claude-haiku-4-5") don't match: their tier name is
+// followed by "-4", not "-5".
+function isClaude5Model(modelId: string): boolean {
+  return /^claude-[a-z]+-5\b/.test(bareModelId(modelId));
+}
+
 function usesAdaptiveAnthropicThinking(modelId: string) {
-  // The Claude 5 generation (Fable, Mythos) uses adaptive thinking, as do
-  // Claude Opus/Sonnet 4.6+. Older 4.x models take the fixed-budget path.
-  const id = bareModelId(modelId);
-  if (/^claude-(?:fable|mythos)-5\b/.test(id)) return true;
-  const match = /^claude-(?:opus|sonnet)-4-(\d+)/.exec(id);
+  // The Claude 5 generation uses adaptive thinking, as do Claude Opus/Sonnet
+  // 4.6+. Older 4.x models take the fixed-budget path.
+  if (isClaude5Model(modelId)) return true;
+  const match = /^claude-(?:opus|sonnet)-4-(\d+)/.exec(bareModelId(modelId));
   return match ? Number(match[1]) >= 6 : false;
 }
 
 // Whether a model accepts a forced `tool_choice` (type: "tool" / "any").
-// The Claude 5 generation (Fable, Mythos) rejects forced tool use with
-// "tool_choice forces tool use is not compatible with this model" — for those
-// we must fall back to auto tool choice and steer via the system prompt.
+// The Claude 5 generation rejects forced tool use with "tool_choice forces
+// tool use is not compatible with this model" — for those we must fall back
+// to auto tool choice and steer via the system prompt.
 function supportsForcedToolChoice(modelId: string): boolean {
-  return !/^claude-(?:fable|mythos)-5\b/.test(bareModelId(modelId));
+  return !isClaude5Model(modelId);
 }
 
 function priceFor(modelId: string) {
@@ -1213,11 +1222,16 @@ export async function handleAiChatRequest(req: Request) {
       return {};
     },
     stopWhen: stepCountIs(conversation.type === 'parametric' ? 60 : 5),
+    // Thinking and visible response tokens share this pool. With adaptive
+    // thinking now always-on for Claude 5 / 4.6+, a heavy reasoning turn can
+    // spend 10k+ tokens before the answer starts — 32k keeps the visible
+    // response from getting squeezed. We stream, so SDK HTTP timeouts aren't
+    // a concern at this size.
     maxOutputTokens:
       conversation.type === 'parametric'
         ? PARAMETRIC_MAX_OUTPUT_TOKENS
         : thinkingEnabled
-          ? 20000
+          ? 32000
           : 16000,
     abortSignal: req.signal,
     // Decouple our render cadence from the provider's native chunking.


### PR DESCRIPTION
The client never sends `thinking: true`, so the Anthropic thinking branch in buildChatModel was dead code: Fable 5 requests went out with no thinking field at all, which on the Claude 5 generation disables thinking entirely. Result: reasoning never streamed in the chat panel, and complex parametric turns degraded (no thinking + the auto tool-choice fallback).

Compute an effective `thinkingEnabled` server-side that turns thinking on unconditionally for adaptive-thinking Anthropic models (Fable/Mythos 5, Opus/Sonnet 4.6+) — adaptive thinking lets the model decide when and how much to think, so it's safe as an always-on default. The flag also drives maxOutputTokens headroom and the log context, so logs now reflect what was actually sent to the provider.

Also normalize dots to dashes in bareModelId so the capability gates match OpenRouter-style aliases (claude-opus-4.6) as well as API ids.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables adaptive thinking by default for Anthropic adaptive models (all Claude 5 variants; Opus/Sonnet 4.6+) to restore reasoning streaming and improve parametric turns. Normalizes model IDs so capability gates match OpenRouter aliases.

- **Bug Fixes**
  - Compute `thinkingEnabled` server-side; auto-enable for Claude 5 and Opus/Sonnet 4.6+; use it in `buildChatModel`, logs, and raise non-parametric `maxOutputTokens` to 32k (16k without thinking).
  - Generalize Claude 5 gates with a `claude-<codename>-5` match and reuse for forced tool-choice fallback; normalize `bareModelId` by replacing dots with dashes (e.g., `claude-opus-4.6` -> `claude-opus-4-6`).

<sup>Written for commit 1f1aa0c81bb8ccf1c01d8796daf8c2c12dfd63cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

