### PR TITLE
fix(root): link global stylesheet via head() so prod isn't unstyled

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import { createRootRoute, HeadContent, Scripts } from '@tanstack/react-router';
 import App from '@/App';
-import '@/index.css';
+import appCss from '@/index.css?url';
 
 const assetUrl = (path: string) =>
   `${import.meta.env.BASE_URL.replace(/\/?$/, '/')}${path.replace(/^\//, '')}`;
@@ -8,6 +8,7 @@ const assetUrl = (path: string) =>
 export const Route = createRootRoute({
   head: () => ({
     meta: [{ title: 'CADAM' }],
+    links: [{ rel: 'stylesheet', href: appCss }],
   }),
   component: RootComponent,
   errorComponent: ({ error }) => (


### PR DESCRIPTION
## Problem

The production site renders with **no CSS** — default serif fonts, unstyled native buttons, logo SVG blown up full-size. Reported as "dependencies not loading"; the missing thing is actually the global stylesheet, not an npm package. Local dev looks fine, which masked it.

## Root cause

`src/routes/__root.tsx` imported the global CSS as a bare side-effect:

```ts
import '@/index.css';
```

Vite injects this via HMR in dev, but TanStack Start's production SSR/prerender build does **not** emit a `<link>` for a bare CSS import — so the deployed `<head>` shipped with zero styling. Latent since the TanStack rewrite (#150); the Product Hunt launch traffic surfaced it.

## Fix

Canonical TanStack Start pattern — import the CSS as a URL and register it in the route `head`:

```ts
import appCss from '@/index.css?url';

head: () => ({
  meta: [{ title: 'CADAM' }],
  links: [{ rel: 'stylesheet', href: appCss }],
}),
```

## Verification

Ran a full production build (`vite build` → Nitro prerender). The prerendered `.output/public/_shell.html` now contains:

```html
<link rel="stylesheet" href="/cadam/assets/index-BBgs0KEz.css" data-precedence="default"/>
```

and the compiled 115 KB Tailwind bundle (incl. Inter/Kumbh Sans fonts) is emitted. Before the change that link was absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing CSS in production by importing the global stylesheet as a URL and linking it in the root route head, so pages render with styles.

- **Bug Fixes**
  - Replaced side-effect `import '@/index.css'` with `import appCss from '@/index.css?url'` and added `links: [{ rel: 'stylesheet', href: appCss }]` in `src/routes/__root.tsx`.
  - Verified via prod build: prerendered shell includes the stylesheet `<link>` and the Tailwind bundle is emitted.

<sup>Written for commit 3985cec1a9d7d2fb63a9e0acbe027a680f3d67c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

