### PR TITLE
toggle for parameter enums

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -41,7 +41,10 @@ export type ParametricArtifact = {
   code: string;
 };
 
-export type ParameterOption = { value: string | number; label: string };
+// label is optional: an OpenSCAD customizer comment can list bare values
+// (e.g. `[Assembled, Exploded]`) with no `value:label` pair, in which case
+// the parser leaves label undefined and the UI falls back to the value.
+export type ParameterOption = { value: string | number; label?: string };
 
 export type ParameterRange = { min?: number; max?: number; step?: number };
 

--- a/src/components/parameter/ParameterInput.tsx
+++ b/src/components/parameter/ParameterInput.tsx
@@ -67,13 +67,13 @@ export function ParameterInput({
             );
             handleValueCommit(selected ? selected.value : next);
           }}
-          className="flex w-full flex-wrap justify-start gap-0.5 rounded-lg bg-adam-neutral-800 p-0.5"
+          className="flex w-full flex-wrap justify-start gap-0.5 rounded-lg bg-adam-neutral-900 p-0.5"
         >
           {paramState.options.map((option) => (
             <ToggleGroupItem
               key={String(option.value)}
               value={String(option.value)}
-              className="h-5 flex-1 rounded-md px-2 text-xs text-adam-neutral-300 transition-colors data-[state=on]:bg-adam-neutral-700 data-[state=on]:text-adam-text-primary [@media(hover:hover)]:hover:text-adam-text-primary"
+              className="h-5 flex-1 rounded-md px-2 text-xs text-adam-neutral-300 transition-colors hover:bg-transparent hover:text-adam-text-primary data-[state=on]:bg-adam-neutral-700 data-[state=on]:font-medium data-[state=on]:text-adam-text-primary data-[state=on]:shadow-sm"
             >
               {option.label ?? String(option.value)}
             </ToggleGroupItem>

--- a/src/components/parameter/ParameterInput.tsx
+++ b/src/components/parameter/ParameterInput.tsx
@@ -10,6 +10,7 @@ import {
 import { ParameterSlider } from '@/components/parameter/ParameterSlider';
 import { Label } from '@/components/ui/label';
 import { ColorPicker } from '@/components/parameter/ColorPicker';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
 export function ParameterInput({
   param,
@@ -39,6 +40,48 @@ export function ParameterInput({
     handleCommit(paramState, value);
   };
 
+  // Enum parameters (those with a fixed set of options, e.g. a "View Mode"
+  // of Assembled/Exploded) are a constrained choice — a free-text field lets
+  // you type a value the model can't honor. Render a segmented toggle so the
+  // only thing selectable is a valid option. Takes precedence over the
+  // type-specific branches below.
+  if (paramState.options && paramState.options.length > 0) {
+    const currentValue = String(paramState.value);
+    return (
+      <div className="grid w-full grid-cols-[80px_1fr] items-center gap-3">
+        <Label
+          className="overflow-hidden text-ellipsis text-xs font-normal text-adam-neutral-300"
+          htmlFor={paramState.name}
+        >
+          {paramState.displayName}
+        </Label>
+        <ToggleGroup
+          type="single"
+          value={currentValue}
+          onValueChange={(next) => {
+            // Radix emits '' when the active item is clicked again; ignore it
+            // so a selection can never be cleared into an invalid empty state.
+            if (!next) return;
+            const selected = paramState.options?.find(
+              (option) => String(option.value) === next,
+            );
+            handleValueCommit(selected ? selected.value : next);
+          }}
+          className="flex w-full flex-wrap justify-start gap-0.5 rounded-lg bg-adam-neutral-800 p-0.5"
+        >
+          {paramState.options.map((option) => (
+            <ToggleGroupItem
+              key={String(option.value)}
+              value={String(option.value)}
+              className="h-5 flex-1 rounded-md px-2 text-xs text-adam-neutral-300 transition-colors data-[state=on]:bg-adam-neutral-700 data-[state=on]:text-adam-text-primary [@media(hover:hover)]:hover:text-adam-text-primary"
+            >
+              {option.label ?? String(option.value)}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+    );
+  }
   if (!paramState.type || paramState.type === 'number') {
     return (
       <div className="grid w-full grid-cols-[80px_1fr] items-center gap-3">

--- a/src/components/parameter/ParameterInput.tsx
+++ b/src/components/parameter/ParameterInput.tsx
@@ -46,30 +46,34 @@ export function ParameterInput({
   // only thing selectable is a valid option. Takes precedence over the
   // type-specific branches below.
   if (paramState.options && paramState.options.length > 0) {
+    const options = paramState.options;
     const currentValue = String(paramState.value);
     return (
       <div className="grid w-full grid-cols-[80px_1fr] items-center gap-3">
         <Label
+          // ToggleGroup renders a <div>, which htmlFor can't target, so the
+          // group is associated via aria-labelledby pointing at this id.
+          id={`${paramState.name}-label`}
           className="overflow-hidden text-ellipsis text-xs font-normal text-adam-neutral-300"
-          htmlFor={paramState.name}
         >
           {paramState.displayName}
         </Label>
         <ToggleGroup
           type="single"
+          aria-labelledby={`${paramState.name}-label`}
           value={currentValue}
           onValueChange={(next) => {
             // Radix emits '' when the active item is clicked again; ignore it
             // so a selection can never be cleared into an invalid empty state.
             if (!next) return;
-            const selected = paramState.options?.find(
+            const selected = options.find(
               (option) => String(option.value) === next,
             );
             handleValueCommit(selected ? selected.value : next);
           }}
           className="flex w-full flex-wrap justify-start gap-0.5 rounded-lg bg-adam-neutral-900 p-0.5"
         >
-          {paramState.options.map((option) => (
+          {options.map((option) => (
             <ToggleGroupItem
               key={String(option.value)}
               value={String(option.value)}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Render enum parameters as a segmented toggle, replacing the text input, so users can only pick valid options. Adds accessible labeling and supports options without labels.

- **New Features**
  - Render enum options with `ToggleGroup`/`ToggleGroupItem`; commits selected value only and ignores the empty clear when re-clicked.
  - Support options without labels by making `label` optional and falling back to the value in the UI.

- **Bug Fixes**
  - Make selection obvious with a darker track, subtle shadow, and medium weight; keep hover background transparent to remove the white flash.
  - Associate the toggle with its label via `aria-labelledby` for better screen reader support.

<sup>Written for commit 4f5b7a6f970cb9dc709d9354ecdc5a3c122e6710. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

