### PR TITLE
fix(chat): persist assistant row before billing to close save race

### DIFF
--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -1368,30 +1368,6 @@ export async function handleAiChatRequest(req: Request) {
               billingTokens,
             };
 
-            try {
-              // Drains the user's remaining balance to zero if the
-              // request cost more than they had. The billing service
-              // accepts the partial deduction, writes an audit row as
-              // `<operation>_partial`, and the pre-flight gate above
-              // will block the next request. Not an error path —
-              // intentional terminal state.
-              await billing.consume(user.email!, {
-                tokens: billingTokens,
-                operation:
-                  conversation.type === 'creative' ? 'chat' : 'parametric',
-                referenceId: responseMessage.id,
-              });
-            } catch (error) {
-              logError(error, {
-                functionName: 'ai-chat',
-                statusCode:
-                  error instanceof BillingClientError ? error.status : 502,
-                userId: user.id,
-                conversationId: conversation.id,
-                additionalContext: { operation: 'billing_consume' },
-              });
-            }
-
             const finalizedParts =
               conversation.type === 'parametric'
                 ? dropTextFromParametricBuildMessage(
@@ -1411,18 +1387,29 @@ export async function handleAiChatRequest(req: Request) {
             // `input-available` (pending).
             const hasPendingToolCall = hasPendingClientToolCall(finalizedParts);
 
+            // Persist the row BEFORE billing. `build_parametric_model` is
+            // resolved client-side: the browser compiles, then UPDATEs this
+            // row to attach the tool output (`persistAssistantParts`). That
+            // UPDATE matches nothing until this INSERT lands, so the browser
+            // retries on a ~1.7s window and otherwise surfaces "Couldn't save
+            // this step". `billing.consume` is a non-fatal external round-trip
+            // (caught + logged below) and the persist doesn't depend on it —
+            // running it after keeps its latency out of the browser's race
+            // window. The row must exist as soon as the stream closes.
+            //
             // What to do with this row — see `decidePersistAction`:
             //   insert → new assistant row.
             //   update → continuation with everything resolved / pure text.
             //   skip   → continuation still ending in a pending CLIENT tool.
             //            The browser persists the `output-available` version
             //            itself (`onToolOutput`); a server write here — delayed
-            //            behind `result.totalUsage` + `billing.consume` — would
-            //            land last and clobber it back to `input-available`,
-            //            leaving a dangling tool call that 500s the next send.
-            //            Mid-loop builds dodge the race because the client's
-            //            compile takes seconds; the terminal `answer_user` is
-            //            instant, so the server reliably wins. Defer to client.
+            //            behind `result.totalUsage` and the network write —
+            //            would land last and clobber it back to
+            //            `input-available`, leaving a dangling tool call that
+            //            500s the next send. Mid-loop builds dodge the race
+            //            because the client's compile takes seconds; the
+            //            terminal `answer_user` is instant, so the server
+            //            reliably wins. Defer to client.
             //
             // Insert places a NEW assistant under whatever the leaf was: for a
             // fresh user turn that's the user message; for a retry (client
@@ -1471,6 +1458,31 @@ export async function handleAiChatRequest(req: Request) {
                 userId: user.id,
                 conversationId: conversation.id,
                 additionalContext: { operation: 'persist_response_message' },
+              });
+            }
+
+            try {
+              // Drains the user's remaining balance to zero if the
+              // request cost more than they had. The billing service
+              // accepts the partial deduction, writes an audit row as
+              // `<operation>_partial`, and the pre-flight gate above
+              // will block the next request. Not an error path —
+              // intentional terminal state. Runs after the persist above so
+              // its latency never delays the row the client is waiting on.
+              await billing.consume(user.email!, {
+                tokens: billingTokens,
+                operation:
+                  conversation.type === 'creative' ? 'chat' : 'parametric',
+                referenceId: responseMessage.id,
+              });
+            } catch (error) {
+              logError(error, {
+                functionName: 'ai-chat',
+                statusCode:
+                  error instanceof BillingClientError ? error.status : 502,
+                userId: user.id,
+                conversationId: conversation.id,
+                additionalContext: { operation: 'billing_consume' },
               });
             }
 

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -1403,13 +1403,12 @@ export async function handleAiChatRequest(req: Request) {
             //   skip   → continuation still ending in a pending CLIENT tool.
             //            The browser persists the `output-available` version
             //            itself (`onToolOutput`); a server write here — delayed
-            //            behind `result.totalUsage` and the network write —
-            //            would land last and clobber it back to
-            //            `input-available`, leaving a dangling tool call that
-            //            500s the next send. Mid-loop builds dodge the race
-            //            because the client's compile takes seconds; the
-            //            terminal `answer_user` is instant, so the server
-            //            reliably wins. Defer to client.
+            //            behind `result.totalUsage` — would land last and
+            //            clobber it back to `input-available`, leaving a
+            //            dangling tool call that 500s the next send. Mid-loop
+            //            builds dodge the race because the client's compile
+            //            takes seconds; the terminal `answer_user` is instant,
+            //            so the server reliably wins. Defer to client.
             //
             // Insert places a NEW assistant under whatever the leaf was: for a
             // fresh user turn that's the user message; for a retry (client


### PR DESCRIPTION
## Problem

Users intermittently hit a **"Couldn't save this step — The model is shown but the build wasn't saved, so Adam paused. Please retry."** toast after a parametric generation.

Confirmed from a production console log:
```
Failed to persist tool output to DB: persistAssistantParts matched no row
after 6 attempts (messageId=6e3204df-…). The assistant message was never persisted.
```

## Root cause

A parametric build splits one assistant message row across **two writers**:

1. The **server** INSERTs the row in `onFinish` (`aiChat.ts`).
2. The **browser** compiles the OpenSCAD locally, then UPDATEs that row with the tool output (`persistAssistantParts` → `handleToolOutput`).

The client UPDATE matches nothing until the server INSERT lands, so it retries on a ~1.7 s window (`messageService.ts`) and otherwise surfaces the toast and pauses the loop (`ChatSession.tsx`).

The INSERT sat **behind two awaits** in `onFinish`:

```
await result.totalUsage
await billing.consume(...)   ← external billing round-trip
…insert the assistant row    ← only after billing returns
```

`billing.consume` is an external HTTP call. When it's slow and the client's compile is fast, the INSERT lands after the client's retry window expires → the toast.

## Fix

`billing.consume` is already non-fatal (caught + logged) and the persist doesn't depend on it. So `onFinish` now **persists the row first, then bills** — keeping billing latency out of the window the browser is waiting on. Pure reorder of two already-independent blocks; no behavior change to billing.

## Notes

This removes the billing round-trip from the race window, which addresses the slow-insert case the log points to. If the toast still recurs after this lands, that's the signal it's the rarer "server never wrote the row" case (an `onFinish` insert error / `decidePersistAction` mis-step), which would be a separate server-side fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist assistant message row before billing to eliminate a write-order race in parametric builds. This fixes the intermittent "Couldn't save this step" toast and prevents the chat loop from pausing.

- **Bug Fixes**
  - Reordered `onFinish` to insert the assistant row before calling billing; clarified the skip-path comment to name `result.totalUsage` as the remaining await.
  - Removes billing latency from the client’s ~1.7s update retry window, so `persistAssistantParts` finds the row.
  - Billing behavior is unchanged and remains non-fatal; errors are still logged.

<sup>Written for commit f170bd4e651ec41c6bea4e56407c1b20ae4aaba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

