### PR TITLE
feat(home): show Product Hunt pill below composer when signed out

### DIFF
--- a/src/components/ProductHuntButton.tsx
+++ b/src/components/ProductHuntButton.tsx
@@ -35,21 +35,31 @@ function ProductHuntLogo({ className }: { className?: string }) {
 /**
  * Time-boxed "upvote us on Product Hunt" badge. Branded with Product Hunt's
  * mark + orange so it reads as special against the neutral UI, but kept to a
- * single pill so it stays out of the way — it sits in the top-right header next
- * to the credits counter. Returns null once {@link LAUNCH_ENDS_AT} passes, so
- * the launch promo cleans up after itself (and leaves no empty node behind).
+ * single pill so it stays out of the way. Returns null once
+ * {@link LAUNCH_ENDS_AT} passes, so the launch promo cleans up after itself
+ * (and leaves no empty node behind).
  *
- * The label collapses to just "Product Hunt" below `md` so the pill stays
- * compact in the cramped mobile top bar; the verb returns on wider screens.
+ * Two placements on the home page:
+ * - `center` — a roomy standalone pill centered below the prompt composer,
+ *   shown to signed-out visitors. Always shows the full "Upvote us on" verb.
+ * - default — an inline pill for the cramped top-right header, shown to
+ *   signed-in users beside the credits counter. The label collapses to just
+ *   "Product Hunt" below `md` so it stays compact in the mobile top bar.
  */
-export function ProductHuntButton({ className }: { className?: string }) {
+export function ProductHuntButton({
+  className,
+  center = false,
+}: {
+  className?: string;
+  center?: boolean;
+}) {
   // Only needs to be correct at mount; the launch window is measured in days,
   // so there's no need to tick a timer to hide it mid-session.
   if (new Date() > LAUNCH_ENDS_AT) {
     return null;
   }
 
-  return (
+  const link = (
     <a
       href={PRODUCT_HUNT_URL}
       target="_blank"
@@ -57,7 +67,7 @@ export function ProductHuntButton({ className }: { className?: string }) {
       onClick={() => {
         try {
           posthog.capture('product_hunt_upvote_click', {
-            location: 'home_header',
+            location: center ? 'home_prompt' : 'home_header',
           });
         } catch {
           // Analytics failures (e.g. blocked by an ad-blocker) must never
@@ -71,10 +81,17 @@ export function ProductHuntButton({ className }: { className?: string }) {
     >
       <ProductHuntLogo className="size-4 shrink-0" />
       <span>
-        <span className="hidden md:inline">Upvote us on </span>
+        <span className={center ? undefined : 'hidden md:inline'}>
+          Upvote us on{' '}
+        </span>
         <span className="font-semibold text-[#FF6154]">Product Hunt</span>
       </span>
       <ArrowUpRight className="h-3.5 w-3.5 text-[#FF6154] transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
     </a>
   );
+
+  // Wrapping inside the component (not the caller) keeps the null-on-expiry
+  // behaviour gap-free: when retired, the whole node — wrapper included —
+  // disappears, leaving no empty centered row in the composer's space-y stack.
+  return center ? <div className="flex justify-center">{link}</div> : link;
 }

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -252,11 +252,7 @@ export function PromptView() {
         )}
       >
         {!user && (
-          <div className="fixed right-4 top-4 z-10 flex flex-row items-center gap-2">
-            {/* Hidden on the smallest screens so it never crowds the Sign
-                Up / Sign In CTAs on a phone; signed-in users get it next to
-                the credits counter instead (see Layout). */}
-            <ProductHuntButton className="hidden sm:inline-flex" />
+          <div className="fixed right-4 top-4 z-10 flex flex-row gap-2">
             <Button
               variant="light"
               onClick={() => navigate({ to: '/signup' })}
@@ -339,6 +335,10 @@ export function PromptView() {
                   </div>
                 )}
               </div>
+              {/* Signed-out visitors get the launch pill below the composer;
+                  signed-in users get it in the top-right header next to the
+                  credits counter instead (see Layout). */}
+              {!user && <ProductHuntButton center />}
               {!isLoading && user && !limitReached && !lowPrompts && (
                 <div className="flex flex-wrap justify-center gap-2">
                   {EXTENSION_PILLS.map(({ href, event, label }) => (


### PR DESCRIPTION
## What

Splits the Product Hunt launch pill's placement by auth state:

- **Signed out:** a roomy, centered pill **below the prompt composer** (its original [#212](https://github.com/Adam-CAD/CADAM/pull/212) spot), always showing the full "Upvote us on Product Hunt" label.
- **Signed in:** unchanged from [#213](https://github.com/Adam-CAD/CADAM/pull/213) — the compact inline pill in the **top-right header**, next to the credits counter.

## Why

[#213](https://github.com/Adam-CAD/CADAM/pull/213) moved the pill to the top-right for *everyone*. The intended design (and what was reviewed locally) is to keep the below-composer placement for signed-out visitors and only use the header slot when signed in. This change was verified locally but landed after #213 merged, so it's going up as a follow-up.

## How

`ProductHuntButton` gains a `center` prop that selects the layout:
- `center` (signed-out): centered block wrapper + full label.
- default (signed-in): inline pill, label collapses to just "Product Hunt" below `md` to stay compact in the mobile top bar.

`PromptView` renders `<ProductHuntButton center />` below the composer only when signed out; `Layout` keeps the plain top-right version for signed-in users. Each state shows the pill in exactly one place — no duplication. The centering wrapper lives inside the component so the null-on-expiry cleanup stays gap-free. Analytics `location` is `home_prompt` (signed out) vs `home_header` (signed in).

## Verification

- `tsc -b --noEmit`, `eslint`, `prettier --check` all pass (plus pre-commit hooks).
- Ran locally against local Supabase and confirmed both states: signed-out pill centered below the composer with the auth buttons alone in the top-right; signed-in pill in the top-right just left of the credits counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the Product Hunt promo by auth state: signed-out users see a centered pill below the prompt composer; signed-in users keep the compact pill in the header.

- **New Features**
  - Added a `center` prop to ProductHuntButton for a centered, full-label pill; default remains the inline header pill with a collapsed label on small screens.
  - PromptView renders the centered pill only when signed out; header placement remains for signed-in users. Analytics location is `home_prompt` vs `home_header`.

<sup>Written for commit aa560f790146eb205cbb243e72e17e5a6c95d6d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

