### PR TITLE
Fix Anthropic chat: thinking + forced tool_choice conflict, and ANTHROPIC_BASE_URL /v1 normalization

### DIFF
--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -315,6 +315,20 @@ function providerFor(modelId: string): ChatProvider {
 type AnthropicProvider = ReturnType<typeof createAnthropic>;
 type GoogleProvider = ReturnType<typeof createGoogleGenerativeAI>;
 
+// The Vercel AI SDK's Anthropic provider expects ANTHROPIC_BASE_URL to already
+// include the "/v1" path segment (its built-in default is
+// "https://api.anthropic.com/v1"). Some environments — notably the Claude
+// Code/Desktop app — export the bare host "https://api.anthropic.com", which is
+// what the official @anthropic-ai/sdk wants but makes this provider POST to
+// "/messages" and 404. Normalize a "/v1"-less override so it still works; return
+// undefined when unset so the SDK keeps owning its own default.
+function normalizedAnthropicBaseURL(): string | undefined {
+  const raw = env('ANTHROPIC_BASE_URL').trim();
+  if (!raw) return undefined;
+  const base = raw.replace(/\/+$/, '');
+  return base.endsWith('/v1') ? base : `${base}/v1`;
+}
+
 type ChatProviders = {
   anthropic: () => AnthropicProvider;
   google: () => GoogleProvider;
@@ -327,9 +341,13 @@ function createChatProviders(): ChatProviders {
   let openrouter: ReturnType<typeof createOpenRouter> | undefined;
   return {
     anthropic: () => {
-      anthropic ??= createAnthropic({
-        apiKey: requiredEnv('ANTHROPIC_API_KEY'),
-      });
+      if (!anthropic) {
+        const baseURL = normalizedAnthropicBaseURL();
+        anthropic = createAnthropic({
+          apiKey: requiredEnv('ANTHROPIC_API_KEY'),
+          ...(baseURL ? { baseURL } : {}),
+        });
+      }
       return anthropic;
     },
     google: () => {

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -1182,14 +1182,22 @@ export async function handleAiChatRequest(req: Request) {
   };
 
   // Parametric step 0 normally pins `build_parametric_model` via a forced
-  // tool_choice. Models that reject forced tool use (Claude 5 — Fable/Mythos)
-  // fall back to auto tool choice, where the model *might* answer with text
-  // instead of building. Track that fallback so we can detect — and log — a
-  // turn that finished without ever calling the build tool.
+  // tool_choice. Two cases fall back to auto tool choice instead — where the
+  // model *might* answer with text instead of building:
+  //   1. Models that reject forced tool use outright (Claude 5 — Fable/Mythos).
+  //   2. Any turn with extended thinking enabled — Anthropic rejects a forced
+  //      tool_choice while thinking is on ("Thinking may not be enabled when
+  //      tool_choice forces tool use"). Adaptive thinking is on by default for
+  //      Claude 5 / Opus·Sonnet 4.6+, so those land here too.
+  // Both rely on the system prompt to steer the build tool call. Track the
+  // fallback so we can detect — and log — a turn that finished without ever
+  // calling the build tool.
+  const forceBuildToolChoice =
+    supportsForcedToolChoice(actualModelId) && !thinkingEnabled;
   const usingAutoToolChoiceFallback =
     conversation.type === 'parametric' &&
     leafRole === 'user' &&
-    !supportsForcedToolChoice(actualModelId);
+    !forceBuildToolChoice;
 
   const result = streamText({
     model: chatLanguageModel,
@@ -1203,13 +1211,13 @@ export async function handleAiChatRequest(req: Request) {
         leafRole === 'user' &&
         stepNumber === 0
       ) {
-        // Restrict the toolset to the build tool on the first step. Models
-        // that accept a forced tool_choice get it pinned; models that reject
-        // forced tool use (Claude 5 — Fable/Mythos) fall back to auto and rely
-        // on the system prompt to call build_parametric_model.
+        // Restrict the toolset to the build tool on the first step. Turns that
+        // accept a forced tool_choice get it pinned; turns that reject forced
+        // tool use (Claude 5, or any thinking-enabled turn) fall back to auto
+        // and rely on the system prompt to call build_parametric_model.
         return {
           activeTools: ['build_parametric_model' as never],
-          ...(supportsForcedToolChoice(actualModelId)
+          ...(forceBuildToolChoice
             ? {
                 toolChoice: {
                   type: 'tool' as const,


### PR DESCRIPTION
Two independent fixes to the Anthropic chat provider in `src/server/aiChat.ts`, one commit each.

## 1. Parametric generation fails on thinking-enabled models

**Symptom:** With the default **Claude Opus 4.8**, parametric generation errors immediately with:

> Thinking may not be enabled when tool_choice forces tool use.

**Cause:** Anthropic forbids a forced `tool_choice` while extended thinking is enabled. Parametric step 0 pins `build_parametric_model` via a forced `tool_choice` for every model that isn't Claude 5 — but adaptive thinking is on by default for Claude Opus/Sonnet 4.6+ (#190), including the default Opus 4.8 (#194). So the two collide and the turn never builds.

**Fix:** Only force the `tool_choice` when thinking is off. When it's on, fall back to the *auto* tool-choice + system-prompt path that already exists for Claude 5 — no new path, just routes thinking turns through it. The existing `usingAutoToolChoiceFallback` observability covers these turns too.

## 2. `ANTHROPIC_BASE_URL` without `/v1` causes 404s

**Symptom:** Every Anthropic chat call 404s when the dev environment exports `ANTHROPIC_BASE_URL=https://api.anthropic.com` (e.g. running inside the Claude Code/Desktop app). The error object shows the request went to `https://api.anthropic.com/messages` — missing `/v1`.

**Cause:** The Vercel AI SDK's Anthropic provider expects `ANTHROPIC_BASE_URL` to already include `/v1` (its built-in default is `https://api.anthropic.com/v1`). The bare host is what the official `@anthropic-ai/sdk` wants, so environments that set it for that SDK break this one.

**Fix:** Normalize a `/v1`-less override by appending `/v1`; leave the SDK's own default untouched when the variable is unset (so behavior is unchanged for everyone who doesn't set it).

## Testing
- `tsc -p tsconfig.app.json --noEmit`, `eslint`, and `prettier --check` all pass.
- Verified locally: parametric generation with Opus 4.8 now completes; direct Anthropic calls succeed with the normalized base URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic chat failures on thinking-enabled models by avoiding forced tool_choice during parametric generation, and normalizes `ANTHROPIC_BASE_URL` to include `/v1` to prevent 404s with the Vercel AI SDK provider.

- **Bug Fixes**
  - Parametric generation: force `tool_choice` only when thinking is off; thinking turns use auto tool choice with the system prompt (covers Claude Opus/Sonnet 4.6+ and Claude 5).
  - Base URL: append `/v1` to `ANTHROPIC_BASE_URL` when missing; leave it unset to use the SDK default. Supports environments configured for `@anthropic-ai/sdk`.

<sup>Written for commit 3c8de8655e4a7819e32c95266e711e7165d9b5d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

