### PR TITLE
fix(models): force build tool for Sonnet 5 in parametric flow

### DIFF
--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -444,11 +444,12 @@ function buildChatModel(
 
 // Capability gates below accept either the OpenRouter alias (`anthropic/claude-…`)
 // or the bare Anthropic ID — strip the prefix here so every gate is called the
-// same way regardless of which form the caller has on hand.
+// same way regardless of which form the caller has on hand. Drop *any* provider
+// prefix (everything up to the last "/"), not just "anthropic/", so a model
+// routed through another provider (e.g. "openrouter/anthropic/claude-fable-5")
+// still matches the `^claude-…` regexes instead of silently slipping past them.
 function bareModelId(modelId: string): string {
-  const id = modelId.startsWith('anthropic/')
-    ? modelId.slice('anthropic/'.length)
-    : modelId;
+  const id = modelId.slice(modelId.lastIndexOf('/') + 1);
   // Anthropic's API uses dashes ("claude-opus-4-6"); the OpenRouter alias
   // uses dots ("claude-opus-4.6"). Normalize so the version regexes match
   // either form.

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -473,12 +473,18 @@ function usesAdaptiveAnthropicThinking(modelId: string) {
   return match ? Number(match[1]) >= 6 : false;
 }
 
+// The reasoning-tier Claude 5 models (Fable, Mythos) reject a forced
+// `tool_choice` outright ("tool_choice forces tool use is not compatible with
+// this model"). Other Claude 5 tiers — notably Sonnet 5 — accept a forced
+// tool_choice on the first-party API, provided thinking is disabled for that
+// step (see the per-step override in the parametric flow).
+function rejectsForcedToolChoice(modelId: string): boolean {
+  return /^claude-(?:fable|mythos)\b/.test(bareModelId(modelId));
+}
+
 // Whether a model accepts a forced `tool_choice` (type: "tool" / "any").
-// The Claude 5 generation rejects forced tool use with "tool_choice forces
-// tool use is not compatible with this model" — for those we must fall back
-// to auto tool choice and steer via the system prompt.
 function supportsForcedToolChoice(modelId: string): boolean {
-  return !isClaude5Model(modelId);
+  return !rejectsForcedToolChoice(modelId);
 }
 
 function priceFor(modelId: string) {
@@ -1208,19 +1214,21 @@ export async function handleAiChatRequest(req: Request) {
     thinking: thinkingEnabled,
   };
 
-  // Parametric step 0 normally pins `build_parametric_model` via a forced
-  // tool_choice. Two cases fall back to auto tool choice instead — where the
-  // model *might* answer with text instead of building:
-  //   1. Models that reject forced tool use outright (Claude 5 — Fable/Mythos).
-  //   2. Any turn with extended thinking enabled — Anthropic rejects a forced
-  //      tool_choice while thinking is on ("Thinking may not be enabled when
-  //      tool_choice forces tool use"). Adaptive thinking is on by default for
-  //      Claude 5 / Opus·Sonnet 4.6+, so those land here too.
-  // Both rely on the system prompt to steer the build tool call. Track the
-  // fallback so we can detect — and log — a turn that finished without ever
-  // calling the build tool.
-  const forceBuildToolChoice =
-    supportsForcedToolChoice(actualModelId) && !thinkingEnabled;
+  // Parametric step 0 pins `build_parametric_model` via a forced tool_choice
+  // whenever the model accepts one. Anthropic rejects a forced tool_choice
+  // while thinking is on ("Thinking may not be enabled when tool_choice forces
+  // tool use"), so for thinking-enabled Anthropic models we disable thinking
+  // for just that first step (see `prepareStep` below); later steps keep their
+  // adaptive thinking. Only the reasoning-tier Claude 5 models (Fable/Mythos),
+  // which reject forced tool use outright, fall back to auto tool choice and
+  // rely on the system prompt to steer the build call — a fragile path where
+  // the model *might* answer with text instead of building. Track that fallback
+  // so we can detect — and log — a turn that finished without building.
+  const forceBuildToolChoice = supportsForcedToolChoice(actualModelId);
+  const disableThinkingForBuildStep =
+    forceBuildToolChoice &&
+    thinkingEnabled &&
+    resolvedProvider === 'anthropic';
   const usingAutoToolChoiceFallback =
     conversation.type === 'parametric' &&
     leafRole === 'user' &&
@@ -1238,10 +1246,14 @@ export async function handleAiChatRequest(req: Request) {
         leafRole === 'user' &&
         stepNumber === 0
       ) {
-        // Restrict the toolset to the build tool on the first step. Turns that
-        // accept a forced tool_choice get it pinned; turns that reject forced
-        // tool use (Claude 5, or any thinking-enabled turn) fall back to auto
-        // and rely on the system prompt to call build_parametric_model.
+        // Restrict the toolset to the build tool on the first step. Models that
+        // accept a forced tool_choice get it pinned; the reasoning-tier Claude 5
+        // models (Fable/Mythos) reject forced tool use and fall back to auto,
+        // relying on the system prompt to call build_parametric_model.
+        // When pinning the tool on a thinking-enabled Anthropic model, thinking
+        // must be off for this step (Anthropic rejects forced tool use while
+        // thinking is on) — disable it here only; later steps keep the adaptive
+        // thinking configured in buildChatModel.
         return {
           activeTools: ['build_parametric_model' as never],
           ...(forceBuildToolChoice
@@ -1250,6 +1262,13 @@ export async function handleAiChatRequest(req: Request) {
                   type: 'tool' as const,
                   toolName: 'build_parametric_model' as never,
                 },
+                ...(disableThinkingForBuildStep
+                  ? {
+                      providerOptions: {
+                        anthropic: { thinking: { type: 'disabled' as const } },
+                      },
+                    }
+                  : {}),
               }
             : {}),
         };


### PR DESCRIPTION
## Summary
Fixes Sonnet 5 thinking for a long time and then ending a parametric turn without ever calling `build_parametric_model` — leaving the user with no built model and no error.

## Root cause
`claude-sonnet-5` matched `isClaude5Model` (`^claude-[a-z]+-5`), so:
- `supportsForcedToolChoice` returned `false`, treating it like the reasoning-tier Fable/Mythos models, and
- adaptive thinking was force-enabled.

With forced `tool_choice` unavailable **and** thinking on, parametric `user` turns fell into the auto tool-choice fallback (system-prompt steering only). Sonnet 5 would think at `effort: high` and finish as plain text instead of calling the build tool — exactly the degraded outcome already logged in `onFinish`. (Opus 4.8 also rode this fallback but happened to comply.)

## Fix
- **Narrow the rejection** to only the reasoning-tier Claude 5 models (`rejectsForcedToolChoice` → `^claude-(?:fable|mythos)`), so Sonnet 5 can pin the build tool.
- **Disable thinking on the forced first step only** via per-step `providerOptions` in `prepareStep` (`thinking: { type: 'disabled' }`), satisfying Anthropic's "thinking may not be enabled when tool_choice forces tool use" constraint. Later steps keep the adaptive thinking from `buildChatModel`.

Net effect: Sonnet 5 (and Opus 4.8, now also off the fragile fallback) reliably emit `build_parametric_model` on step 0. Only Fable/Mythos remain on system-prompt steering, with the existing degraded-outcome logging intact.

## Verification notes
- Could not run typecheck locally (node_modules not installed in this worktree). Edits verified against the published type defs: AI SDK v6 `PrepareStepResult` accepts per-step `providerOptions`; `@ai-sdk/anthropic` v3 accepts `thinking: { type: 'disabled' }`.
- Relies on first-party Sonnet 5 accepting a forced `tool_choice` with thinking off (per the Sonnet 5 migration guidance; the blanket "Claude 5 rejects forced tool use" applies to the reasoning tier). If wrong, it surfaces as a 400 via existing `onError` logging rather than failing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the parametric flow where Sonnet 5 would think for a long time and finish as text without calling `build_parametric_model`. We now force the build tool on step 0 (with thinking disabled for that step) so Sonnet 5 and Opus 4.8 reliably build; only `claude-fable`/`claude-mythos` stay on the auto fallback.

- **Bug Fixes**
  - Narrow forced-tool rejection to only reasoning-tier Claude 5 models via `rejectsForcedToolChoice`, and strip any provider prefix in `bareModelId` so gates still match when routed (e.g. `openrouter/anthropic/…`).
  - Force `tool_choice` for the build step when supported; for Anthropic models with thinking enabled, disable thinking only on step 0 via per-step `providerOptions`.
  - Preserve the auto tool-choice fallback (and logging) for models that reject forced tool use.

<sup>Written for commit 3972064acf73f937cd5af6e115c85edddd136939. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

