### PR TITLE
feat(prompt): add free-plan "Start free trial" pill above greeting

### DIFF
--- a/src/components/FreePlanTrialPill.tsx
+++ b/src/components/FreePlanTrialPill.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { getLevel, useAuth } from '@/contexts/AuthContext';
+import { TrialDialog } from '@/components/auth/TrialDialog';
+import { cn } from '@/lib/utils';
+
+/**
+ * "Free plan | Start free trial" pill shown above the greeting for signed-in
+ * free-plan users who haven't used their trial yet — the CADAM port of the
+ * workspace pill. It stays hidden while billing is loading (`isLoading`) so it
+ * never flashes on a paying user, and once the trial has been used the pill
+ * disappears entirely. The CTA opens the existing 7-day trial flow.
+ *
+ * `reveal` is the shared fade gate: the page holds the pill back until the
+ * greeting chrome is ready so the pill fades in with the rest of the view
+ * instead of popping in the moment billing alone resolves.
+ */
+export function FreePlanTrialPill({ reveal }: { reveal: boolean }) {
+  const { user, billing, isLoading } = useAuth();
+  const [trialOpen, setTrialOpen] = useState(false);
+
+  const level = getLevel(billing);
+  const hasTrialed = billing?.user.hasTrialed ?? false;
+
+  // Only signed-in free-plan users who can still start a trial, and only once
+  // billing has resolved so the pill never flashes on a paid user.
+  if (!user || isLoading || level !== 'free' || hasTrialed) return null;
+
+  return (
+    <>
+      <div
+        className={cn(
+          'mb-6 inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04)]',
+          'motion-safe:transition-opacity motion-safe:duration-1000 motion-safe:ease-out',
+          reveal ? 'opacity-100' : 'opacity-0',
+        )}
+      >
+        <span className="text-adam-text-secondary">Free plan</span>
+        <span className="h-4 w-px bg-white/10" />
+        <button
+          type="button"
+          onClick={() => setTrialOpen(true)}
+          className="font-medium text-adam-blue transition-colors hover:text-adam-blue/80"
+        >
+          Start free trial
+        </button>
+      </div>
+      <TrialDialog open={trialOpen} onOpenChange={setTrialOpen} />
+    </>
+  );
+}

--- a/src/components/FreePlanTrialPill.tsx
+++ b/src/components/FreePlanTrialPill.tsx
@@ -1,20 +1,23 @@
 import { useState } from 'react';
 import { getLevel, useAuth } from '@/contexts/AuthContext';
 import { TrialDialog } from '@/components/auth/TrialDialog';
-import { cn } from '@/lib/utils';
 
 /**
  * "Free plan | Start free trial" pill shown above the greeting for signed-in
  * free-plan users who haven't used their trial yet — the CADAM port of the
- * workspace pill. It stays hidden while billing is loading (`isLoading`) so it
- * never flashes on a paying user, and once the trial has been used the pill
- * disappears entirely. The CTA opens the existing 7-day trial flow.
+ * workspace pill. It renders nothing until billing has resolved (so it never
+ * flashes on a paying user) and disappears once the trial has been used.
  *
- * `reveal` is the shared fade gate: the page holds the pill back until the
- * greeting chrome is ready so the pill fades in with the rest of the view
- * instead of popping in the moment billing alone resolves.
+ * The fade is mount-triggered (`animate-in fade-in`) rather than driven by a
+ * parent `reveal` gate: because the pill only mounts after the network-backed
+ * billing query resolves, a parent opacity flag would already be `true` by
+ * then and the pill would pop in. Animating on mount fades it in whenever it
+ * actually appears.
+ *
+ * `TrialDialog` is mounted lazily on click so its `useSubscriptionProducts`
+ * query doesn't fire for every free-plan visitor who never opens it.
  */
-export function FreePlanTrialPill({ reveal }: { reveal: boolean }) {
+export function FreePlanTrialPill() {
   const { user, billing, isLoading } = useAuth();
   const [trialOpen, setTrialOpen] = useState(false);
 
@@ -27,15 +30,9 @@ export function FreePlanTrialPill({ reveal }: { reveal: boolean }) {
 
   return (
     <>
-      <div
-        className={cn(
-          'mb-6 inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04)]',
-          'motion-safe:transition-opacity motion-safe:duration-1000 motion-safe:ease-out',
-          reveal ? 'opacity-100' : 'opacity-0',
-        )}
-      >
+      <div className="duration-[350ms] mb-6 inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04)] ease-out animate-in fade-in slide-in-from-bottom-1">
         <span className="text-adam-text-secondary">Free plan</span>
-        <span className="h-4 w-px bg-white/10" />
+        <span className="h-4 w-px bg-white/10" aria-hidden="true" />
         <button
           type="button"
           onClick={() => setTrialOpen(true)}
@@ -44,7 +41,9 @@ export function FreePlanTrialPill({ reveal }: { reveal: boolean }) {
           Start free trial
         </button>
       </div>
-      <TrialDialog open={trialOpen} onOpenChange={setTrialOpen} />
+      {trialOpen && (
+        <TrialDialog open={trialOpen} onOpenChange={setTrialOpen} />
+      )}
     </>
   );
 }

--- a/src/components/FreePlanTrialPill.tsx
+++ b/src/components/FreePlanTrialPill.tsx
@@ -14,12 +14,15 @@ import { TrialDialog } from '@/components/auth/TrialDialog';
  * then and the pill would pop in. Animating on mount fades it in whenever it
  * actually appears.
  *
- * `TrialDialog` is mounted lazily on click so its `useSubscriptionProducts`
- * query doesn't fire for every free-plan visitor who never opens it.
+ * `TrialDialog` is mounted on first open (not up front) so its
+ * `useSubscriptionProducts` query doesn't fire for every free-plan visitor who
+ * never opens it — and then stays mounted so Radix can play its close
+ * animation, which a `{open && ...}` unmount would skip.
  */
 export function FreePlanTrialPill() {
   const { user, billing, isLoading } = useAuth();
   const [trialOpen, setTrialOpen] = useState(false);
+  const [dialogMounted, setDialogMounted] = useState(false);
 
   const level = getLevel(billing);
   const hasTrialed = billing?.user.hasTrialed ?? false;
@@ -30,18 +33,21 @@ export function FreePlanTrialPill() {
 
   return (
     <>
-      <div className="duration-[350ms] mb-6 inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04)] ease-out animate-in fade-in slide-in-from-bottom-1">
+      <div className="duration-[350ms] inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm shadow-[0_1px_3px_rgba(0,0,0,0.04)] ease-out animate-in fade-in slide-in-from-bottom-1">
         <span className="text-adam-text-secondary">Free plan</span>
         <span className="h-4 w-px bg-white/10" aria-hidden="true" />
         <button
           type="button"
-          onClick={() => setTrialOpen(true)}
+          onClick={() => {
+            setDialogMounted(true);
+            setTrialOpen(true);
+          }}
           className="font-medium text-adam-blue transition-colors hover:text-adam-blue/80"
         >
           Start free trial
         </button>
       </div>
-      {trialOpen && (
+      {dialogMounted && (
         <TrialDialog open={trialOpen} onOpenChange={setTrialOpen} />
       )}
     </>

--- a/src/components/FreePlanTrialPill.tsx
+++ b/src/components/FreePlanTrialPill.tsx
@@ -28,8 +28,13 @@ export function FreePlanTrialPill() {
   const hasTrialed = billing?.user.hasTrialed ?? false;
 
   // Only signed-in free-plan users who can still start a trial, and only once
-  // billing has resolved so the pill never flashes on a paid user.
-  if (!user || isLoading || level !== 'free' || hasTrialed) return null;
+  // billing has resolved. The `!billing` guard matters because the billing
+  // query throws on error — leaving `isLoading` false but `billing` null — and
+  // `getLevel(null)` reads as 'free'. Without it, a paid user whose billing
+  // fetch transiently fails would be shown the trial pill.
+  if (!user || isLoading || !billing || level !== 'free' || hasTrialed) {
+    return null;
+  }
 
   return (
     <>

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -270,7 +270,7 @@ export function PromptView() {
 
         <main className="flex h-full w-full flex-col items-center justify-center px-4 md:px-8">
           <div className="mx-auto flex max-w-3xl flex-col items-center justify-center">
-            <FreePlanTrialPill reveal={isLoaded} />
+            <FreePlanTrialPill />
             <h1
               className={cn(
                 'mb-8 text-center text-2xl font-medium text-adam-text-primary md:text-3xl lg:text-4xl',

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -270,17 +270,24 @@ export function PromptView() {
 
         <main className="flex h-full w-full flex-col items-center justify-center px-4 md:px-8">
           <div className="mx-auto flex max-w-3xl flex-col items-center justify-center">
-            <FreePlanTrialPill />
-            <h1
-              className={cn(
-                'mb-8 text-center text-2xl font-medium text-adam-text-primary md:text-3xl lg:text-4xl',
-                'motion-safe:transition-opacity motion-safe:duration-1000 motion-safe:ease-out',
-                isLoaded ? 'opacity-100' : 'opacity-0',
-              )}
-            >
-              {getTimeBasedGreeting}
-              {firstName ? `, ${firstName}` : ''}!
-            </h1>
+            {/* The pill floats above the greeting (absolute, out of flow) so
+                it mounting after billing resolves — or never showing for paid
+                users — never reflows the centered greeting. */}
+            <div className="relative flex flex-col items-center">
+              <div className="absolute bottom-full left-1/2 mb-6 w-max -translate-x-1/2">
+                <FreePlanTrialPill />
+              </div>
+              <h1
+                className={cn(
+                  'mb-8 text-center text-2xl font-medium text-adam-text-primary md:text-3xl lg:text-4xl',
+                  'motion-safe:transition-opacity motion-safe:duration-1000 motion-safe:ease-out',
+                  isLoaded ? 'opacity-100' : 'opacity-0',
+                )}
+              >
+                {getTimeBasedGreeting}
+                {firstName ? `, ${firstName}` : ''}!
+              </h1>
+            </div>
           </div>
           <div className="flex w-full flex-col items-center">
             <div className="w-full max-w-3xl space-y-4 pb-12">

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -11,6 +11,7 @@ import { Model } from '@shared/types';
 import { MessageItem } from '../types/misc.ts';
 import { LimitReachedMessage } from '@/components/LimitReachedMessage';
 import { LowPromptsWarningMessage } from '@/components/LowPromptsWarningMessage';
+import { FreePlanTrialPill } from '@/components/FreePlanTrialPill';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { cn } from '@/lib/utils';
 import { SelectedItemsContext } from '@/contexts/SelectedItemsContext';
@@ -269,6 +270,7 @@ export function PromptView() {
 
         <main className="flex h-full w-full flex-col items-center justify-center px-4 md:px-8">
           <div className="mx-auto flex max-w-3xl flex-col items-center justify-center">
+            <FreePlanTrialPill reveal={isLoaded} />
             <h1
               className={cn(
                 'mb-8 text-center text-2xl font-medium text-adam-text-primary md:text-3xl lg:text-4xl',


### PR DESCRIPTION
Port the workspace free-trial pill to CADAM. Shows a "Free plan | Start free trial" pill above the prompt-view greeting for signed-in free-plan users who haven't trialed yet, opening the existing TrialDialog. Hidden while billing loads (so it never flashes on a paid user) and once the trial has been used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Free plan | Start free trial” pill above the Prompt view greeting for signed-in free users who haven’t used their trial. It appears only after billing resolves, opens `TrialDialog` on click, and hides once a trial is used.

- **Bug Fixes**
  - Use mount-triggered fade-in and position the pill absolutely above the greeting to avoid pop-in and layout shift.
  - Lazy-mount `TrialDialog`, keep it mounted after first open for close animations, and mark the pill’s divider `aria-hidden` for performance and a11y.
  - Don’t render the pill when billing is unknown/null to avoid showing it to paid users on transient billing errors.

<sup>Written for commit 82f6b019682d84ef043350167edb61f0fda6ae2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

