### PR TITLE
fix(models): show only model names in picker dropdown

### DIFF
--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -193,7 +193,7 @@ export function ModelSelector({
           <DropdownMenuItem
             key={model.id}
             className={cn(
-              'cursor-pointer rounded-md bg-adam-neutral-700 px-4 py-3 transition-colors duration-150 focus:bg-adam-bg-secondary-dark',
+              'cursor-pointer rounded-md bg-adam-neutral-700 px-4 py-2 transition-colors duration-150 focus:bg-adam-bg-secondary-dark',
               selectedModel === model.id && 'bg-adam-neutral-800',
               !!model.disabled && 'cursor-not-allowed opacity-50',
             )}
@@ -204,26 +204,14 @@ export function ModelSelector({
             }}
             disabled={!!model.disabled}
           >
-            <div className="flex-1">
-              <div className="flex items-center">
-                <span
-                  className={cn(
-                    'font-medium',
-                    focused ? 'text-white' : 'text-adam-text-primary',
-                  )}
-                >
-                  {model.name}
-                </span>
-              </div>
-              <p
-                className={cn(
-                  'mt-0.5 text-xs',
-                  focused ? 'text-white' : 'text-gray-400',
-                )}
-              >
-                {model.description}
-              </p>
-            </div>
+            <span
+              className={cn(
+                'text-sm font-medium',
+                focused ? 'text-white' : 'text-adam-text-primary',
+              )}
+            >
+              {model.name}
+            </span>
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -193,7 +193,8 @@ export function ModelSelector({
           <DropdownMenuItem
             key={model.id}
             className={cn(
-              'cursor-pointer rounded-md bg-adam-neutral-700 px-4 py-2 transition-colors duration-150 focus:bg-adam-bg-secondary-dark',
+              'cursor-pointer rounded-md bg-adam-neutral-700 px-4 transition-colors duration-150 focus:bg-adam-bg-secondary-dark',
+              currentType === 'creative' ? 'py-3' : 'py-2',
               selectedModel === model.id && 'bg-adam-neutral-800',
               !!model.disabled && 'cursor-not-allowed opacity-50',
             )}
@@ -204,14 +205,29 @@ export function ModelSelector({
             }}
             disabled={!!model.disabled}
           >
-            <span
-              className={cn(
-                'text-sm font-medium',
-                focused ? 'text-white' : 'text-adam-text-primary',
+            <div className="flex-1">
+              <span
+                className={cn(
+                  'text-sm font-medium',
+                  focused ? 'text-white' : 'text-adam-text-primary',
+                )}
+              >
+                {model.name}
+              </span>
+              {/* Creative modes (Draft/Textureless/Max Quality) rely on the
+                  description to explain the speed/quality/texture tradeoff;
+                  parametric models show names only to keep the list compact. */}
+              {currentType === 'creative' && model.description && (
+                <p
+                  className={cn(
+                    'mt-0.5 text-xs',
+                    focused ? 'text-white' : 'text-gray-400',
+                  )}
+                >
+                  {model.description}
+                </p>
               )}
-            >
-              {model.name}
-            </span>
+            </div>
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>


### PR DESCRIPTION
## Summary
- Drop the per-model description paragraphs from the model picker dropdown and tighten row padding (`py-3` → `py-2`), so each row shows just the model name.

## Why
With more models in the list, the dropdown extended too far up the screen. Names-only keeps it compact. The `description` field is retained in the model config data; it's just no longer rendered in the dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show only model names in the picker for parametric models to keep the list compact; keep descriptions for creative modes (Draft/Textureless/Max Quality).
Row padding is now `py-2` for parametric rows and `py-3` for creative rows; the `description` field stays in config.

<sup>Written for commit a37b9bdc37c5a62bce688990417f1c8ca6f9389f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

