### PR TITLE
Replace Claude Fable 5 with Claude Opus 4.8 in model picker

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -246,8 +246,8 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'anthropic/claude-fable-5',
-    name: 'Claude Fable 5',
+    id: 'anthropic/claude-opus-4.8',
+    name: 'Claude Opus 4.8',
     description: 'Most powerful Anthropic model for complex reasoning',
     provider: 'Anthropic',
     supportsTools: true,

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -52,7 +52,7 @@ const MODEL_PRICES: Record<
   { input: number; output: number; cacheRead?: number; cacheWrite?: number }
 > = {
   // Anthropic
-  'anthropic/claude-fable-5': { input: 10, output: 50 },
+  'anthropic/claude-opus-4.8': { input: 5, output: 25 },
   'anthropic/claude-opus-4': { input: 15, output: 75 },
   'anthropic/claude-sonnet-4.6': { input: 3, output: 15 },
   'anthropic/claude-sonnet-4.5': { input: 3, output: 15 },


### PR DESCRIPTION
Swap the parametric model picker entry back to Claude Opus 4.8, routing to the `anthropic/claude-opus-4.8` id and pricing it at $5/$25 per million input/output tokens.

The generalized capability gates from #187/#190 already handle Opus 4.8: usesAdaptiveAnthropicThinking matches the opus-4.6+ branch (adaptive thinking on), and isClaude5Model doesn't match claude-opus-4-8, so forced tool_choice is restored for parametric step 0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swapped the parametric model picker entry from Claude Fable 5 to Claude Opus 4.8 (`anthropic/claude-opus-4.8`) and updated pricing to $5 input / $25 output per million tokens. Capability gates already handle Opus 4.8: adaptive thinking is on (opus-4.6+ path) and, since it’s not a Claude 5 model, forced tool_choice is restored for parametric step 0.

<sup>Written for commit c63e579eac790517b260b46ad1129b141d34467f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

