### PR TITLE
feat(home): make the whole banner clickable, not just the CTA

### DIFF
--- a/src/components/NewProductBanner.tsx
+++ b/src/components/NewProductBanner.tsx
@@ -167,7 +167,7 @@ export function NewProductBanner() {
             with Onshape and Fusion a tad smaller and tucked behind it on either
             side. The overlap reads as "Adam plugs into both your CAD tools."
             On hover the two tools ease outward to reveal themselves. */}
-        <div className="flex shrink-0 items-center -space-x-3">
+        <div className="pointer-events-none flex shrink-0 items-center -space-x-3">
           <div className="grid size-10 translate-y-1 -rotate-6 place-items-center rounded-lg border border-white/10 bg-adam-neutral-950 transition-transform duration-300 ease-out group-hover:-translate-x-1.5 group-hover:-rotate-[9deg]">
             <img
               alt="Onshape"
@@ -206,7 +206,14 @@ export function NewProductBanner() {
           // rule, so on hover only the background darkens (to neutral-200), the
           // text stays black. Explicit white focus ring because the app sets no
           // `.dark` class — the default `ring-ring` would be near-black/invisible.
-          className="shrink-0 gap-1.5 bg-white font-semibold text-black transition-colors hover:bg-neutral-200 focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-adam-bg-dark sm:mr-3"
+          //
+          // after:absolute after:inset-0 stretches this link's hit area over the
+          // whole card (its nearest positioned ancestor), so a click anywhere on
+          // the banner opens adam.new and fires the same event — maximizing the
+          // clickable surface. The dismiss button (z-10) sits above this overlay,
+          // and the logo cluster opts out via pointer-events-none, so both still
+          // get their own clicks.
+          className="shrink-0 gap-1.5 bg-white font-semibold text-black transition-colors after:absolute after:inset-0 after:content-[''] hover:bg-neutral-200 focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-adam-bg-dark sm:mr-3"
           size="sm"
           variant="light"
         >

--- a/src/views/PrivacyPolicyView.tsx
+++ b/src/views/PrivacyPolicyView.tsx
@@ -7,9 +7,9 @@ export function PrivacyPolicyView() {
         <div className="rounded-lg bg-adam-bg-secondary-dark p-8 shadow-md">
           <div className="mb-8 flex flex-col items-center justify-center">
             <img
-              src={`${import.meta.env.BASE_URL}/adam-logo.svg`}
-              alt="Adam Logo"
-              className="mb-4 h-8 w-8"
+              src={`${import.meta.env.BASE_URL}/cadam-logo.svg`}
+              alt="CADAM Logo"
+              className="mb-4 h-8 w-auto"
             />
             <h1 className="text-center text-3xl font-semibold text-white">
               Privacy Policy

--- a/src/views/ResetPasswordView.tsx
+++ b/src/views/ResetPasswordView.tsx
@@ -43,9 +43,9 @@ export function ResetPasswordView() {
         <div className="rounded-lg bg-adam-bg-secondary-dark p-8 shadow-md">
           <div className="mb-4 flex flex-col items-center justify-center gap-2">
             <img
-              src={`${import.meta.env.BASE_URL}/adam-logo.svg`}
-              alt="Adam Logo"
-              className="mr-2 h-8 w-8"
+              src={`${import.meta.env.BASE_URL}/cadam-logo.svg`}
+              alt="CADAM Logo"
+              className="h-8 w-auto"
             />
             <h1 className="text-2xl font-semibold text-white">
               Reset Password

--- a/src/views/SignUpEmailView.tsx
+++ b/src/views/SignUpEmailView.tsx
@@ -119,9 +119,9 @@ export function SignUpEmailView() {
         <div className="rounded-lg bg-adam-bg-secondary-dark p-8 shadow-md">
           <div className="mb-4 flex flex-col items-center justify-center gap-2">
             <img
-              src={`${import.meta.env.BASE_URL}/adam-logo.svg`}
-              alt="Adam Logo"
-              className="mr-2 h-8 w-8"
+              src={`${import.meta.env.BASE_URL}/cadam-logo.svg`}
+              alt="CADAM Logo"
+              className="h-8 w-auto"
             />
             <h1 className="text-2xl font-semibold text-white">
               Create Account

--- a/src/views/SignUpView.tsx
+++ b/src/views/SignUpView.tsx
@@ -64,9 +64,9 @@ export function SignUpView() {
         <div className="rounded-lg bg-adam-bg-secondary-dark p-8 shadow-md">
           <div className="mb-4 flex flex-col items-center justify-center gap-2">
             <img
-              src={`${import.meta.env.BASE_URL}/adam-logo.svg`}
-              alt="Adam Logo"
-              className="mr-2 h-8 w-8"
+              src={`${import.meta.env.BASE_URL}/cadam-logo.svg`}
+              alt="CADAM Logo"
+              className="h-8 w-auto"
             />
             <h1 className="text-xl font-semibold text-white">Create Account</h1>
           </div>

--- a/src/views/TermsOfServiceView.tsx
+++ b/src/views/TermsOfServiceView.tsx
@@ -7,9 +7,9 @@ export function TermsOfServiceView() {
         <div className="rounded-lg bg-adam-bg-secondary-dark p-8 shadow-md">
           <div className="mb-8 flex flex-col items-center justify-center">
             <img
-              src={`${import.meta.env.BASE_URL}/adam-logo.svg`}
-              alt="Adam Logo"
-              className="mb-4 h-8 w-8"
+              src={`${import.meta.env.BASE_URL}/cadam-logo.svg`}
+              alt="CADAM Logo"
+              className="mb-4 h-8 w-auto"
             />
             <h1 className="text-center text-3xl font-semibold text-white">
               Terms of Service

--- a/src/views/UpdatePasswordView.tsx
+++ b/src/views/UpdatePasswordView.tsx
@@ -53,9 +53,9 @@ export function UpdatePasswordView() {
         <div className="rounded-lg bg-adam-bg-secondary-dark p-8 shadow-md">
           <div className="mb-4 flex flex-col items-center justify-center gap-2">
             <img
-              src={`${import.meta.env.BASE_URL}/adam-logo.svg`}
-              alt="Adam Logo"
-              className="mr-2 h-8 w-8"
+              src={`${import.meta.env.BASE_URL}/cadam-logo.svg`}
+              alt="CADAM Logo"
+              className="h-8 w-auto"
             />
             <h1 className="text-2xl font-semibold text-white">
               Update Password


### PR DESCRIPTION
## Summary
Follow-up to #202. Two changes:
1. Makes the **entire** announcement banner clickable (not just the "Try now" button) — a click anywhere on the card opens https://adam.new.
2. Continues the **CADAM rebrand**: swaps the Adam mark for the CADAM wordmark on the auth and legal page headers, matching the sign-in page.

## Clickable banner
A **stretched link**: the existing CTA anchor gets `after:absolute after:inset-0`, so its hit area covers the whole card (its nearest positioned ancestor). A click anywhere on the banner triggers that same anchor — navigation + the `new_product_banner_click` PostHog event.

- **Dismiss X** stays independent: it's `z-10` (above the overlay) and a sibling of the anchor (not nested), so it dismisses without navigating.
- **Logo cluster** opts out via `pointer-events-none`, so the `z-20` Adam tile passes clicks through to the overlay.
- One real link, keyboard-accessible (Tab → "Try now" → Enter), and no invalid nested interactive elements.

## CADAM rebrand — auth & legal pages
Replaces the square Adam icon with the CADAM **wordmark** (`public/cadam-logo.svg`) on the page headers, so they match the sign-in page (which already uses the wordmark):
- Sign-up, Sign-up-email, Reset-password, Update-password, Privacy Policy, Terms of Service.
- Sized `h-8 w-auto` so the wide mark keeps the existing 32px header height and stays centered (dropped the stray `mr-2`).
- The small square mark elsewhere (collapsed sidebar, chat assistant avatar) is intentionally left unchanged.

> Note: the sidebar logo, favicon (blue CADAM icon), login-page wordmark, and banner timer/`will-change` fixes all shipped in #202 and are already on `master`.

## Files
- `src/components/NewProductBanner.tsx` — stretched-link overlay + cluster opt-out
- `src/views/{SignUpView,SignUpEmailView,ResetPasswordView,UpdatePasswordView,PrivacyPolicyView,TermsOfServiceView}.tsx` — CADAM wordmark headers

## Checks
- `tsc -b --noEmit`, `eslint`, and `prettier` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the entire announcement banner clickable so a click anywhere opens adam.new and triggers the existing banner click event.

Implemented a stretched-link overlay; the Dismiss (X) still dismisses without navigation, the logo cluster ignores clicks, and keyboard access remains a single real link.

<sup>Written for commit 7fbe7853892b27c27f79b0b1cb3ea621ab26ab75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
