### PR TITLE
docs(readme): add Try it live + video demo sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@
 
 ---
 
+## 🌐 Try it live
+
+**👉 [adam.new/cadam](https://adam.new/cadam)**. Generate a CAD model in seconds, right in your browser. No install required.
+
 ## ✨ Features
 
 - 🤖 **AI-Powered Generation** - Transform natural language and images into 3D models
@@ -46,17 +50,11 @@
 | **Smart Updates**          | Efficient parameter changes without AI re-generation |
 | **Custom Fonts**           | Built-in Geist font support for text in models       |
 
-## 📸 Demo
+## 🎬 Demo
 
-<!-- Add demo GIFs or screenshots here -->
-<!-- Example format:
-![CADAM Demo](./demo/demo.gif)
-
-### Example: Creating a parametric gear
-![Gear Example](./demo/gear-example.png)
--->
-
-> 🎬 **Try it live:** https://adam.new/cadam
+<div align="center">
+  <video src="https://github.com/user-attachments/assets/f6b1905e-1603-4ad0-b196-12c1d7bf87b2" width="100%" controls></video>
+</div>
 
 ## 📺 Screenshots
 

--- a/README.md
+++ b/README.md
@@ -60,16 +60,6 @@
 
 <img src="./public/screenshot-2.jpeg" alt="CADAM Screenshot 2" />
 
-<details>
-  <summary>More screenshots</summary>
-
-  <br/>
-  <img src="./public/screenshot-1.jpeg" alt="CADAM Screenshot 1" />
-  <br/>
-  <img src="./public/screenshot-3.jpeg" alt="CADAM Screenshot 3" />
-
-</details>
-
 ## 🚀 Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@
 ## 🎬 Demo
 
 <div align="center">
-  <video src="https://github.com/user-attachments/assets/f6b1905e-1603-4ad0-b196-12c1d7bf87b2" width="100%" controls></video>
+  <video src="https://github.com/user-attachments/assets/f6b1905e-1603-4ad0-b196-12c1d7bf87b2" width="100%" controls>
+    <a href="https://github.com/user-attachments/assets/f6b1905e-1603-4ad0-b196-12c1d7bf87b2">Watch the demo video</a>
+  </video>
 </div>
 
 ## 📺 Screenshots


### PR DESCRIPTION
## What

- Add a **🌐 Try it live** section above Features with the [adam.new/cadam](https://adam.new/cadam) link (moved out of the old Demo placeholder).
- Replace the old screenshot-placeholder **Demo** section with a **🎬 Demo** section that embeds an inline MP4 video player.

## Notes

The demo video is hosted via a GitHub user-attachments URL and renders as an inline player on github.com. It is not committed to the repo, so it does not bloat clones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update README to add a Try it live section linking to https://adam.new/cadam and replace the Demo placeholder with an inline MP4 video, with a fallback text link if playback fails. Remove the “More screenshots” collapsible; the video is hosted via GitHub attachments so it doesn’t add large assets to the repo.

<sup>Written for commit bcc9bff66bcbd9c4bcedf2a3bbefd30fcc44a529. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

