### PR TITLE
feat(settings): manage account in the identity provider under SSO

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -10,6 +10,10 @@ SUPABASE_SERVICE_ROLE_KEY="<Test Service Role Key>"
 # to keep the native auth UI (the local Supabase CLI stack can't host
 # custom OIDC providers).
 # VITE_SSO_PROVIDER="custom:my-idp"
+# Optional: when SSO owns the identity, point profile / password / delete
+# management at the provider's account page (the accounts.google.com model)
+# instead of editing them in-app. Unset keeps the native in-app controls.
+# VITE_ACCOUNT_URL="https://accounts.example.com/account"
 VITE_POSTHOG_PROJECT_KEY="<Test PostHog Project Key>"
 VITE_SENTRY_ENVIRONMENT="local"
 VITE_SENTRY_DSN="<Sentry DSN>"

--- a/src/components/chat/UserAvatar.tsx
+++ b/src/components/chat/UserAvatar.tsx
@@ -1,14 +1,27 @@
+import { useAuth } from '@/contexts/AuthContext';
 import { useProfile, useAvatarUrl } from '@/services/profileService';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { getInitials } from '@/lib/utils';
 
 export function UserAvatar({ className }: { className?: string }) {
+  const { user } = useAuth();
   const { data: profile } = useProfile();
   const { data: avatarUrl } = useAvatarUrl(profile?.avatar_path);
 
+  // A self-uploaded avatar wins; otherwise fall back to the identity provider's
+  // profile picture. Supabase GoTrue stores the OIDC `picture` claim in
+  // user_metadata (as `avatar_url`, and sometimes `picture`), so this renders
+  // the SSO account's photo instead of the generated initials. Provider-
+  // agnostic — works for any Supabase OAuth provider, not just the hosted SSO.
+  const metadata = user?.user_metadata as
+    | { avatar_url?: string; picture?: string }
+    | undefined;
+  const providerAvatar = metadata?.avatar_url || metadata?.picture;
+  const src = avatarUrl || providerAvatar || undefined;
+
   return (
     <Avatar className={className}>
-      <AvatarImage src={avatarUrl || undefined} />
+      <AvatarImage src={src} />
       <AvatarFallback>{getInitials(profile?.full_name || null)}</AvatarFallback>
     </Avatar>
   );

--- a/src/components/chat/UserAvatar.tsx
+++ b/src/components/chat/UserAvatar.tsx
@@ -2,22 +2,30 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useProfile, useAvatarUrl } from '@/services/profileService';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { getInitials } from '@/lib/utils';
+import { accountUrl, ssoProvider } from '@/lib/supabase';
 
 export function UserAvatar({ className }: { className?: string }) {
   const { user } = useAuth();
   const { data: profile } = useProfile();
   const { data: avatarUrl } = useAvatarUrl(profile?.avatar_path);
 
-  // A self-uploaded avatar wins; otherwise fall back to the identity provider's
-  // profile picture. Supabase GoTrue stores the OIDC `picture` claim in
-  // user_metadata (as `avatar_url`, and sometimes `picture`), so this renders
-  // the SSO account's photo instead of the generated initials. Provider-
-  // agnostic — works for any Supabase OAuth provider, not just the hosted SSO.
+  // Supabase GoTrue stores the OIDC `picture` claim in user_metadata (as
+  // `avatar_url`, and sometimes `picture`), so `providerAvatar` is the SSO
+  // account's photo; `avatarUrl` is the CADAM-local, self-uploaded picture.
+  // Provider-agnostic — works for any Supabase OAuth provider.
   const metadata = user?.user_metadata as
     | { avatar_url?: string; picture?: string }
     | undefined;
   const providerAvatar = metadata?.avatar_url || metadata?.picture;
-  const src = avatarUrl || providerAvatar || undefined;
+
+  // When SSO owns the identity (same condition SettingsView uses to make the
+  // account read-only), the provider photo is the single source of truth, so it
+  // wins — a stale CADAM-local upload can no longer diverge from the Adam photo.
+  // In self-host mode the self-uploaded avatar keeps winning.
+  const ssoManaged = Boolean(ssoProvider && accountUrl);
+  const src = ssoManaged
+    ? providerAvatar || avatarUrl || undefined
+    : avatarUrl || providerAvatar || undefined;
 
   return (
     <Avatar className={className}>

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -19,6 +19,15 @@ export const isSupabaseConfigMissing = !rawSupabaseUrl || !rawSupabaseKey;
 export const ssoProvider = (import.meta.env.VITE_SSO_PROVIDER ||
   null) as Provider | null;
 
+// Optional external account-management URL. When SSO mode is on and the
+// identity is owned by an external provider, the deployment can point profile
+// / password / delete management at that provider's account page (the
+// accounts.google.com model) instead of editing them here. Set
+// VITE_ACCOUNT_URL to that page's URL; when unset (or when SSO is off) the
+// native in-app account controls are used. Provider-agnostic — self-hosters
+// point it anywhere or leave it blank.
+export const accountUrl = (import.meta.env.VITE_ACCOUNT_URL || '') as string;
+
 // Fallback values keep the client constructable so imports don't throw
 // when env vars are missing. The app should gate on isSupabaseConfigMissing
 // and avoid making real requests in this state.

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -18,6 +18,8 @@ import { useProfile, useUpdateProfile } from '@/services/profileService';
 import { AvatarUpdateDialog } from '@/components/auth/AvatarUpdateDialog';
 import { useTokenPacks } from '@/hooks/useTokenPacks';
 import { PLAN_DISPLAY_NAMES } from '@/config/plan-features';
+import { accountUrl, ssoProvider } from '@/lib/supabase';
+import { UserAvatar } from '@/components/chat/UserAvatar';
 
 function formatPeriodEnd(iso: string | null | undefined): string | null {
   if (!iso) return null;
@@ -137,6 +139,12 @@ export default function SettingsView() {
       },
     });
 
+  // When SSO owns the identity and an external account page is configured,
+  // profile / email / password / delete are managed there (the
+  // accounts.google.com model) rather than edited in-app. Self-host (no SSO
+  // or no account URL) keeps the native controls.
+  const ssoManaged = Boolean(ssoProvider && accountUrl);
+
   const tierLabel = `Adam ${PLAN_DISPLAY_NAMES[level]}`;
 
   const tierAccent =
@@ -165,93 +173,130 @@ export default function SettingsView() {
               Account
             </h2>
 
-            <div className="divide-y divide-adam-neutral-800">
-              <div className="flex items-center justify-between gap-4 pb-5">
-                <div className="flex min-w-0 flex-1 items-center gap-3">
-                  <AvatarUpdateDialog />
-                  {editingName ? (
-                    <Input
-                      ref={nameInputRef}
-                      value={newName}
-                      className="h-9 w-full max-w-xs"
-                      onChange={(e) => setNewName(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && !e.shiftKey) {
-                          e.preventDefault();
-                          handleUpdateName();
-                        }
-                      }}
-                    />
-                  ) : (
-                    <div className="min-w-0 truncate text-sm text-adam-neutral-50">
+            {ssoManaged ? (
+              <div className="flex flex-col gap-5">
+                <div className="flex items-center gap-3">
+                  <UserAvatar className="h-10 w-10" />
+                  <div className="min-w-0">
+                    <div className="truncate text-sm text-adam-neutral-50">
                       {profile?.full_name || user?.email}
                     </div>
+                    <div className="mt-0.5 truncate text-xs text-adam-neutral-200">
+                      {user?.email}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between gap-4 border-t border-adam-neutral-800 pt-5">
+                  <div className="min-w-0">
+                    <div className="text-sm text-adam-neutral-50">
+                      Manage account
+                    </div>
+                    <div className="mt-0.5 text-xs leading-relaxed text-adam-neutral-200">
+                      Update your name, email, password, and account details in
+                      your Adam account.
+                    </div>
+                  </div>
+                  <a
+                    href={accountUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex-shrink-0"
+                  >
+                    <Button variant="dark" className="rounded-full font-light">
+                      Manage account
+                    </Button>
+                  </a>
+                </div>
+              </div>
+            ) : (
+              <div className="divide-y divide-adam-neutral-800">
+                <div className="flex items-center justify-between gap-4 pb-5">
+                  <div className="flex min-w-0 flex-1 items-center gap-3">
+                    <AvatarUpdateDialog />
+                    {editingName ? (
+                      <Input
+                        ref={nameInputRef}
+                        value={newName}
+                        className="h-9 w-full max-w-xs"
+                        onChange={(e) => setNewName(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && !e.shiftKey) {
+                            e.preventDefault();
+                            handleUpdateName();
+                          }
+                        }}
+                      />
+                    ) : (
+                      <div className="min-w-0 truncate text-sm text-adam-neutral-50">
+                        {profile?.full_name || user?.email}
+                      </div>
+                    )}
+                  </div>
+                  {editingName ? (
+                    <div className="flex flex-shrink-0 items-center gap-2">
+                      <Button
+                        onClick={() => handleUpdateName()}
+                        variant="light"
+                        disabled={isUpdateLoading}
+                        className="rounded-full font-light"
+                      >
+                        {isUpdateLoading ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          'Save'
+                        )}
+                      </Button>
+                      <Button
+                        onClick={() => {
+                          setEditingName(false);
+                          setNewName(profile?.full_name || '');
+                        }}
+                        variant="dark"
+                        className="rounded-full font-light"
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button
+                      onClick={() => setEditingName(true)}
+                      variant="dark"
+                      className="flex-shrink-0 rounded-full font-light"
+                    >
+                      Edit
+                    </Button>
                   )}
                 </div>
-                {editingName ? (
-                  <div className="flex flex-shrink-0 items-center gap-2">
-                    <Button
-                      onClick={() => handleUpdateName()}
-                      variant="light"
-                      disabled={isUpdateLoading}
-                      className="rounded-full font-light"
-                    >
-                      {isUpdateLoading ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        'Save'
-                      )}
-                    </Button>
-                    <Button
-                      onClick={() => {
-                        setEditingName(false);
-                        setNewName(profile?.full_name || '');
-                      }}
-                      variant="dark"
-                      className="rounded-full font-light"
-                    >
-                      Cancel
-                    </Button>
+
+                <div className="py-5">
+                  <div className="text-sm text-adam-neutral-50">Email</div>
+                  <div className="mt-0.5 truncate text-xs text-adam-neutral-200">
+                    {user?.email}
                   </div>
-                ) : (
+                </div>
+
+                <div className="flex items-center justify-between gap-4 pt-5">
+                  <div className="min-w-0">
+                    <div className="text-sm text-adam-neutral-50">Password</div>
+                    <div className="mt-0.5 text-xs text-adam-neutral-200">
+                      Send a reset link to your email
+                    </div>
+                  </div>
                   <Button
-                    onClick={() => setEditingName(true)}
+                    onClick={() => handleResetPassword()}
+                    disabled={isResetLoading}
                     variant="dark"
                     className="flex-shrink-0 rounded-full font-light"
                   >
-                    Edit
+                    {isResetLoading ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      'Reset Password'
+                    )}
                   </Button>
-                )}
-              </div>
-
-              <div className="py-5">
-                <div className="text-sm text-adam-neutral-50">Email</div>
-                <div className="mt-0.5 truncate text-xs text-adam-neutral-200">
-                  {user?.email}
                 </div>
               </div>
-
-              <div className="flex items-center justify-between gap-4 pt-5">
-                <div className="min-w-0">
-                  <div className="text-sm text-adam-neutral-50">Password</div>
-                  <div className="mt-0.5 text-xs text-adam-neutral-200">
-                    Send a reset link to your email
-                  </div>
-                </div>
-                <Button
-                  onClick={() => handleResetPassword()}
-                  disabled={isResetLoading}
-                  variant="dark"
-                  className="flex-shrink-0 rounded-full font-light"
-                >
-                  {isResetLoading ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    'Reset Password'
-                  )}
-                </Button>
-              </div>
-            </div>
+            )}
           </section>
 
           {/* Notifications */}
@@ -418,31 +463,35 @@ export default function SettingsView() {
             </div>
           </section>
 
-          {/* Data & Privacy */}
-          <section className="rounded-xl border border-adam-neutral-800 bg-adam-background-2 p-6">
-            <h2 className="mb-5 text-sm font-medium text-adam-neutral-50">
-              Data and privacy
-            </h2>
+          {/* Data & Privacy — when SSO owns the identity, account deletion is
+              handled in the Adam account ("Manage account" above), so the
+              in-app delete is hidden to avoid a partial, one-sided delete. */}
+          {!ssoManaged && (
+            <section className="rounded-xl border border-adam-neutral-800 bg-adam-background-2 p-6">
+              <h2 className="mb-5 text-sm font-medium text-adam-neutral-50">
+                Data and privacy
+              </h2>
 
-            <div className="flex items-start justify-between gap-4">
-              <div className="min-w-0 flex-1">
-                <div className="text-sm text-adam-neutral-50">
-                  Delete account
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm text-adam-neutral-50">
+                    Delete account
+                  </div>
+                  <div className="mt-0.5 text-xs leading-relaxed text-adam-neutral-200">
+                    Permanently delete your account and all associated data.
+                  </div>
                 </div>
-                <div className="mt-0.5 text-xs leading-relaxed text-adam-neutral-200">
-                  Permanently delete your account and all associated data.
-                </div>
+                <DeleteAccountDialog>
+                  <Button
+                    className="flex-shrink-0 rounded-full font-light"
+                    variant="destructive"
+                  >
+                    Delete
+                  </Button>
+                </DeleteAccountDialog>
               </div>
-              <DeleteAccountDialog>
-                <Button
-                  className="flex-shrink-0 rounded-full font-light"
-                  variant="destructive"
-                >
-                  Delete
-                </Button>
-              </DeleteAccountDialog>
-            </div>
-          </section>
+            </section>
+          )}
 
           <div className="mt-2 flex items-center justify-center gap-3 text-xs text-adam-neutral-300">
             <Link

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -193,7 +193,7 @@ export default function SettingsView() {
                     </div>
                     <div className="mt-0.5 text-xs leading-relaxed text-adam-neutral-200">
                       Update your name, email, password, and account details in
-                      your Adam account.
+                      your account.
                     </div>
                   </div>
                   <a


### PR DESCRIPTION
Companion to the workspace `/account` page. When hosted CADAM signs in through Adam ID, profile/email/password/delete are owned by the Adam account — so editing them here (in CADAM's own Supabase) creates two copies that can't stay in sync. This routes account management to the provider, the accounts.google.com model.

## What changed (SSO-managed mode only)

When `VITE_SSO_PROVIDER` **and** `VITE_ACCOUNT_URL` are set, the Settings → Account section becomes:
- **Read-only identity**: avatar + name + email (from the session/profile).
- A single **"Manage account"** button that opens the configured account page in a new tab.
- The in-app **Delete account** section is **hidden** — deletion is owned by the provider account, so exposing a CADAM-only delete would be a one-sided, partial delete.

Notifications and Billing are unchanged (CADAM-owned preferences).

## Self-host / GPL hygiene

`VITE_ACCOUNT_URL` unset (or SSO off) ⇒ **byte-identical to today**: the native editable name / avatar / password-reset controls and the Delete account section render exactly as before. The URL is provider-agnostic — nothing hardcodes a specific product, so self-hosters point it anywhere or leave it blank.

## Verification

- `npm run typecheck` clean, `npm run build` green, prettier/eslint clean.
- Native controls confirmed intact in the non-SSO branch (self-host path unchanged).
- A signed-in screenshot will come from prod once `VITE_ACCOUNT_URL` is set (it's a prod-only env; PR previews don't carry it).

Operator step on merge: set `VITE_ACCOUNT_URL=https://accounts.adam.new/account` on the hosted CADAM Vercel project (after the workspace `/account` PR ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route account management to the identity provider under SSO, with a read-only Account view and a “Manage account” link. Provider profile photos are now used, and under SSO they override local uploads.

- New Features
  - Enable SSO-managed mode when `VITE_SSO_PROVIDER` and `VITE_ACCOUNT_URL` are set.
  - Read-only identity (avatar, name, email) with a “Manage account” button; in-app Delete is hidden.
  - Avatar behavior: under SSO, the provider photo (`user_metadata.avatar_url`/`picture`) is the source of truth; otherwise, local upload wins with provider as fallback.
  - Manage-account copy is provider-agnostic.

- Migration
  - Hosted: set `VITE_ACCOUNT_URL=https://accounts.adam.new/account` after the workspace `/account` PR ships.
  - No action needed for self-hosted or when SSO is off.

<sup>Written for commit cbdb782991aa0d8a4f542011b4b65ab1701d26cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

