### PR TITLE
feat(auth): drop "Create Account" heading; CADAM wordmark on sign-in

### DIFF
--- a/src/views/SignInView.tsx
+++ b/src/views/SignInView.tsx
@@ -283,8 +283,8 @@ export function SignInView() {
           <div className="mb-4 flex flex-col items-center justify-center">
             <div>
               <img
-                src={`${import.meta.env.BASE_URL}/adam-logo-full.svg`}
-                alt="Adam Logo"
+                src={`${import.meta.env.BASE_URL}/cadam-logo.svg`}
+                alt="CADAM Logo"
                 className="w-32"
               />
             </div>

--- a/src/views/SignUpView.tsx
+++ b/src/views/SignUpView.tsx
@@ -68,7 +68,6 @@ export function SignUpView() {
               alt="CADAM Logo"
               className="h-8 w-auto"
             />
-            <h1 className="text-xl font-semibold text-white">Create Account</h1>
           </div>
           <div className="w-full py-2">
             <Button


### PR DESCRIPTION
## Summary
Small follow-up to the CADAM rebrand (#202, #206) on the auth pages.

## Changes
- **Sign-up (`/signup`)** — removes the "Create Account" heading so the CADAM wordmark stands alone as the page header.
- **Sign-in** — swaps the remaining `adam-logo-full.svg` for the CADAM wordmark (`cadam-logo.svg`). This swap was made in #202 but dropped in its squash-merge, so the live sign-in page was still showing the Adam logo. Now matches sign-up.

## Files
- `src/views/SignUpView.tsx` — drop the heading
- `src/views/SignInView.tsx` — CADAM wordmark

## Checks
- `tsc -b --noEmit` passes; pre-commit `eslint` + `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns auth pages with the CADAM rebrand. Removes the "Create Account" heading on `/signup` and swaps the sign-in logo to `cadam-logo.svg` with "CADAM Logo" alt text, replacing the last Adam logo.

<sup>Written for commit 46aae2215c74e04722d51d2492a64be54521094c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

