### PR TITLE
Add launch demo GIF to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 <div align="center">
+  <a href="https://adam.new/cadam">
+    <img src="./public/cadam-launch.gif" alt="CADAM — text-to-CAD live demo" width="100%">
+  </a>
+</div>
+
+<div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="./public/Github-Banner-Dark.png">
     <source media="(prefers-color-scheme: light)" srcset="./public/Github-Banner-Light.png">
@@ -49,14 +55,6 @@
 | **Parameter Extraction**   | Automatically identifies adjustable dimensions       |
 | **Smart Updates**          | Efficient parameter changes without AI re-generation |
 | **Custom Fonts**           | Built-in Geist font support for text in models       |
-
-## 🎬 Demo
-
-<div align="center">
-  <video src="https://github.com/user-attachments/assets/f6b1905e-1603-4ad0-b196-12c1d7bf87b2" width="100%" controls>
-    <a href="https://github.com/user-attachments/assets/f6b1905e-1603-4ad0-b196-12c1d7bf87b2">Watch the demo video</a>
-  </video>
-</div>
 
 ## 📺 Screenshots
 


### PR DESCRIPTION
Adds an autoplaying, looping demo GIF to the very top of the README (linked to [adam.new/cadam](https://adam.new/cadam)).

- Source: the existing Demo clip (4K, 38.6s).
- Converted to a web-friendly **720px · 12fps** GIF via a two-pass lanczos palette + gifsicle optimization — **~5.1 MB**, full length, UI text stays legible.
- Kept separate from the benchmarks PR so each can be reviewed independently.

The static banner remains directly below the GIF.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an autoplaying, looping launch demo GIF to the top of the README, linked to https://adam.new/cadam, and removes the old Demo video section. The GIF is optimized (900px, 12fps, ~7.8 MB) for legibility; the static banner remains directly below.

<sup>Written for commit ea83f494063e40bbd64317b97167f5aecf178520. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

