### PR TITLE
copy(banner): update headline to mention professional workflows

### DIFF
--- a/src/components/NewProductBanner.tsx
+++ b/src/components/NewProductBanner.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 // Copy lives in one place so the owner can swap headline/subtext/CTA without
 // touching the markup. See the PR summary for runner-up options.
 const COPY = {
-  headline: 'The new Adam is here',
+  headline: 'The new Adam for professional workflows is here',
   subtext:
     'Adam now works inside your real CAD in Onshape and Fusion, editing models, BOMs, and drawings.',
   cta: 'Try now',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the marketing banner headline to mention professional workflows. New headline: "The new Adam for professional workflows is here," which better signals CAD-focused use in Onshape and Fusion.

<sup>Written for commit bc5d5c743fbd4ae766995846c680d0131d24c800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

