### PR TITLE
feat(models): add Claude Sonnet 5 to parametric model picker

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -255,6 +255,15 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
+    id: 'anthropic/claude-sonnet-5',
+    name: 'Claude Sonnet 5',
+    description: 'Frontier Anthropic model balancing speed and reasoning',
+    provider: 'Anthropic',
+    supportsTools: true,
+    supportsThinking: true,
+    supportsVision: true,
+  },
+  {
     id: 'openai/gpt-5.5',
     name: 'GPT-5.5',
     description: 'Latest OpenAI model for reliable CAD generation',

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -53,6 +53,7 @@ const MODEL_PRICES: Record<
 > = {
   // Anthropic
   'anthropic/claude-opus-4.8': { input: 5, output: 25 },
+  'anthropic/claude-sonnet-5': { input: 2, output: 10 },
   'anthropic/claude-opus-4': { input: 15, output: 75 },
   'anthropic/claude-sonnet-4.6': { input: 3, output: 15 },
   'anthropic/claude-sonnet-4.5': { input: 3, output: 15 },


### PR DESCRIPTION
## Summary
- Add **Claude Sonnet 5** (`anthropic/claude-sonnet-5`) to the parametric model picker, placed after Claude Opus 4.8.
- Add its pricing to `MODEL_PRICES`: $2 in / $10 out per 1M tokens (per [OpenRouter](https://openrouter.ai/anthropic/claude-sonnet-5)).

## Notes
No other wiring needed — everything else is pattern-driven:
- **Provider routing**: the `anthropic/` prefix routes through the Anthropic SDK, normalizing the id to `claude-sonnet-5`.
- **Adaptive thinking & tool-choice**: `isClaude5Model` already matches `claude-sonnet-5`, so it inherits adaptive thinking and auto tool-choice handling without a list update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Claude Sonnet 5 (`anthropic/claude-sonnet-5`) to the parametric model picker, placed after Claude Opus 4.8, with pricing set to $2 input / $10 output per 1M tokens. It uses existing Anthropic routing and inherits adaptive thinking, tool-use, and vision support.

<sup>Written for commit 15ae67a586b6d11a088274cc4bef2a2163852bb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

