### PR TITLE
feat(home): move Product Hunt pill to top-right, next to credits counter

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import { PanelLeft } from 'lucide-react';
 
 import { Sidebar } from './Sidebar';
 import { CreditsButton } from './CreditsButton';
+import { ProductHuntButton } from './ProductHuntButton';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { useIsMobile } from '@/hooks/useIsMobile';
@@ -70,12 +71,15 @@ export function Layout() {
               The `!user` branch above returns early, so no `user` guard here. */}
           {location.pathname === '/' && (
             <div
-              className={`absolute z-20 transition-all duration-300 ease-in-out ${
+              className={`absolute z-20 flex items-center gap-2 transition-all duration-300 ease-in-out ${
                 isSidebarOpen && !isMobile
                   ? 'right-[2.25rem] top-[2.25rem]'
                   : 'right-3.5 top-3.5'
               }`}
             >
+              {/* Launch promo — sits just left of the credits counter, self-hides
+                  after the Product Hunt window closes. */}
+              <ProductHuntButton />
               <CreditsButton />
             </div>
           )}

--- a/src/components/ProductHuntButton.tsx
+++ b/src/components/ProductHuntButton.tsx
@@ -33,10 +33,14 @@ function ProductHuntLogo({ className }: { className?: string }) {
 }
 
 /**
- * Time-boxed "upvote us on Product Hunt" badge for the home page. Branded with
- * Product Hunt's mark + orange so it reads as special against the neutral UI,
- * but kept to a single pill so it stays out of the way. Returns null once
- * {@link LAUNCH_ENDS_AT} passes, so the launch promo cleans up after itself.
+ * Time-boxed "upvote us on Product Hunt" badge. Branded with Product Hunt's
+ * mark + orange so it reads as special against the neutral UI, but kept to a
+ * single pill so it stays out of the way — it sits in the top-right header next
+ * to the credits counter. Returns null once {@link LAUNCH_ENDS_AT} passes, so
+ * the launch promo cleans up after itself (and leaves no empty node behind).
+ *
+ * The label collapses to just "Product Hunt" below `md` so the pill stays
+ * compact in the cramped mobile top bar; the verb returns on wider screens.
  */
 export function ProductHuntButton({ className }: { className?: string }) {
   // Only needs to be correct at mount; the launch window is measured in days,
@@ -46,33 +50,31 @@ export function ProductHuntButton({ className }: { className?: string }) {
   }
 
   return (
-    // Self-centering wrapper so callers can drop <ProductHuntButton /> straight
-    // into a stacked layout: after the launch window the component returns null
-    // and leaves no empty row (and no stray vertical gap).
-    <div className={cn('flex justify-center', className)}>
-      <a
-        href={PRODUCT_HUNT_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={() => {
-          try {
-            posthog.capture('product_hunt_upvote_click', {
-              location: 'prompt_view',
-            });
-          } catch {
-            // Analytics failures (e.g. blocked by an ad-blocker) must never
-            // block the link's navigation.
-          }
-        }}
-        className="group inline-flex items-center gap-2 rounded-full border border-[#FF6154]/40 bg-[#FF6154]/10 px-4 py-1.5 text-sm text-adam-text-primary transition-colors hover:border-[#FF6154]/70 hover:bg-[#FF6154]/15"
-      >
-        <ProductHuntLogo className="size-4 shrink-0" />
-        <span>
-          Upvote us on{' '}
-          <span className="font-semibold text-[#FF6154]">Product Hunt</span>
-        </span>
-        <ArrowUpRight className="h-3.5 w-3.5 text-[#FF6154] transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
-      </a>
-    </div>
+    <a
+      href={PRODUCT_HUNT_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={() => {
+        try {
+          posthog.capture('product_hunt_upvote_click', {
+            location: 'home_header',
+          });
+        } catch {
+          // Analytics failures (e.g. blocked by an ad-blocker) must never
+          // block the link's navigation.
+        }
+      }}
+      className={cn(
+        'group inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-[#FF6154]/40 bg-[#FF6154]/10 px-3 py-1.5 text-sm font-medium text-adam-text-primary shadow-sm transition-colors hover:border-[#FF6154]/70 hover:bg-[#FF6154]/15',
+        className,
+      )}
+    >
+      <ProductHuntLogo className="size-4 shrink-0" />
+      <span>
+        <span className="hidden md:inline">Upvote us on </span>
+        <span className="font-semibold text-[#FF6154]">Product Hunt</span>
+      </span>
+      <ArrowUpRight className="h-3.5 w-3.5 text-[#FF6154] transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+    </a>
   );
 }

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -252,7 +252,11 @@ export function PromptView() {
         )}
       >
         {!user && (
-          <div className="fixed right-4 top-4 z-10 flex flex-row gap-2">
+          <div className="fixed right-4 top-4 z-10 flex flex-row items-center gap-2">
+            {/* Hidden on the smallest screens so it never crowds the Sign
+                Up / Sign In CTAs on a phone; signed-in users get it next to
+                the credits counter instead (see Layout). */}
+            <ProductHuntButton className="hidden sm:inline-flex" />
             <Button
               variant="light"
               onClick={() => navigate({ to: '/signup' })}
@@ -335,7 +339,6 @@ export function PromptView() {
                   </div>
                 )}
               </div>
-              <ProductHuntButton />
               {!isLoading && user && !limitReached && !lowPrompts && (
                 <div className="flex flex-wrap justify-center gap-2">
                   {EXTENSION_PILLS.map(({ href, event, label }) => (


### PR DESCRIPTION
## What

Moves the Product Hunt launch pill from the prompt-composer column up into the top-right header, next to the credits counter.

Follow-up to #212.

## Why

In the composer column the pill overlapped the "out of credits" / limit banner (both occupy the space right under the prompt box). Moving it to the header clears that collision and gives it a more deliberate, less invasive home.

## Behaviour

- **Signed-in (home):** sits just left of the credits counter, inside the same auto-positioning container, so it tracks the sidebar open/close shift.
- **Signed-out (home):** sits just left of the Sign Up / Sign In buttons. Hidden below `sm` so it never crowds the auth CTAs on a phone.
- The pill shares the credits counter's exact dimensions (`px-3 py-1.5 text-sm font-medium`, rounded-full), so they line up cleanly in the shared `flex items-center gap-2` row.
- Label collapses to just "Product Hunt" below `md` to stay compact in the header; the "Upvote us on" verb returns on wider screens.
- Still self-hides after `LAUNCH_ENDS_AT` (returns `null`, no empty node). Analytics `location` renamed `prompt_view` → `home_header`.

## Implementation notes

- `ProductHuntButton` now renders a bare `<a>` (dropped the self-centering wrapper it needed when stacked under the composer) and forwards `className`.

## Verification

- `tsc -b --noEmit`, `eslint`, and `prettier --check` all pass.
- Verified live (dev server) on desktop + mobile for the signed-out state: pill is top-right left of the auth buttons on desktop, hidden on mobile, and gone from the composer column. The signed-in arrangement (left of the credits counter) can't be screenshotted locally without a real auth/billing backend, but it reuses the same shared container and identical pill dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the Product Hunt launch pill to the top-right header next to the credits counter to prevent overlap with the out‑of‑credits banner. Removed it from the prompt composer.

- **Refactors**
  - Component now renders as a bare link and forwards `className`; matches credits pill sizing.
  - Placement: signed-in shows left of credits and tracks sidebar shift; signed-out shows left of auth buttons and hides below `sm`.
  - Label collapses to “Product Hunt” below `md`; still time-boxed (self-hides after `LAUNCH_ENDS_AT`).
  - Analytics location updated from `prompt_view` to `home_header`.

<sup>Written for commit 3b680e887ec61e01658679d18736f3444b753bab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

