### PR TITLE
feat(billing): support optional token cost multiplier via env

### DIFF
--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -522,11 +522,16 @@ function usdCostFromUsage(modelId: string, usage: LanguageModelUsage): number {
   );
 }
 
+function billingMultiplier(): number {
+  const raw = Number(env('CADAM_BILLING_MULTIPLIER'));
+  return Number.isFinite(raw) && raw > 0 ? raw : 1;
+}
+
 function billingTokensFromUsage(
   modelId: string,
   usage: LanguageModelUsage,
 ): number {
-  const usdCost = usdCostFromUsage(modelId, usage);
+  const usdCost = usdCostFromUsage(modelId, usage) * billingMultiplier();
   return Math.max(1, Math.ceil(usdCost / USD_PER_BILLING_TOKEN));
 }
 


### PR DESCRIPTION
## What

Adds `CADAM_BILLING_MULTIPLIER`, an optional environment variable applied to the computed inference cost before it's converted to billing tokens in `src/server/aiChat.ts`.

```ts
function billingMultiplier(): number {
  const raw = Number(env('CADAM_BILLING_MULTIPLIER'));
  return Number.isFinite(raw) && raw > 0 ? raw : 1;
}
// usdCostFromUsage(modelId, usage) * billingMultiplier()
```

## Behavior

- **Unset / blank / invalid → falls back to `1`** (no-op). Cloning and running the project locally without the variable behaves exactly as before.
- Only affects the chat/parametric generation path. Mesh's flat cost is unchanged.
- Scoped to this app; no shared billing logic is touched.

## Config

Set the variable in the deployment environment (Vercel project settings) to tune the effective rate; leave it unset everywhere else.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional `CADAM_BILLING_MULTIPLIER` to scale the computed USD inference cost before converting to billing tokens in the chat path. Defaults to 1 when unset or invalid; Mesh flat cost and shared billing logic are unchanged.

<sup>Written for commit ac280370500b845a87716018716e693c8be17716. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

