### PR TITLE
fix(trial): dynamic Pro credits + more pill spacing

### DIFF
--- a/src/components/auth/TrialDialog.tsx
+++ b/src/components/auth/TrialDialog.tsx
@@ -84,7 +84,7 @@ export function TrialDialog({
           <li className="flex items-center gap-2">
             <Check className="h-4 w-4 text-adam-neutral-100" />
             <span className="text-adam-neutral-100">
-              {proCredits
+              {proCredits !== undefined
                 ? `${proCredits.toLocaleString()} credits per month`
                 : 'Monthly Pro credits'}
             </span>

--- a/src/components/auth/TrialDialog.tsx
+++ b/src/components/auth/TrialDialog.tsx
@@ -36,6 +36,10 @@ export function TrialDialog({
       p.active,
   );
 
+  // Derive the credit allowance from the live Pro product rather than
+  // hardcoding it, so the dialog can't drift from the actual plan.
+  const proCredits = proMonthly?.tokenAmount;
+
   const handleSubscribe = () => {
     if (!user) {
       navigate({ to: '/signin' });
@@ -80,7 +84,9 @@ export function TrialDialog({
           <li className="flex items-center gap-2">
             <Check className="h-4 w-4 text-adam-neutral-100" />
             <span className="text-adam-neutral-100">
-              5,000 tokens per month
+              {proCredits
+                ? `${proCredits.toLocaleString()} credits per month`
+                : 'Monthly Pro credits'}
             </span>
           </li>
           <li className="flex items-center gap-2">

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -274,7 +274,7 @@ export function PromptView() {
                 it mounting after billing resolves — or never showing for paid
                 users — never reflows the centered greeting. */}
             <div className="relative flex flex-col items-center">
-              <div className="absolute bottom-full left-1/2 mb-6 w-max -translate-x-1/2">
+              <div className="absolute bottom-full left-1/2 mb-16 w-max -translate-x-1/2">
                 <FreePlanTrialPill />
               </div>
               <h1


### PR DESCRIPTION
Follow-up fixes to the free-trial pill (the original pill PR is already merged to master).

## What & why

**1. Trial dialog showed hardcoded "5,000 tokens per month"**
`TrialDialog` hardcoded the credit figure, so it could drift from the actual Pro plan. It now derives the number from the live Pro product (`proMonthly.tokenAmount`) and uses the app's "credits" wording (matching `CreditsButton` / `UpgradeModal`), falling back to "Monthly Pro credits" until products load. Mirrors how the workspace upgrade dialog renders credits dynamically.

**2. Not enough padding between the pill and the greeting**
Bumped the pill's gap above the `h1` from `mb-6` (24px) to `mb-16` (64px) to match the workspace repo (`apps/web/features/chat/chat-page.tsx`).

## Verification
Rendered both through CADAM's real Vite + Tailwind build:
- Dialog renders "<n> credits per month" from the product's `tokenAmount` (showed "2,000 credits per month" against mock product data).
- Pill-to-greeting gap measured at 64px.
- `npm run typecheck` and `eslint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)