### PR TITLE
fix(chat): show inline out-of-tokens message with trial prompt in chat

### DIFF
--- a/src/components/LimitReachedMessage.tsx
+++ b/src/components/LimitReachedMessage.tsx
@@ -76,7 +76,7 @@ function LimitReachedSpan({ onTrialClick }: { onTrialClick?: () => void }) {
           className="cursor-pointer text-adam-blue hover:underline"
           onClick={onTrialClick}
         >
-          Start a trial
+          Start a free trial
         </span>{' '}
         to experience all Pro features for 7 days, completely free.
       </span>

--- a/src/components/UpgradeModal.tsx
+++ b/src/components/UpgradeModal.tsx
@@ -58,6 +58,11 @@ function creditsBadge(level: PlanLevel, product: BillingProduct | undefined) {
 export function UpgradeModal({ open, onOpenChange }: UpgradeModalProps) {
   const { billing } = useAuth();
   const currentLevel = getLevel(billing);
+  // The 7-day free trial is a Pro-only offer, available once per user. Only
+  // free-tier users who haven't trialed yet are eligible — for everyone else
+  // the Pro button stays a normal "Get Pro".
+  const canTrial =
+    currentLevel === 'free' && !(billing?.user.hasTrialed ?? false);
   const { data: products = [] } = useSubscriptionProducts();
   const { mutate: subscribe, isPending: isSubscribing } =
     useSubscriptionService();
@@ -71,8 +76,15 @@ export function UpgradeModal({ open, onOpenChange }: UpgradeModalProps) {
     if (level === currentLevel) return;
     setActiveLevel(level);
     if (currentLevel === 'free' && priceId) {
+      // Pro is the only trial-eligible tier; match the button's
+      // "Start a free trial" label by actually requesting the 7-day trial.
+      const isTrial = level === 'pro' && canTrial;
       subscribe(
-        { priceId, source: 'upgrade_modal' },
+        {
+          priceId,
+          source: isTrial ? 'upgrade_modal_trial' : 'upgrade_modal',
+          ...(isTrial ? { trialPeriodDays: 7 } : {}),
+        },
         { onSettled: () => setActiveLevel(null) },
       );
     } else if (currentLevel !== 'free') {
@@ -171,6 +183,8 @@ export function UpgradeModal({ open, onOpenChange }: UpgradeModalProps) {
                       'Current plan'
                     ) : level === 'free' ? (
                       'Downgrade'
+                    ) : level === 'pro' && canTrial ? (
+                      'Start a free trial'
                     ) : (
                       `Get ${displayName}`
                     )}

--- a/src/components/chat/ChatSession.tsx
+++ b/src/components/chat/ChatSession.tsx
@@ -957,27 +957,27 @@ export function ChatSession({
             `src/server/aiChat.ts`). We hide them while a stream is in
             flight; the freshly-arrived pills replace the stale ones
             when streaming finishes. */}
-        {/* Out of tokens: surface the upgrade / "Start a trial" prompt
+        {/* Out of tokens: surface the upgrade / "Start a free trial" prompt
             inline above the (disabled) input. The transient toast from
             `billingAwareFetch` covers the instant the send fails; this
-            persistent message keeps the path to keep chatting visible. */}
-        {isDisabled ? (
-          <div className="mx-auto max-w-3xl">
-            <LimitReachedMessage />
-          </div>
-        ) : (
-          !isLoading && (
+            persistent message keeps the path to keep chatting visible. Gated
+            on `!isLoading` like the pills so it never overlaps a stream that's
+            still terminating after a 402. */}
+        {!isLoading &&
+          (isDisabled ? (
+            <div className="mx-auto max-w-3xl">
+              <LimitReachedMessage />
+            </div>
+          ) : (
             <div className="mx-auto max-w-3xl pt-1">
               <SuggestionPills
                 suggestions={conversation.settings?.suggestions ?? []}
                 onSelect={(suggestion) =>
                   void handleSend([{ type: 'text', text: suggestion }])
                 }
-                disabled={isDisabled}
               />
             </div>
-          )
-        )}
+          ))}
         <TextAreaChat
           type={conversation.type}
           onSubmit={(parts) => void handleSend(parts)}

--- a/src/components/chat/ChatSession.tsx
+++ b/src/components/chat/ChatSession.tsx
@@ -1,5 +1,6 @@
 import { MessageBubble } from '@/components/chat/MessageBubble';
 import { SuggestionPills } from '@/components/chat/SuggestionPills';
+import { LimitReachedMessage } from '@/components/LimitReachedMessage';
 import TextAreaChat from '@/components/TextAreaChat';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useAuth } from '@/contexts/AuthContext';
@@ -956,16 +957,26 @@ export function ChatSession({
             `src/server/aiChat.ts`). We hide them while a stream is in
             flight; the freshly-arrived pills replace the stale ones
             when streaming finishes. */}
-        {!isLoading && (
-          <div className="mx-auto max-w-3xl pt-1">
-            <SuggestionPills
-              suggestions={conversation.settings?.suggestions ?? []}
-              onSelect={(suggestion) =>
-                void handleSend([{ type: 'text', text: suggestion }])
-              }
-              disabled={isDisabled}
-            />
+        {/* Out of tokens: surface the upgrade / "Start a trial" prompt
+            inline above the (disabled) input. The transient toast from
+            `billingAwareFetch` covers the instant the send fails; this
+            persistent message keeps the path to keep chatting visible. */}
+        {isDisabled ? (
+          <div className="mx-auto max-w-3xl">
+            <LimitReachedMessage />
           </div>
+        ) : (
+          !isLoading && (
+            <div className="mx-auto max-w-3xl pt-1">
+              <SuggestionPills
+                suggestions={conversation.settings?.suggestions ?? []}
+                onSelect={(suggestion) =>
+                  void handleSend([{ type: 'text', text: suggestion }])
+                }
+                disabled={isDisabled}
+              />
+            </div>
+          )
         )}
         <TextAreaChat
           type={conversation.type}


### PR DESCRIPTION
A 402 during an active chat only surfaced a transient toast; the "Start a trial" / upgrade prompt lived solely on PromptView. Render the existing <LimitReachedMessage /> inline above the (disabled) input when the token budget is exhausted, so the path to keep chatting stays visible and survives navigation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show an inline “out of tokens” message with a Start a free trial/upgrade prompt directly in chat when the token budget is exhausted, rendering `LimitReachedMessage` above the disabled input so the path to keep chatting stays visible. Add a true “Start a free trial” flow for the Pro plan in the upgrade modal for eligible free users, requesting a 7‑day trial and updating the CTA.

- **Bug Fixes**
  - Gate the inline message on !isLoading to avoid overlap with an in‑flight stream after a 402.
  - Align copy to “Start a free trial” in `LimitReachedMessage` and `UpgradeModal`.
  - Show `SuggestionPills` only when input is enabled; drop the unused `disabled` prop.

<sup>Written for commit 9d5cd77e35617c3f9711790396233512bb9542f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

