### PR TITLE
feat(auth)!: root is the only auth surface in SSO mode

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -3,11 +3,13 @@ VITE_SUPABASE_URL='http://127.0.0.1:54321'
 SUPABASE_SERVICE_ROLE_KEY="<Test Service Role Key>"
 # Optional: SSO-only mode. Set to any Supabase OAuth provider slug — e.g.
 # 'custom:my-idp' for a custom OIDC provider configured in your Supabase
-# dashboard — and the auth views drop the native sign-in/sign-up UI and
-# redirect straight to that provider. Leave unset to keep the native auth UI
-# (the local Supabase CLI stack can't host custom OIDC providers).
+# dashboard — and the app root becomes the only auth surface: its signed-out
+# UI is unchanged, but the sign-in/sign-up affordances redirect to the
+# provider, /signin & /signup & /signup-email bounce to root, and
+# unauthenticated deep links redirect straight to the provider. Leave unset
+# to keep the native auth UI (the local Supabase CLI stack can't host
+# custom OIDC providers).
 # VITE_SSO_PROVIDER="custom:my-idp"
-# VITE_SSO_LABEL="Sign in"
 VITE_POSTHOG_PROJECT_KEY="<Test PostHog Project Key>"
 VITE_SENTRY_ENVIRONMENT="local"
 VITE_SENTRY_DSN="<Sentry DSN>"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,7 +16,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/lib/supabase';
+import { supabase, ssoProvider } from '@/lib/supabase';
 import {
   Sheet,
   SheetContent,
@@ -68,6 +68,15 @@ function DesktopSidebar({ isSidebarOpen, setIsSidebarOpen }: SidebarProps) {
 
   const handleSignOut = async () => {
     try {
+      if (ssoProvider) {
+        // In SSO mode root is the app's only auth surface, so sign-out lands
+        // there. Navigate BEFORE the session dies: on a guarded route the
+        // AuthGuard would otherwise fire the provider redirect the moment the
+        // session goes away and sign the user straight back in.
+        await navigate({ to: '/' });
+        await signOut();
+        return;
+      }
       await signOut();
       navigate({ to: '/signin' });
     } catch (error) {

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from '@tanstack/react-router';
 import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+// The module-level `toast`, not the hook: the SSO error handler lives inside
+// the guard's redirect effect, and a hook-returned reference would have to
+// join the effect's dependency array. The module function is identity-stable
+// by construction, keeping the deps — and the non-SSO re-run behavior —
+// exactly as they were before SSO mode existed.
+import { toast } from '@/hooks/use-toast';
 import { Loader2 } from 'lucide-react';
 import { ssoProvider } from '@/lib/supabase';
 import { signInWithSsoProvider } from '@/lib/ssoAuth';
@@ -14,7 +19,6 @@ export function AuthGuard({ children }: AuthGuardProps) {
   const { session, user, isLoading } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const { toast } = useToast();
   // In SSO mode the guard fires the provider redirect itself — once per
   // mount (StrictMode re-runs effects in dev).
   const hasFiredSsoRedirect = useRef(false);
@@ -57,7 +61,6 @@ export function AuthGuard({ children }: AuthGuardProps) {
     isLoading,
     location.pathname,
     location.searchStr,
-    toast,
   ]);
 
   if (isLoading) {

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,7 +1,10 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from '@tanstack/react-router';
 import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/hooks/use-toast';
 import { Loader2 } from 'lucide-react';
+import { ssoProvider } from '@/lib/supabase';
+import { signInWithSsoProvider } from '@/lib/ssoAuth';
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -11,12 +14,38 @@ export function AuthGuard({ children }: AuthGuardProps) {
   const { session, user, isLoading } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
+  const { toast } = useToast();
+  // In SSO mode the guard fires the provider redirect itself — once per
+  // mount (StrictMode re-runs effects in dev).
+  const hasFiredSsoRedirect = useRef(false);
 
   useEffect(() => {
     if (!isLoading && !session && !user) {
       // Capture current path for redirect after authentication
       // Only include pathname and search to avoid security issues
       const currentPath = location.pathname + location.searchStr;
+
+      if (ssoProvider) {
+        // The provider redirect IS the sign-in: send the browser straight
+        // there with the intended URL preserved — no intermediate route.
+        // Only the spinner below renders while the redirect happens.
+        if (hasFiredSsoRedirect.current) return;
+        hasFiredSsoRedirect.current = true;
+
+        signInWithSsoProvider(currentPath).catch((error) => {
+          toast({
+            title: 'Whoopsies',
+            description:
+              error instanceof Error ? error.message : 'Something went wrong',
+            variant: 'destructive',
+          });
+          // The redirect failed — fall back to root, whose signed-out state
+          // offers the manual sign-in affordances.
+          navigate({ to: '/', replace: true });
+        });
+        return;
+      }
+
       const search = currentPath !== '/' ? { redirect: currentPath } : {};
 
       navigate({ to: '/signin', search, replace: true });
@@ -28,6 +57,7 @@ export function AuthGuard({ children }: AuthGuardProps) {
     isLoading,
     location.pathname,
     location.searchStr,
+    toast,
   ]);
 
   if (isLoading) {
@@ -39,6 +69,16 @@ export function AuthGuard({ children }: AuthGuardProps) {
   }
 
   if (!session || !user) {
+    // In SSO mode the effect above is redirecting the browser to the
+    // provider — keep the spinner up instead of flashing a blank frame.
+    if (ssoProvider) {
+      return (
+        <div className="flex min-h-screen items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
+        </div>
+      );
+    }
+
     return null;
   }
 

--- a/src/components/auth/DeleteAccountDialog.tsx
+++ b/src/components/auth/DeleteAccountDialog.tsx
@@ -9,7 +9,8 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { supabase, ssoProvider, ssoSignedOutStorageKey } from '@/lib/supabase';
+import { useNavigate } from '@tanstack/react-router';
+import { supabase, ssoProvider } from '@/lib/supabase';
 import * as Sentry from '@sentry/react';
 import { useToast } from '@/hooks/use-toast';
 import { useMutation } from '@tanstack/react-query';
@@ -33,6 +34,7 @@ export const DeleteAccountDialog = ({
 }) => {
   const [confirmText, setConfirmText] = useState('');
   const { toast } = useToast();
+  const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const [step, setStep] = useState<1 | 2>(1);
   const [selectedReason, setSelectedReason] =
@@ -47,11 +49,13 @@ export const DeleteAccountDialog = ({
         body: JSON.stringify({ reason: selectedReason }),
       });
     },
-    onSuccess: () => {
-      // In SSO mode the auth views redirect to the provider on mount — mark
-      // the sign-out so the just-deleted user isn't signed straight back in.
+    onSuccess: async () => {
+      // In SSO mode root is the app's only auth surface, so the deletion
+      // flow lands there. Navigate BEFORE the session dies: this dialog
+      // lives on a guarded route, and the AuthGuard would otherwise fire
+      // the provider redirect and sign the just-deleted user back in.
       if (ssoProvider) {
-        sessionStorage.setItem(ssoSignedOutStorageKey, '1');
+        await navigate({ to: '/' });
       }
       // Sign out locally and redirect after deletion
       supabase.auth.signOut();

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Session, User } from '@supabase/supabase-js';
-import { supabase, ssoProvider, ssoSignedOutStorageKey } from '@/lib/supabase';
+import { supabase } from '@/lib/supabase';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import posthog from 'posthog-js';
@@ -248,12 +248,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signOut = async () => {
     const { error } = await supabase.auth.signOut();
     if (error) throw error;
-    // In SSO mode the auth views redirect to the provider on mount — mark
-    // the explicit sign-out so they wait for a click instead of signing the
-    // user straight back in.
-    if (ssoProvider) {
-      sessionStorage.setItem(ssoSignedOutStorageKey, '1');
-    }
   };
 
   const signInWithMagicLink = async (email: string) => {

--- a/src/lib/ssoAuth.ts
+++ b/src/lib/ssoAuth.ts
@@ -1,0 +1,29 @@
+import { supabase, ssoProvider } from '@/lib/supabase';
+
+// Build an absolute, same-frontend redirect URL for the OAuth return leg.
+// Uses the current origin + Vite base path so the provider sends the user
+// back to whichever frontend initiated the redirect (adam.new/cadam,
+// app.adamcad.com, Vercel previews).
+function getAppRedirectUrl(path: string) {
+  const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+  return `${window.location.origin}${basePath}${path}`;
+}
+
+// Kick off the SSO provider redirect. `redirectPath` is the in-app path
+// (router space, no base path) the user should land on after the provider
+// round-trip. signInWithOAuth reports provider/config failures via the
+// returned error rather than throwing — surface it so callers can react.
+export async function signInWithSsoProvider(redirectPath: string = '/') {
+  if (!ssoProvider) return;
+
+  const { error } = await supabase.auth.signInWithOAuth({
+    provider: ssoProvider,
+    options: {
+      redirectTo: getAppRedirectUrl(redirectPath),
+    },
+  });
+  if (error) {
+    throw error;
+  }
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -7,21 +7,17 @@ const rawSupabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 // Flag used by the UI to show a helpful message instead of crashing
 export const isSupabaseConfigMissing = !rawSupabaseUrl || !rawSupabaseKey;
 
-// Optional SSO-only mode for the auth views. Set VITE_SSO_PROVIDER to any
-// Supabase OAuth provider slug (e.g. 'custom:my-idp' for a custom OIDC
-// provider configured in the Supabase dashboard) and the auth views drop the
-// native sign-in/sign-up UI and redirect straight to that provider. Leave it
-// unset to keep the native auth UI — the local Supabase CLI stack can't host
-// custom OIDC providers, so it stays unset in local dev.
+// Optional SSO-only mode. Set VITE_SSO_PROVIDER to any Supabase OAuth
+// provider slug (e.g. 'custom:my-idp' for a custom OIDC provider configured
+// in the Supabase dashboard) and the app root becomes the only auth surface:
+// its existing signed-out UI stays as-is, but every sign-in/sign-up
+// affordance redirects to the provider instead of the native auth routes
+// (which bounce back to root), and unauthenticated deep links redirect
+// straight to the provider. Leave it unset to keep the native auth UI —
+// the local Supabase CLI stack can't host custom OIDC providers, so it
+// stays unset in local dev.
 export const ssoProvider = (import.meta.env.VITE_SSO_PROVIDER ||
   null) as Provider | null;
-export const ssoLabel: string = import.meta.env.VITE_SSO_LABEL || 'Sign in';
-
-// Set on explicit sign-out and consumed by the auth views: in SSO mode the
-// views normally redirect to the provider on mount, but right after signing
-// out that would sign the user straight back in via the still-live provider
-// session — the marker makes the views wait for an explicit click instead.
-export const ssoSignedOutStorageKey = 'ssoSignedOut';
 
 // Fallback values keep the client constructable so imports don't throw
 // when env vars are missing. The app should gate on isSupabaseConfigMissing

--- a/src/routes/signin.tsx
+++ b/src/routes/signin.tsx
@@ -1,6 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 import { SignInView } from '@/views/SignInView';
+import { ssoProvider } from '@/lib/supabase';
 
 export const Route = createFileRoute('/signin')({
+  // With an SSO provider configured, root is the app's only auth surface —
+  // the native auth routes bounce straight there without rendering.
+  beforeLoad: () => {
+    if (ssoProvider) {
+      throw redirect({ to: '/', replace: true });
+    }
+  },
   component: SignInView,
 });

--- a/src/routes/signup-email.tsx
+++ b/src/routes/signup-email.tsx
@@ -1,6 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 import { SignUpEmailView } from '@/views/SignUpEmailView';
+import { ssoProvider } from '@/lib/supabase';
 
 export const Route = createFileRoute('/signup-email')({
+  // With an SSO provider configured, root is the app's only auth surface —
+  // the native auth routes bounce straight there without rendering.
+  beforeLoad: () => {
+    if (ssoProvider) {
+      throw redirect({ to: '/', replace: true });
+    }
+  },
   component: SignUpEmailView,
 });

--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -1,6 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 import { SignUpView } from '@/views/SignUpView';
+import { ssoProvider } from '@/lib/supabase';
 
 export const Route = createFileRoute('/signup')({
+  // With an SSO provider configured, root is the app's only auth surface —
+  // the native auth routes bounce straight there without rendering.
+  beforeLoad: () => {
+    if (ssoProvider) {
+      throw redirect({ to: '/', replace: true });
+    }
+  },
   component: SignUpView,
 });

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -3,7 +3,8 @@ import { ArrowUpRight, LogIn } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/lib/supabase';
+import { supabase, ssoProvider } from '@/lib/supabase';
+import { signInWithSsoProvider } from '@/lib/ssoAuth';
 import TextAreaChat from '@/components/TextAreaChat';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { useState, useMemo, useEffect } from 'react';
@@ -114,6 +115,22 @@ export function PromptView() {
       return 'Good evening';
     }
   }, []); // Empty dependency array means it only calculates once per page load
+
+  // In SSO mode the provider redirect IS the sign-in: the existing signed-out
+  // affordances below fire it directly instead of navigating to the native
+  // auth routes (which bounce back to root in this mode). Same UI, same
+  // pixels — only where the click goes changes.
+  const { mutate: signInWithSso } = useMutation({
+    mutationFn: () => signInWithSsoProvider('/'),
+    onError: (error) => {
+      toast({
+        title: 'Whoopsies',
+        description:
+          error instanceof Error ? error.message : 'Something went wrong',
+        variant: 'destructive',
+      });
+    },
+  });
 
   const { mutate: handleGenerate, isPending: isGenerating } = useMutation({
     mutationFn: async (parts: AppUIMessage['parts']) => {
@@ -254,13 +271,17 @@ export function PromptView() {
           <div className="fixed right-4 top-4 z-10 flex flex-row gap-2">
             <Button
               variant="light"
-              onClick={() => navigate({ to: '/signup' })}
+              onClick={() =>
+                ssoProvider ? signInWithSso() : navigate({ to: '/signup' })
+              }
               className="w-auto"
             >
               Sign Up
             </Button>
             <Button
-              onClick={() => navigate({ to: '/signin' })}
+              onClick={() =>
+                ssoProvider ? signInWithSso() : navigate({ to: '/signin' })
+              }
               className="w-auto"
             >
               <LogIn className="mr-2 h-4 w-4" />
@@ -303,6 +324,10 @@ export function PromptView() {
                   }}
                   onFocus={() => {
                     if (!user) {
+                      if (ssoProvider) {
+                        signInWithSso();
+                        return;
+                      }
                       navigate({ to: '/signin' });
                       return;
                     }
@@ -367,6 +392,12 @@ export function PromptView() {
                 <p className="text-center text-sm text-gray-500">
                   <Link
                     to="/signin"
+                    onClick={(e) => {
+                      if (ssoProvider) {
+                        e.preventDefault();
+                        signInWithSso();
+                      }
+                    }}
                     className="!text-adam-blue hover:!text-adam-blue/80"
                   >
                     Sign in
@@ -374,6 +405,12 @@ export function PromptView() {
                   or{' '}
                   <Link
                     to="/signup"
+                    onClick={(e) => {
+                      if (ssoProvider) {
+                        e.preventDefault();
+                        signInWithSso();
+                      }
+                    }}
                     className="!text-adam-blue hover:!text-adam-blue/80"
                   >
                     create an account

--- a/src/views/SignInView.tsx
+++ b/src/views/SignInView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate, Link, useLocation } from '@tanstack/react-router';
 import { ArrowLeft, Loader2, Mail } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -13,12 +13,7 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
 import { AuthError } from '@supabase/supabase-js';
-import {
-  supabase,
-  ssoProvider,
-  ssoLabel,
-  ssoSignedOutStorageKey,
-} from '@/lib/supabase';
+import { supabase } from '@/lib/supabase';
 import { useMutation } from '@tanstack/react-query';
 import { GoogleIcon } from '@/components/icons/CompanyIcons';
 import { validateRedirectUrl } from '@/lib/utils';
@@ -97,67 +92,6 @@ export function SignInView() {
       },
     });
 
-  const [showSsoFallback, setShowSsoFallback] = useState(false);
-  const hasAutoFiredSso = useRef(false);
-
-  const { mutate: signInWithSso } = useMutation({
-    mutationFn: async () => {
-      if (!ssoProvider) return;
-
-      // Use Supabase's built-in redirectTo parameter with validated URL
-      const redirectTo =
-        redirectPath !== '/'
-          ? getAppRedirectUrl(redirectPath)
-          : getAppRedirectUrl('/');
-
-      // signInWithOAuth reports provider/config failures via the returned
-      // error rather than throwing — surface it so onError shows the toast.
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: ssoProvider,
-        options: {
-          redirectTo,
-        },
-      });
-      if (error) {
-        throw error;
-      }
-    },
-    onError: (error) => {
-      // The auto-redirect failed — leave the manual button on screen.
-      setShowSsoFallback(true);
-      toast({
-        title: 'Whoopsies',
-        description:
-          error instanceof Error ? error.message : 'Something went wrong',
-        variant: 'destructive',
-      });
-    },
-  });
-
-  // In SSO mode the redirect is the sign-in: fire it on mount, exactly once
-  // (StrictMode re-runs effects in dev). Skip it right after an explicit
-  // sign-out — otherwise the still-live provider session would sign the user
-  // straight back in — and fall back to a manual button if the redirect
-  // hasn't happened after a few seconds, so nobody is stranded.
-  useEffect(() => {
-    if (!ssoProvider) return;
-
-    if (!hasAutoFiredSso.current) {
-      hasAutoFiredSso.current = true;
-
-      if (sessionStorage.getItem(ssoSignedOutStorageKey)) {
-        sessionStorage.removeItem(ssoSignedOutStorageKey);
-        setShowSsoFallback(true);
-        return;
-      }
-
-      signInWithSso();
-    }
-
-    const fallbackTimer = setTimeout(() => setShowSsoFallback(true), 4000);
-    return () => clearTimeout(fallbackTimer);
-  }, [signInWithSso]);
-
   const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
@@ -227,42 +161,6 @@ export function SignInView() {
       setIsVerifying(false);
     }
   };
-
-  // With an SSO provider configured, the deployment delegates auth entirely
-  // to that provider — the redirect is the sign-in. The view auto-fires it
-  // on mount and only shows a manual button when the redirect is skipped
-  // (right after sign-out) or didn't happen (error, blocked navigation).
-  if (ssoProvider) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-adam-bg-dark p-4">
-        <div className="w-full max-w-md">
-          <div className="flex flex-col gap-4 rounded-lg bg-adam-bg-secondary-dark p-8 shadow-md">
-            <div className="mb-4 flex flex-col items-center justify-center">
-              <div>
-                <img
-                  src={`${import.meta.env.BASE_URL}/cadam-logo.svg`}
-                  alt="CADAM Logo"
-                  className="w-32"
-                />
-              </div>
-            </div>
-            {showSsoFallback ? (
-              // Not disabled while pending: the mutation ends in a page
-              // navigation, and a re-click just re-issues the same redirect.
-              <Button onClick={() => signInWithSso()} className="w-full p-6">
-                {ssoLabel}
-              </Button>
-            ) : (
-              <div className="flex items-center justify-center gap-2 p-6 text-sm text-gray-400">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Redirecting to sign in...
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-    );
-  }
 
   if (magicLinkSent) {
     return (

--- a/src/views/SignUpEmailView.tsx
+++ b/src/views/SignUpEmailView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate, Link, useLocation } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -6,12 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
-import {
-  supabase,
-  ssoProvider,
-  ssoLabel,
-  ssoSignedOutStorageKey,
-} from '@/lib/supabase';
+import { supabase } from '@/lib/supabase';
 import { useMutation } from '@tanstack/react-query';
 import { GoogleIcon } from '@/components/icons/CompanyIcons';
 import { validateRedirectUrl } from '@/lib/utils';
@@ -71,67 +66,6 @@ export function SignUpEmailView() {
       },
     });
 
-  const [showSsoFallback, setShowSsoFallback] = useState(false);
-  const hasAutoFiredSso = useRef(false);
-
-  const { mutate: signInWithSso } = useMutation({
-    mutationFn: async () => {
-      if (!ssoProvider) return;
-
-      // Use Supabase's built-in redirectTo parameter with validated URL
-      const redirectTo =
-        redirectPath !== '/'
-          ? getAppRedirectUrl(redirectPath)
-          : getAppRedirectUrl('/');
-
-      // signInWithOAuth reports provider/config failures via the returned
-      // error rather than throwing — surface it so onError shows the toast.
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: ssoProvider,
-        options: {
-          redirectTo,
-        },
-      });
-      if (error) {
-        throw error;
-      }
-    },
-    onError: (error) => {
-      // The auto-redirect failed — leave the manual button on screen.
-      setShowSsoFallback(true);
-      toast({
-        title: 'Whoopsies',
-        description:
-          error instanceof Error ? error.message : 'Something went wrong',
-        variant: 'destructive',
-      });
-    },
-  });
-
-  // In SSO mode the redirect is the sign-in: fire it on mount, exactly once
-  // (StrictMode re-runs effects in dev). Skip it right after an explicit
-  // sign-out — otherwise the still-live provider session would sign the user
-  // straight back in — and fall back to a manual button if the redirect
-  // hasn't happened after a few seconds, so nobody is stranded.
-  useEffect(() => {
-    if (!ssoProvider) return;
-
-    if (!hasAutoFiredSso.current) {
-      hasAutoFiredSso.current = true;
-
-      if (sessionStorage.getItem(ssoSignedOutStorageKey)) {
-        sessionStorage.removeItem(ssoSignedOutStorageKey);
-        setShowSsoFallback(true);
-        return;
-      }
-
-      signInWithSso();
-    }
-
-    const fallbackTimer = setTimeout(() => setShowSsoFallback(true), 4000);
-    return () => clearTimeout(fallbackTimer);
-  }, [signInWithSso]);
-
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -178,42 +112,6 @@ export function SignUpEmailView() {
       setIsLoading(false);
     }
   };
-
-  // With an SSO provider configured, the deployment delegates auth entirely
-  // to that provider — the redirect is the sign-in. The view auto-fires it
-  // on mount and only shows a manual button when the redirect is skipped
-  // (right after sign-out) or didn't happen (error, blocked navigation).
-  if (ssoProvider) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-adam-bg-dark p-4">
-        <div className="w-full max-w-md">
-          <div className="rounded-lg bg-adam-bg-secondary-dark p-8 shadow-md">
-            <div className="mb-4 flex flex-col items-center justify-center gap-2">
-              <img
-                src={`${import.meta.env.BASE_URL}/cadam-logo.svg`}
-                alt="CADAM Logo"
-                className="h-8 w-auto"
-              />
-            </div>
-            <div className="w-full py-2">
-              {showSsoFallback ? (
-                // Not disabled while pending: the mutation ends in a page
-                // navigation, and a re-click just re-issues the same redirect.
-                <Button onClick={() => signInWithSso()} className="w-full p-6">
-                  {ssoLabel}
-                </Button>
-              ) : (
-                <div className="flex items-center justify-center gap-2 p-6 text-sm text-gray-400">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Redirecting to sign in...
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-adam-bg-dark p-4">

--- a/src/views/SignUpView.tsx
+++ b/src/views/SignUpView.tsx
@@ -1,17 +1,11 @@
 import { Link, useNavigate, useLocation } from '@tanstack/react-router';
-import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
-import {
-  supabase,
-  ssoProvider,
-  ssoLabel,
-  ssoSignedOutStorageKey,
-} from '@/lib/supabase';
+import { supabase } from '@/lib/supabase';
 import { useMutation } from '@tanstack/react-query';
 import { GoogleIcon } from '@/components/icons/CompanyIcons';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import { validateRedirectUrl } from '@/lib/utils';
 
 function getAppRedirectUrl(path: string) {
@@ -63,103 +57,6 @@ export function SignUpView() {
         });
       },
     });
-
-  const [showSsoFallback, setShowSsoFallback] = useState(false);
-  const hasAutoFiredSso = useRef(false);
-
-  const { mutate: signInWithSso } = useMutation({
-    mutationFn: async () => {
-      if (!ssoProvider) return;
-
-      // Use Supabase's built-in redirectTo parameter with validated URL
-      const redirectTo =
-        redirectPath !== '/'
-          ? getAppRedirectUrl(redirectPath)
-          : getAppRedirectUrl('/');
-
-      // signInWithOAuth reports provider/config failures via the returned
-      // error rather than throwing — surface it so onError shows the toast.
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: ssoProvider,
-        options: {
-          redirectTo,
-        },
-      });
-      if (error) {
-        throw error;
-      }
-    },
-    onError: (error) => {
-      // The auto-redirect failed — leave the manual button on screen.
-      setShowSsoFallback(true);
-      toast({
-        title: 'Whoopsies',
-        description:
-          error instanceof Error ? error.message : 'Something went wrong',
-        variant: 'destructive',
-      });
-    },
-  });
-
-  // In SSO mode the redirect is the sign-in: fire it on mount, exactly once
-  // (StrictMode re-runs effects in dev). Skip it right after an explicit
-  // sign-out — otherwise the still-live provider session would sign the user
-  // straight back in — and fall back to a manual button if the redirect
-  // hasn't happened after a few seconds, so nobody is stranded.
-  useEffect(() => {
-    if (!ssoProvider) return;
-
-    if (!hasAutoFiredSso.current) {
-      hasAutoFiredSso.current = true;
-
-      if (sessionStorage.getItem(ssoSignedOutStorageKey)) {
-        sessionStorage.removeItem(ssoSignedOutStorageKey);
-        setShowSsoFallback(true);
-        return;
-      }
-
-      signInWithSso();
-    }
-
-    const fallbackTimer = setTimeout(() => setShowSsoFallback(true), 4000);
-    return () => clearTimeout(fallbackTimer);
-  }, [signInWithSso]);
-
-  // With an SSO provider configured, the deployment delegates auth entirely
-  // to that provider — the redirect is the sign-in. The view auto-fires it
-  // on mount and only shows a manual button when the redirect is skipped
-  // (right after sign-out) or didn't happen (error, blocked navigation).
-  if (ssoProvider) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-adam-bg-dark p-4">
-        <div className="w-full max-w-md">
-          <div className="rounded-lg bg-adam-bg-secondary-dark p-8 shadow-md">
-            <div className="mb-4 flex flex-col items-center justify-center gap-2">
-              <img
-                src={`${import.meta.env.BASE_URL}/cadam-logo.svg`}
-                alt="CADAM Logo"
-                className="h-8 w-auto"
-              />
-            </div>
-            <div className="w-full py-2">
-              {showSsoFallback ? (
-                // Not disabled while pending: the mutation ends in a page
-                // navigation, and a re-click just re-issues the same redirect.
-                <Button onClick={() => signInWithSso()} className="w-full p-6">
-                  {ssoLabel}
-                </Button>
-              ) : (
-                <div className="flex items-center justify-center gap-2 p-6 text-sm text-gray-400">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Redirecting to sign in...
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-adam-bg-dark p-4">


### PR DESCRIPTION
## What

Reworks the env-gated SSO mode (`VITE_SSO_PROVIDER`) from the `/signin`-as-a-page model to **root as the only auth surface**. Root's existing signed-out UI is untouched — same prompt view, same greeting, same Sign Up / Sign In buttons, same "Sign in or create an account" links, pixel-for-pixel. The only observable difference in SSO mode is where clicks go.

## The resting-state model

The app root is the stable signed-out state. When `VITE_SSO_PROVIDER` is set and the user is unauthenticated:

- **Root renders exactly what it renders today** (the guest prompt view). Nothing auto-fires at rest — being signed in at adam.new must NOT pull the user back into CADAM without a click. That's what gives per-app sign-out semantics.
- **The existing affordances redirect to the provider.** The top-right Sign Up / Sign In buttons, the composer's signed-out focus handler, and the bottom "Sign in / create an account" links all fire `supabase.auth.signInWithOAuth({ provider, options: { redirectTo } })` directly (shared helper in `src/lib/ssoAuth.ts`, `{error}`-throw + destructive toast; if the redirect fails or the user comes back, the page is simply still there).

## Deep links: the guard fires directly

An unauthenticated hit on a protected route (`/history`, `/settings`, `/subscription`, `/editor/$id`) no longer detours through `/signin`. `AuthGuard` fires the provider redirect itself — only a spinner renders while the browser turns around — with `redirectTo` preserving the intended URL. A once-per-mount ref guards StrictMode's double effect pass; on failure it falls back to root with a toast.

## Auth routes die in SSO mode

`/signin`, `/signup`, `/signup-email` get a `beforeLoad` that redirects to root before any view renders. Their now-dead in-view SSO branches (auto-fire + fallback button) are removed, restoring the views to their pre-SSO code. Self-host (env unset): routes and native forms render exactly as master.

## Sign-out lands at root

Both sign-out paths (sidebar `handleSignOut`, delete-account dialog) navigate to root in SSO mode — and they navigate **before** the session dies, so the guard on the current protected route can't fire the provider redirect and sign the user straight back in.

## Marker machinery deleted

The `sessionStorage` `ssoSignedOut` marker (set in `AuthProvider.signOut` / delete-account, consumed by the auth views) existed only because sign-out landed on an auto-firing route. Root doesn't auto-fire, so the whole mechanism is gone. `VITE_SSO_LABEL` is dropped too — the existing buttons keep their own labels.

## Verification (dev server, both modes)

SSO mode (`VITE_SSO_PROVIDER=custom:adam-staging`, hosted `VITE_SUPABASE_URL=https://api.adam.new`):
- Unauthenticated root shows the standard guest UI with **zero** authorize calls at rest.
- Each affordance click fires `GET https://api.adam.new/auth/v1/authorize?provider=custom%3Aadam-staging&redirect_to=http%3A%2F%2Flocalhost%3A3000%2Fcadam%2F`.
- `/signin`, `/signup`, `/signup-email` land on root with no view flash.
- Deep link to `/history` fires exactly one authorize with `redirect_to=...%2Fcadam%2Fhistory`, spinner only.
- Element-for-element fingerprint of the signed-out root is **identical** between SSO mode and flag-off.

Self-host mode (env unset):
- `/signin` renders the full native form (Google, email/password, magic-link toggle, forgot-password, sign-up link).
- Sign In button navigates to `/signin` as on master.

`npm run typecheck`, `npm run build`, `npm run lint` (0 errors) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the app root the only auth surface when `VITE_SSO_PROVIDER` is set. Unauthed clicks and guarded deep links go straight to the provider; auth routes bounce to root; sign‑out lands on root to avoid instant re‑login.

- **New Features**
  - Root triggers provider OAuth for Sign Up/Sign In, composer focus, and footer links via `signInWithSsoProvider` with `redirectTo`.
  - `AuthGuard` redirects unauthenticated deep links directly to the provider (spinner only) and preserves the intended URL; uses module-level `toast` to keep effect deps identical to master.
  - `/signin`, `/signup`, `/signup-email` redirect to root in SSO mode; native forms remain for non‑SSO.
  - Sign‑out (sidebar and delete‑account) navigates to root before ending the session to avoid bounce‑back.
  - Removed the `sessionStorage` sign‑out marker and `VITE_SSO_LABEL`; added `src/lib/ssoAuth.ts`.

- **Migration**
  - Set `VITE_SSO_PROVIDER` to enable SSO‑only mode.
  - Remove `VITE_SSO_LABEL` from all environments.
  - No changes when unset (self‑host mode behaves as before).

<sup>Written for commit f35e79e42d8b75d211b6b02c52175c06ebfc07c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

