### PR TITLE
feat(home): add time-boxed Product Hunt upvote pill

### DIFF
--- a/src/components/ProductHuntButton.tsx
+++ b/src/components/ProductHuntButton.tsx
@@ -1,0 +1,78 @@
+import { ArrowUpRight } from 'lucide-react';
+import posthog from 'posthog-js';
+import { cn } from '@/lib/utils';
+
+// We're live on Product Hunt for a few days only. Rather than rely on someone
+// remembering to delete this, the badge hides itself once the launch window
+// closes. Push the date out to keep it up longer, or set it in the past to
+// retire the badge early. Stored as UTC; ~end of 2026-06-24 Pacific.
+const LAUNCH_ENDS_AT = new Date('2026-06-25T07:00:00Z');
+
+const PRODUCT_HUNT_URL = 'https://www.producthunt.com/products/cadam?bc=1';
+
+// Product Hunt's brand orange.
+const PH_ORANGE = '#FF6154';
+
+// The Product Hunt "P" logomark, inlined so the badge is instantly recognizable
+// without shipping another asset to /public.
+function ProductHuntLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      viewBox="0 0 40 40"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="20" cy="20" r="20" fill={PH_ORANGE} />
+      <path
+        d="M22.667 20.667H17V14h5.667a3.333 3.333 0 0 1 0 6.667m0-10.667H13.667v20H17v-6h5.667a6.667 6.667 0 1 0 0-13.333"
+        fill="#fff"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Time-boxed "upvote us on Product Hunt" badge for the home page. Branded with
+ * Product Hunt's mark + orange so it reads as special against the neutral UI,
+ * but kept to a single pill so it stays out of the way. Returns null once
+ * {@link LAUNCH_ENDS_AT} passes, so the launch promo cleans up after itself.
+ */
+export function ProductHuntButton({ className }: { className?: string }) {
+  // Only needs to be correct at mount; the launch window is measured in days,
+  // so there's no need to tick a timer to hide it mid-session.
+  if (new Date() > LAUNCH_ENDS_AT) {
+    return null;
+  }
+
+  return (
+    // Self-centering wrapper so callers can drop <ProductHuntButton /> straight
+    // into a stacked layout: after the launch window the component returns null
+    // and leaves no empty row (and no stray vertical gap).
+    <div className={cn('flex justify-center', className)}>
+      <a
+        href={PRODUCT_HUNT_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={() => {
+          try {
+            posthog.capture('product_hunt_upvote_click', {
+              location: 'prompt_view',
+            });
+          } catch {
+            // Analytics failures (e.g. blocked by an ad-blocker) must never
+            // block the link's navigation.
+          }
+        }}
+        className="group inline-flex items-center gap-2 rounded-full border border-[#FF6154]/40 bg-[#FF6154]/10 px-4 py-1.5 text-sm text-adam-text-primary transition-colors hover:border-[#FF6154]/70 hover:bg-[#FF6154]/15"
+      >
+        <ProductHuntLogo className="size-4 shrink-0" />
+        <span>
+          Upvote us on{' '}
+          <span className="font-semibold text-[#FF6154]">Product Hunt</span>
+        </span>
+        <ArrowUpRight className="h-3.5 w-3.5 text-[#FF6154] transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+      </a>
+    </div>
+  );
+}

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -12,6 +12,7 @@ import { MessageItem } from '../types/misc.ts';
 import { LimitReachedMessage } from '@/components/LimitReachedMessage';
 import { LowPromptsWarningMessage } from '@/components/LowPromptsWarningMessage';
 import { NewProductBanner } from '@/components/NewProductBanner';
+import { ProductHuntButton } from '@/components/ProductHuntButton';
 import { FreePlanTrialPill } from '@/components/FreePlanTrialPill';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { cn } from '@/lib/utils';
@@ -334,6 +335,7 @@ export function PromptView() {
                   </div>
                 )}
               </div>
+              <ProductHuntButton />
               {!isLoading && user && !limitReached && !lowPrompts && (
                 <div className="flex flex-wrap justify-center gap-2">
                   {EXTENSION_PILLS.map(({ href, event, label }) => (


### PR DESCRIPTION
## What

Adds a small Product Hunt upvote pill to the home page (`PromptView`), centered directly under the prompt composer. Shows for everyone (signed-in and signed-out) and links to our launch: https://www.producthunt.com/products/cadam?bc=1

## Why

We're live on Product Hunt for a few days and want a noticeable-but-not-invasive nudge to upvote, placed where new and returning visitors land.

## Notes for reviewers

- **Self-expiring.** The pill hides itself once the launch window closes, via a single `LAUNCH_ENDS_AT` constant in `src/components/ProductHuntButton.tsx` (currently `2026-06-25T07:00:00Z`, ~midnight Pacific on the 24th). Bump the date to extend, or set it in the past to retire it early. When expired it returns `null` and leaves no empty gap, so there's no dead UI and nothing to remember to remove. The component can be deleted wholesale after the launch.
- **Placement.** Rendered unconditionally in the composer column, just above the existing extension pills and the sign-in prompt — so it's visible to logged-out visitors too (the extension pills are gated behind sign-in).
- **Branding.** Product Hunt logomark inlined as SVG (no new asset in `/public`) + PH orange (`#FF6154`) so it stands out against the neutral dark UI, but kept to one pill so it stays out of the way. Follows the existing extension-pill pattern (same shape, trailing arrow).
- **Analytics.** Clicks fire a `product_hunt_upvote_click` PostHog event, wrapped in try/catch so a blocked analytics call never blocks navigation — same pattern as the extension pills and `NewProductBanner`.

## Verification

- `tsc -b --noEmit`, `eslint`, and `prettier --check` all pass.
- Ran the dev server and verified rendering on desktop (1280px) and mobile (375px): single line, no wrapping, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a small Product Hunt upvote pill under the home prompt composer to drive launch traffic. It shows for all users and opens the launch page in a new tab.

- **New Features**
  - `ProductHuntButton` auto-expires by returning null after `LAUNCH_ENDS_AT`.
  - Centered in `PromptView`; inline PH logo and orange accent match the pill style.
  - Captures `product_hunt_upvote_click` with `posthog-js` (non-blocking); uses `lucide-react` arrow icon.
  - No layout gap when expired; works for signed-in and signed-out users.

<sup>Written for commit 65b2a0e4cdfd23c01f3cb4332e894dd76d2d6256. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

