### PR TITLE
fix(auth): send Supabase auth emails back to the cadam frontend

### DIFF
--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -8,6 +8,16 @@ import { AuthContext, type BillingStatus, getLevel } from './AuthContext';
 import { apiJson } from '@/services/api';
 import { z } from 'zod';
 
+// Build an absolute, same-frontend redirect URL for Supabase auth emails / OAuth.
+// Uses the current origin + Vite base path so links return to whichever frontend
+// initiated them (adam.new/cadam, app.adamcad.com, Vercel previews) rather than
+// falling back to the project's Site URL (which points at the workspace app).
+function getAppRedirectUrl(path: string) {
+  const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+  return `${window.location.origin}${basePath}${path}`;
+}
+
 const LOCAL_BILLING_STATUS: BillingStatus = {
   user: { hasTrialed: false },
   subscription: {
@@ -227,7 +237,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const { error: signUpError } = await supabase.auth.signUp({
       email,
       password,
-      options: { data: { full_name: name } },
+      options: {
+        data: { full_name: name },
+        emailRedirectTo: getAppRedirectUrl('/'),
+      },
     });
     if (signUpError) throw signUpError;
   };
@@ -240,7 +253,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signInWithMagicLink = async (email: string) => {
     const { error } = await supabase.auth.signInWithOtp({
       email,
-      options: { shouldCreateUser: true },
+      options: {
+        shouldCreateUser: true,
+        emailRedirectTo: getAppRedirectUrl('/'),
+      },
     });
     if (error) throw error;
   };
@@ -255,7 +271,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   const resetPassword = async (email: string) => {
-    const { error } = await supabase.auth.resetPasswordForEmail(email);
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: getAppRedirectUrl('/update-password'),
+    });
     if (error) throw error;
   };
 


### PR DESCRIPTION
## Problem

Fixing "Google SSO on `adam.new/cadam` dumps you on the workspace app" surfaced a shared root cause in Supabase project `sgprnbvihmydyrzvkcir` (served at `api.adam.new`, the project cadam actually authenticates against): when a flow sends **no** explicit redirect, Supabase falls back to the project **Site URL**, which points at the workspace app.

The SSO case was fixed via the dashboard allowlist. The **email** flows have the same problem in code — `resetPassword`, `signInWithMagicLink`, and `signUp` send no redirect, so the links in those emails land on the workspace app instead of cadam.

## Fix

Pass an explicit, per-frontend redirect on each call, built from `window.location.origin + import.meta.env.BASE_URL` (same pattern the Google OAuth buttons already use), so emails return to whichever frontend initiated them (`adam.new/cadam`, `app.adamcad.com`, Vercel previews):

- `resetPasswordForEmail` → `…/update-password`
- `signUp` (`emailRedirectTo`) → `…/`
- `signInWithOtp` (`emailRedirectTo`) → `…/`

All resolve under redirect prefixes already allow-listed in the Supabase project, so **no dashboard change is required**.

## Test

- [ ] Request a password reset → email link opens `…/cadam/update-password`
- [ ] Magic-link sign-in → link opens `…/cadam/`
- [ ] New email signup → confirmation link opens `…/cadam/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send all auth emails from `Supabase` back to the cadam frontend that started the flow, instead of the workspace app. Builds per-frontend redirects from the current origin and `import.meta.env.BASE_URL`.

- **Bug Fixes**
  - Added `getAppRedirectUrl` using `window.location.origin` + `import.meta.env.BASE_URL`.
  - `signUp`: set `emailRedirectTo` to `/`.
  - `signInWithOtp`: set `emailRedirectTo` to `/`.
  - `resetPasswordForEmail`: set `redirectTo` to `/update-password`.
  - No dashboard changes needed; existing allowlisted redirect prefixes cover these.

<sup>Written for commit 0645f9e588cf031f5b04dc81648df13c2caeef7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

