### PR TITLE
feat(models): replace Gemini 3.5 Flash with GLM 5.2 in parametric picker

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -264,14 +264,13 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'google/gemini-3.5-flash',
-    name: 'Gemini 3.5 Flash',
-    description:
-      'High-efficiency Google multimodal model with fast coding and reasoning',
-    provider: 'Google',
+    id: 'z-ai/glm-5.2',
+    name: 'GLM 5.2',
+    description: 'Z.AI model with strong agentic coding and reasoning',
+    provider: 'Z.AI',
     supportsTools: true,
     supportsThinking: true,
-    supportsVision: true,
+    supportsVision: false,
   },
 ];
 

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -73,6 +73,9 @@ const MODEL_PRICES: Record<
 
   // MoonshotAI
   'moonshotai/kimi-k2.6': { input: 0.6, output: 2.5 },
+
+  // Z.AI
+  'z-ai/glm-5.2': { input: 1.2, output: 4.1 },
 };
 
 const FALLBACK_MODEL_PRICE = { input: 15, output: 75 };


### PR DESCRIPTION
Swap the Gemini 3.5 Flash entry for Z.AI's GLM 5.2 (z-ai/glm-5.2), which routes through OpenRouter. Text-only (vision off), with reasoning and tool support. Add its OpenRouter pricing ($1.20/$4.10 per 1M) so billing uses real rates instead of the conservative fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace `google/gemini-3.5-flash` with `z-ai/glm-5.2` in the parametric model picker. GLM 5.2 is text-only (no vision), supports tools and reasoning, and uses OpenRouter pricing for accurate billing ($1.20 input / $4.10 output per 1M tokens).

<sup>Written for commit 3db5e2e00387310a028b23a2e900ab66d00b3077. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

