### PR TITLE
feat(models): add Claude Fable 5 back to parametric model picker

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -248,7 +248,7 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
   {
     id: 'anthropic/claude-fable-5',
     name: 'Claude Fable 5',
-    description: 'Most intelligent Anthropic model for complex reasoning',
+    description: 'Most capable Anthropic model; best reasoning at highest cost',
     provider: 'Anthropic',
     supportsTools: true,
     supportsThinking: true,
@@ -257,7 +257,7 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
   {
     id: 'anthropic/claude-opus-4.8',
     name: 'Claude Opus 4.8',
-    description: 'Most powerful Anthropic model for complex reasoning',
+    description: 'Powerful Anthropic model for complex reasoning',
     provider: 'Anthropic',
     supportsTools: true,
     supportsThinking: true,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -246,6 +246,15 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
+    id: 'anthropic/claude-fable-5',
+    name: 'Claude Fable 5',
+    description: 'Most intelligent Anthropic model for complex reasoning',
+    provider: 'Anthropic',
+    supportsTools: true,
+    supportsThinking: true,
+    supportsVision: true,
+  },
+  {
     id: 'anthropic/claude-opus-4.8',
     name: 'Claude Opus 4.8',
     description: 'Most powerful Anthropic model for complex reasoning',

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -52,6 +52,7 @@ const MODEL_PRICES: Record<
   { input: number; output: number; cacheRead?: number; cacheWrite?: number }
 > = {
   // Anthropic
+  'anthropic/claude-fable-5': { input: 10, output: 50 },
   'anthropic/claude-opus-4.8': { input: 5, output: 25 },
   'anthropic/claude-sonnet-5': { input: 2, output: 10 },
   'anthropic/claude-opus-4': { input: 15, output: 75 },
@@ -1227,9 +1228,7 @@ export async function handleAiChatRequest(req: Request) {
   // so we can detect — and log — a turn that finished without building.
   const forceBuildToolChoice = supportsForcedToolChoice(actualModelId);
   const disableThinkingForBuildStep =
-    forceBuildToolChoice &&
-    thinkingEnabled &&
-    resolvedProvider === 'anthropic';
+    forceBuildToolChoice && thinkingEnabled && resolvedProvider === 'anthropic';
   const usingAutoToolChoiceFallback =
     conversation.type === 'parametric' &&
     leafRole === 'user' &&


### PR DESCRIPTION
## Summary
- Restore the `anthropic/claude-fable-5` entry to `PARAMETRIC_MODELS` in `src/lib/utils.ts`, placed above Opus 4.8. Unlike #194 (which swapped Fable 5 out for Opus 4.8), this is additive — Opus 4.8 and Sonnet 5 stay in the picker.
- Restore its `MODEL_PRICES` row in `src/server/aiChat.ts` at $10/$50 per million input/output tokens, the same pricing it had before removal.

## Notes
No capability-gate changes needed: `isClaude5Model` matches `claude-fable-5` generically (adaptive thinking on), and `rejectsForcedToolChoice` already covers the fable/mythos tiers, so the parametric flow won't force `tool_choice` on it. Picker components render from `PARAMETRIC_MODELS` dynamically.

## Testing
- `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `anthropic/claude-fable-5` to the parametric model picker and pricing table alongside `anthropic/claude-opus-4.8` and `anthropic/claude-sonnet-5`. Updates picker copy to differentiate Fable 5 (most capable, highest cost) from Opus 4.8; pricing is $10 per 1M input tokens and $50 per 1M output tokens.

<sup>Written for commit 2614132582be3000a47b52e48046f05f83766574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

