### PR TITLE
Add sidebar hover menu for recent creations.

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { Link, useNavigate, useRouterState } from '@tanstack/react-router';
 import { Menu, Plus, LogOut, Crown, Settings, LayoutGrid } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -32,7 +32,14 @@ import { DiscordIcon, GitHubIcon } from './icons/CompanyIcons';
 import { cn } from '@/lib/utils';
 import { Conversation, ConversationSettings } from '@shared/types';
 import { UserAvatar } from '@/components/chat/UserAvatar';
+import { SidebarConversationItem } from '@/components/sidebar/SidebarConversationItem';
+import { RenameDialogDrawer } from '@/components/history/RenameDialogDrawer';
+import {
+  useDeleteConversation,
+  useRenameConversation,
+} from '@/services/conversationService';
 import { useProfile } from '@/services/profileService';
+import { useToast } from '@/hooks/use-toast';
 
 interface SidebarProps {
   isSidebarOpen: boolean;
@@ -46,6 +53,28 @@ function DesktopSidebar({ isSidebarOpen, setIsSidebarOpen }: SidebarProps) {
   const { user, signOut } = useAuth();
   const isMobile = useIsMobile();
   const { data: profile } = useProfile();
+  const { toast } = useToast();
+  const activeEditorId = useRouterState({
+    select: (state) => state.location.pathname.match(/^\/editor\/([^/]+)/)?.[1],
+  });
+  const [renameTarget, setRenameTarget] = useState<Conversation | null>(null);
+  const [renameTitle, setRenameTitle] = useState('');
+  const [renameOpen, setRenameOpen] = useState(false);
+
+  const deleteConversation = useDeleteConversation({
+    onDeleted: (conversationId) => {
+      if (activeEditorId === conversationId) {
+        navigate({ to: '/' });
+      }
+    },
+  });
+
+  const renameConversation = useRenameConversation({
+    onRenamed: () => {
+      setRenameOpen(false);
+      setRenameTarget(null);
+    },
+  });
 
   // Get 10 most recent conversations
   const { data: recentConversations } = useQuery<Conversation[]>({
@@ -80,6 +109,40 @@ function DesktopSidebar({ isSidebarOpen, setIsSidebarOpen }: SidebarProps) {
       setIsSidebarOpen(false); // setIsSidebarOpen is actually setOpen from Sheet component
     }
     navigate({ to: path });
+  };
+
+  const closeMobileSidebar = () => {
+    if (isMobile) {
+      setIsSidebarOpen(false);
+    }
+  };
+
+  const handleRenameRequest = (
+    conversationId: string,
+    currentTitle: string,
+  ) => {
+    const conversation = recentConversations?.find(
+      (item) => item.id === conversationId,
+    );
+    if (!conversation) return;
+    setRenameTarget(conversation);
+    setRenameTitle(currentTitle || conversation.title);
+    setRenameOpen(true);
+  };
+
+  const handleRenameSave = () => {
+    if (!renameTarget) return;
+    if (!renameTitle.trim()) {
+      toast({
+        title: 'Title cannot be empty',
+        variant: 'default',
+      });
+      return;
+    }
+    renameConversation.mutate({
+      conversationId: renameTarget.id,
+      newTitle: renameTitle.trim(),
+    });
   };
 
   const renderUserSectionTrigger = () => {
@@ -228,35 +291,34 @@ function DesktopSidebar({ isSidebarOpen, setIsSidebarOpen }: SidebarProps) {
                   </Button>
                 </ConditionalWrapper>
                 {isSidebarOpen && submenu && (
-                  <ul className="ml-7 flex list-none flex-col gap-1 border-l border-adam-neutral-500 px-2">
-                    {submenu.map(
-                      (
-                        conversation: Omit<
-                          Conversation,
-                          'message_count' | 'last_message_at'
-                        >,
-                      ) => {
-                        return (
-                          <Link
-                            to="/editor/$id"
-                            params={{ id: conversation.id }}
+                  <div className="ml-7 border-l border-adam-neutral-500 px-2">
+                    {submenu.length === 0 ? (
+                      <p className="px-1 py-1.5 text-xs text-adam-neutral-500">
+                        No creations yet
+                      </p>
+                    ) : (
+                      <ul className="flex list-none flex-col gap-0.5">
+                        {submenu.map((conversation) => (
+                          <SidebarConversationItem
                             key={conversation.id}
-                            onClick={() => {
-                              if (isMobile) {
-                                setIsSidebarOpen(false);
-                              }
-                            }}
-                          >
-                            <li key={conversation.id}>
-                              <span className="line-clamp-1 text-ellipsis text-nowrap rounded-md p-1 text-xs font-medium text-adam-neutral-400 transition-colors duration-200 ease-in-out [@media(hover:hover)]:hover:bg-adam-neutral-950 [@media(hover:hover)]:hover:text-adam-neutral-10">
-                                {conversation.title}
-                              </span>
-                            </li>
-                          </Link>
-                        );
-                      },
+                            conversation={conversation}
+                            onDelete={(id) => deleteConversation.mutate(id)}
+                            onRename={handleRenameRequest}
+                            onNavigate={closeMobileSidebar}
+                          />
+                        ))}
+                      </ul>
                     )}
-                  </ul>
+                    {submenu.length > 0 && (
+                      <Link
+                        to="/history"
+                        onClick={closeMobileSidebar}
+                        className="mt-1 block px-1 py-1 text-xs font-medium text-adam-blue transition-colors [@media(hover:hover)]:hover:text-adam-blue/80"
+                      >
+                        View all creations
+                      </Link>
+                    )}
+                  </div>
                 )}
               </div>
             ))}
@@ -399,6 +461,16 @@ function DesktopSidebar({ isSidebarOpen, setIsSidebarOpen }: SidebarProps) {
           </div>
         </div>
       </div>
+      <RenameDialogDrawer
+        open={renameOpen}
+        onOpenChange={(open) => {
+          setRenameOpen(open);
+          if (!open) setRenameTarget(null);
+        }}
+        newTitle={renameTitle}
+        onNewTitleChange={setRenameTitle}
+        onRename={handleRenameSave}
+      />
     </div>
   );
 }

--- a/src/components/sidebar/SidebarConversationItem.tsx
+++ b/src/components/sidebar/SidebarConversationItem.tsx
@@ -1,0 +1,126 @@
+import { Link } from '@tanstack/react-router';
+import { ExternalLink, MoreVertical, Pencil, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Conversation } from '@shared/types';
+
+interface SidebarConversationItemProps {
+  conversation: Pick<Conversation, 'id' | 'title'>;
+  onDelete: (conversationId: string) => void;
+  onRename: (conversationId: string, currentTitle: string) => void;
+  onNavigate?: () => void;
+}
+
+export function SidebarConversationItem({
+  conversation,
+  onDelete,
+  onRename,
+  onNavigate,
+}: SidebarConversationItemProps) {
+  return (
+    <li className="group relative list-none">
+      <Link
+        to="/editor/$id"
+        params={{ id: conversation.id }}
+        onClick={onNavigate}
+        className="block min-w-0 pr-7"
+      >
+        <span className="line-clamp-1 text-ellipsis text-nowrap rounded-md p-1 text-xs font-medium text-adam-neutral-400 transition-colors duration-200 ease-in-out [@media(hover:hover)]:group-hover:bg-adam-neutral-950 [@media(hover:hover)]:group-hover:text-adam-neutral-10">
+          {conversation.title || 'Untitled creation'}
+        </span>
+      </Link>
+      <div className="absolute right-0 top-1/2 -translate-y-1/2 opacity-0 transition-opacity duration-150 [@media(hover:hover)]:focus-within:opacity-100 [@media(hover:hover)]:group-hover:opacity-100">
+        <AlertDialog>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 p-0 text-adam-neutral-400 hover:bg-adam-neutral-950 hover:text-adam-neutral-100"
+                onClick={(event) => event.preventDefault()}
+              >
+                <MoreVertical className="h-3.5 w-3.5" />
+                <span className="sr-only">Creation options</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              className="min-w-[10rem] border-adam-neutral-700 bg-[#191A1A]"
+            >
+              <DropdownMenuItem
+                asChild
+                className="text-adam-neutral-50 hover:cursor-pointer hover:bg-adam-neutral-950 focus:bg-adam-neutral-950"
+              >
+                <Link
+                  to="/editor/$id"
+                  params={{ id: conversation.id }}
+                  onClick={onNavigate}
+                >
+                  <ExternalLink className="mr-2 h-3.5 w-3.5" />
+                  Open
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-adam-neutral-50 hover:cursor-pointer hover:bg-adam-neutral-950 focus:bg-adam-neutral-950"
+                onClick={(event) => {
+                  event.preventDefault();
+                  onRename(conversation.id, conversation.title);
+                }}
+              >
+                <Pencil className="mr-2 h-3.5 w-3.5" />
+                Rename
+              </DropdownMenuItem>
+              <AlertDialogTrigger asChild>
+                <DropdownMenuItem
+                  className="text-adam-neutral-50 hover:cursor-pointer hover:bg-adam-neutral-950 hover:text-red-500 focus:bg-adam-neutral-950 focus:text-red-500"
+                  onSelect={(event) => event.preventDefault()}
+                >
+                  <Trash2 className="mr-2 h-3.5 w-3.5" />
+                  Delete
+                </DropdownMenuItem>
+              </AlertDialogTrigger>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <AlertDialogContent className="border-[2px] border-adam-neutral-700 bg-adam-background-1">
+            <AlertDialogHeader>
+              <AlertDialogTitle className="text-adam-neutral-100">
+                Delete creation
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete &ldquo;
+                {conversation.title || 'Untitled creation'}&rdquo;? This action
+                cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-red-600 hover:bg-red-700 dark:bg-red-900 dark:hover:bg-red-800"
+                onClick={() => onDelete(conversation.id)}
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </li>
+  );
+}

--- a/src/services/conversationService.ts
+++ b/src/services/conversationService.ts
@@ -1,8 +1,198 @@
 import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/hooks/use-toast';
+import { HistoryConversation } from '@/types/misc';
 import { Conversation } from '@shared/types';
 import { supabase } from '@/lib/supabase';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
+
+type ConversationListItem = Pick<Conversation, 'id' | 'title'> &
+  Partial<Conversation>;
+
+async function removeConversationImages(
+  userId: string,
+  conversationId: string,
+) {
+  const { data: list } = await supabase.storage
+    .from('images')
+    .list(`${userId}/${conversationId}`);
+  if (list?.length) {
+    await supabase.storage
+      .from('images')
+      .remove(list.map((file) => `${userId}/${conversationId}/${file.name}`));
+  }
+}
+
+function patchConversationListCaches(
+  queryClient: QueryClient,
+  conversationId: string,
+  mode: 'remove' | { rename: string },
+) {
+  const patch = <T extends ConversationListItem>(items: T[] | undefined) => {
+    if (!items) return items;
+    if (mode === 'remove') {
+      return items.filter((item) => item.id !== conversationId);
+    }
+    return items.map((item) =>
+      item.id === conversationId ? { ...item, title: mode.rename } : item,
+    );
+  };
+
+  queryClient.setQueryData(
+    ['conversations'],
+    (old: HistoryConversation[] | undefined) => patch(old),
+  );
+  queryClient.setQueryData(
+    ['conversations', 'recent'],
+    (old: Conversation[] | undefined) => patch(old),
+  );
+  if (mode !== 'remove') {
+    queryClient.setQueryData(
+      ['conversation', conversationId],
+      (old: Conversation | undefined) =>
+        old ? { ...old, title: mode.rename } : old,
+    );
+  } else {
+    queryClient.removeQueries({ queryKey: ['conversation', conversationId] });
+    queryClient.removeQueries({ queryKey: ['messages', conversationId] });
+  }
+}
+
+export function useDeleteConversation(options?: {
+  onDeleted?: (conversationId: string) => void;
+}) {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (conversationId: string) => {
+      const { error } = await supabase
+        .from('conversations')
+        .delete()
+        .eq('id', conversationId);
+
+      if (error) throw error;
+
+      if (user?.id) {
+        void removeConversationImages(user.id, conversationId);
+      }
+    },
+    onMutate: async (conversationId) => {
+      await queryClient.cancelQueries({ queryKey: ['conversations'] });
+      await queryClient.cancelQueries({
+        queryKey: ['conversations', 'recent'],
+      });
+      const previousConversations = queryClient.getQueryData(['conversations']);
+      const previousRecent = queryClient.getQueryData([
+        'conversations',
+        'recent',
+      ]);
+      patchConversationListCaches(queryClient, conversationId, 'remove');
+      return { previousConversations, previousRecent };
+    },
+    onSuccess: (_data, conversationId) => {
+      queryClient.invalidateQueries({ queryKey: ['conversations'] });
+      queryClient.invalidateQueries({ queryKey: ['conversations', 'recent'] });
+      options?.onDeleted?.(conversationId);
+      toast({
+        title: 'Creation deleted',
+        description: 'The conversation was removed successfully.',
+      });
+    },
+    onError: (error, _conversationId, context) => {
+      console.error('Error deleting conversation:', error);
+      queryClient.setQueryData(
+        ['conversations'],
+        context?.previousConversations,
+      );
+      queryClient.setQueryData(
+        ['conversations', 'recent'],
+        context?.previousRecent,
+      );
+      toast({
+        title: 'Error',
+        description: 'Failed to delete conversation',
+        variant: 'destructive',
+      });
+    },
+  });
+}
+
+export function useRenameConversation(options?: { onRenamed?: () => void }) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      conversationId,
+      newTitle,
+    }: {
+      conversationId: string;
+      newTitle: string;
+    }) => {
+      const { error } = await supabase
+        .from('conversations')
+        .update({ title: newTitle })
+        .eq('id', conversationId);
+
+      if (error) throw error;
+    },
+    onMutate: async ({ conversationId, newTitle }) => {
+      await queryClient.cancelQueries({ queryKey: ['conversations'] });
+      await queryClient.cancelQueries({
+        queryKey: ['conversations', 'recent'],
+      });
+      const previousConversations = queryClient.getQueryData(['conversations']);
+      const previousRecent = queryClient.getQueryData([
+        'conversations',
+        'recent',
+      ]);
+      const previousConversation = queryClient.getQueryData([
+        'conversation',
+        conversationId,
+      ]);
+      patchConversationListCaches(queryClient, conversationId, {
+        rename: newTitle,
+      });
+      return { previousConversations, previousRecent, previousConversation };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['conversations'] });
+      queryClient.invalidateQueries({ queryKey: ['conversations', 'recent'] });
+      options?.onRenamed?.();
+      toast({
+        title: 'Creation renamed',
+        description: 'The conversation title was updated.',
+      });
+    },
+    onError: (error, { conversationId }, context) => {
+      console.error('Error renaming conversation:', error);
+      queryClient.setQueryData(
+        ['conversations'],
+        context?.previousConversations,
+      );
+      queryClient.setQueryData(
+        ['conversations', 'recent'],
+        context?.previousRecent,
+      );
+      queryClient.setQueryData(
+        ['conversation', conversationId],
+        context?.previousConversation,
+      );
+      toast({
+        title: 'Error',
+        description: 'Failed to rename conversation',
+        variant: 'destructive',
+      });
+    },
+  });
+}
 
 const defaultConversation: Conversation = {
   id: '',

--- a/src/views/HistoryView.tsx
+++ b/src/views/HistoryView.tsx
@@ -20,6 +20,10 @@ import { HistoryConversation } from '../types/misc.ts';
 import { ConversationCard } from '@/components/history/ConversationCard';
 import { VisualCard } from '@/components/history/VisualCard';
 import { RenameDialogDrawer } from '@/components/history/RenameDialogDrawer';
+import {
+  useDeleteConversation,
+  useRenameConversation,
+} from '@/services/conversationService';
 import { cn } from '@/lib/utils';
 
 const VIEW_TRANSITION_PROPS = {
@@ -48,6 +52,14 @@ export function HistoryView() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const shouldReduceMotion = useReducedMotion();
+
+  const deleteConversation = useDeleteConversation();
+  const renameConversation = useRenameConversation({
+    onRenamed: () => {
+      setEditingConversation(null);
+      setOpen(false);
+    },
+  });
 
   const handleOpenChange = (open: boolean) => {
     setOpen(open);
@@ -106,108 +118,6 @@ export function HistoryView() {
       });
     }
   }, [conversationQuery.isError, toast]);
-
-  const deleteConversation = useMutation({
-    mutationFn: async (conversationId: string) => {
-      const { error } = await supabase
-        .from('conversations')
-        .delete()
-        .eq('id', conversationId);
-
-      if (error) throw error;
-
-      supabase.storage
-        .from('images')
-        .list(`${user?.id}/${conversationId}`)
-        .then(({ data: list }) => {
-          if (list) {
-            const filesToRemove = list.map(
-              (file) => `${user?.id}/${conversationId}/${file.name}`,
-            );
-            supabase.storage.from('images').remove(filesToRemove);
-          }
-        });
-    },
-    onMutate: async (conversationId) => {
-      await queryClient.cancelQueries({ queryKey: ['conversations'] });
-      const previousConversations = queryClient.getQueryData(['conversations']);
-      queryClient.setQueryData(
-        ['conversations'],
-        (old: HistoryConversation[]) =>
-          old.filter((conv) => conv.id !== conversationId),
-      );
-      return { previousConversations };
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['conversations'] });
-      toast({
-        title: 'Success',
-        description: 'Conversation deleted successfully',
-      });
-    },
-    onError: (error: unknown, _conversationId: string, context) => {
-      console.error('Error deleting conversation:', error);
-      queryClient.setQueryData(
-        ['conversations'],
-        context?.previousConversations,
-      );
-      toast({
-        title: 'Error',
-        description: 'Failed to delete conversation',
-        variant: 'destructive',
-      });
-    },
-  });
-
-  const renameConversation = useMutation({
-    mutationFn: async ({
-      conversationId,
-      newTitle,
-    }: {
-      conversationId: string;
-      newTitle: string;
-    }) => {
-      const { error } = await supabase
-        .from('conversations')
-        .update({ title: newTitle })
-        .eq('id', conversationId);
-
-      if (error) throw error;
-    },
-    onMutate: async ({ conversationId, newTitle }) => {
-      await queryClient.cancelQueries({ queryKey: ['conversations'] });
-      const previousConversations = queryClient.getQueryData(['conversations']);
-      queryClient.setQueryData(
-        ['conversations'],
-        (old: HistoryConversation[]) =>
-          old.map((conv) =>
-            conv.id === conversationId ? { ...conv, title: newTitle } : conv,
-          ),
-      );
-      return { previousConversations };
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['conversations'] });
-      toast({
-        title: 'Success',
-        description: 'Conversation renamed successfully',
-      });
-      setEditingConversation(null);
-      setOpen(false);
-    },
-    onError: (error: unknown, _variables, context) => {
-      console.error('Error renaming conversation:', error);
-      queryClient.setQueryData(
-        ['conversations'],
-        context?.previousConversations,
-      );
-      toast({
-        title: 'Error',
-        description: 'Failed to rename conversation',
-        variant: 'destructive',
-      });
-    },
-  });
 
   const togglePrivacy = useMutation({
     mutationFn: async ({


### PR DESCRIPTION
## Summary
- Add hover dropdown on sidebar recent creations (Open, Rename, Delete)
- Show empty state when there are no creations; hide "View all creations" when empty
- Extract shared `useDeleteConversation` / `useRenameConversation` hooks used by Sidebar and History

## Test plan
- [ ] Hover a recent creation → ⋮ menu appears with Open / Rename / Delete
- [ ] Rename from sidebar → title updates in sidebar and on History page
- [ ] Delete from sidebar → item removed; deleting active editor redirects to `/`
- [ ] Empty account → shows "No creations yet", no "View all creations" link
- [ ] With creations → "View all creations" links to `/history`
- [ ] Mobile sidebar sheet → same behavior works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a hover actions menu to recent creations in the sidebar so you can Open, Rename, or Delete without leaving the page. Shared mutations keep the sidebar and History in sync, with proper redirects and empty states.

- **New Features**
  - "…" hover menu per creation with Open, Rename, Delete
  - Rename via dialog; updates both Sidebar and History
  - Delete removes item; deleting the active editor redirects to `/`
  - Empty state: shows “No creations yet”; hides “View all creations”
  - Mobile: navigating from the sidebar closes the sheet

- **Refactors**
  - Extracted `useDeleteConversation` and `useRenameConversation` to `conversationService` with optimistic cache updates and image cleanup
  - `HistoryView` now uses the shared hooks

<sup>Written for commit fe7535f8d5dd26e6b0f2211e4014e0e010b208d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

