### PR TITLE
feat(account): internal server-to-server account-purge endpoint

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -24,3 +24,9 @@ ENVIRONMENT="local"
 ADAM_URL="<Adam URL or dev URL>"
 WEBHOOK_BASE_URL="<Public TanStack App URL>"
 NGROK_URL="<NGROK URL>"
+# Shared bearer secret for the internal server-to-server account-purge endpoint
+# (POST /api/internal/account/delete). The upstream identity provider's purge
+# worker presents this to erase a user's data here when their account is
+# deleted. Leave unset to hard-disable the endpoint (it 503s every request).
+# Provider-agnostic: any deployment sets its own value.
+ACCOUNT_PURGE_SECRET="<Shared account-purge secret>"

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -8,273 +8,283 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as UpdatePasswordRouteImport } from './routes/update-password'
-import { Route as TermsOfServiceRouteImport } from './routes/terms-of-service'
-import { Route as SignupEmailRouteImport } from './routes/signup-email'
-import { Route as SignupRouteImport } from './routes/signup'
-import { Route as SigninRouteImport } from './routes/signin'
-import { Route as ResetPasswordRouteImport } from './routes/reset-password'
-import { Route as PrivacyPolicyRouteImport } from './routes/privacy-policy'
-import { Route as ConfirmEmailRouteImport } from './routes/confirm-email'
-import { Route as LayoutRouteImport } from './routes/_layout'
-import { Route as LayoutIndexRouteImport } from './routes/_layout/index'
-import { Route as ApiTitleGeneratorRouteImport } from './routes/api/title-generator'
-import { Route as ApiPromptGeneratorRouteImport } from './routes/api/prompt-generator'
-import { Route as ApiParametricChatRouteImport } from './routes/api/parametric-chat'
-import { Route as ApiMeshRouteImport } from './routes/api/mesh'
-import { Route as ApiFalWebhookRouteImport } from './routes/api/fal-webhook'
-import { Route as ApiDeleteUserRouteImport } from './routes/api/delete-user'
-import { Route as ApiCreativeChatRouteImport } from './routes/api/creative-chat'
-import { Route as ApiBillingStatusRouteImport } from './routes/api/billing-status'
-import { Route as ApiBillingProductsRouteImport } from './routes/api/billing-products'
-import { Route as ApiBillingPortalRouteImport } from './routes/api/billing-portal'
-import { Route as ApiBillingCheckoutRouteImport } from './routes/api/billing-checkout'
-import { Route as LayoutAuthRouteImport } from './routes/_layout/_auth'
-import { Route as LayoutSplatRouteImport } from './routes/_layout/$'
-import { Route as ApiJacksonPollockSplatRouteImport } from './routes/api/jackson-pollock/$'
-import { Route as LayoutShareIdRouteImport } from './routes/_layout/share/$id'
-import { Route as LayoutAuthSubscriptionRouteImport } from './routes/_layout/_auth/subscription'
-import { Route as LayoutAuthSettingsRouteImport } from './routes/_layout/_auth/settings'
-import { Route as LayoutAuthHistoryRouteImport } from './routes/_layout/_auth/history'
-import { Route as LayoutAuthEditorIdRouteImport } from './routes/_layout/_auth/editor/$id'
+import { Route as rootRouteImport } from './routes/__root';
+import { Route as UpdatePasswordRouteImport } from './routes/update-password';
+import { Route as TermsOfServiceRouteImport } from './routes/terms-of-service';
+import { Route as SignupEmailRouteImport } from './routes/signup-email';
+import { Route as SignupRouteImport } from './routes/signup';
+import { Route as SigninRouteImport } from './routes/signin';
+import { Route as ResetPasswordRouteImport } from './routes/reset-password';
+import { Route as PrivacyPolicyRouteImport } from './routes/privacy-policy';
+import { Route as ConfirmEmailRouteImport } from './routes/confirm-email';
+import { Route as LayoutRouteImport } from './routes/_layout';
+import { Route as LayoutIndexRouteImport } from './routes/_layout/index';
+import { Route as ApiTitleGeneratorRouteImport } from './routes/api/title-generator';
+import { Route as ApiPromptGeneratorRouteImport } from './routes/api/prompt-generator';
+import { Route as ApiParametricChatRouteImport } from './routes/api/parametric-chat';
+import { Route as ApiMeshRouteImport } from './routes/api/mesh';
+import { Route as ApiFalWebhookRouteImport } from './routes/api/fal-webhook';
+import { Route as ApiDeleteUserRouteImport } from './routes/api/delete-user';
+import { Route as ApiCreativeChatRouteImport } from './routes/api/creative-chat';
+import { Route as ApiBillingStatusRouteImport } from './routes/api/billing-status';
+import { Route as ApiBillingProductsRouteImport } from './routes/api/billing-products';
+import { Route as ApiBillingPortalRouteImport } from './routes/api/billing-portal';
+import { Route as ApiBillingCheckoutRouteImport } from './routes/api/billing-checkout';
+import { Route as LayoutAuthRouteImport } from './routes/_layout/_auth';
+import { Route as LayoutSplatRouteImport } from './routes/_layout/$';
+import { Route as ApiJacksonPollockSplatRouteImport } from './routes/api/jackson-pollock/$';
+import { Route as LayoutShareIdRouteImport } from './routes/_layout/share/$id';
+import { Route as LayoutAuthSubscriptionRouteImport } from './routes/_layout/_auth/subscription';
+import { Route as LayoutAuthSettingsRouteImport } from './routes/_layout/_auth/settings';
+import { Route as LayoutAuthHistoryRouteImport } from './routes/_layout/_auth/history';
+import { Route as ApiInternalAccountDeleteRouteImport } from './routes/api/internal/account/delete';
+import { Route as LayoutAuthEditorIdRouteImport } from './routes/_layout/_auth/editor/$id';
 
 const UpdatePasswordRoute = UpdatePasswordRouteImport.update({
   id: '/update-password',
   path: '/update-password',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const TermsOfServiceRoute = TermsOfServiceRouteImport.update({
   id: '/terms-of-service',
   path: '/terms-of-service',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const SignupEmailRoute = SignupEmailRouteImport.update({
   id: '/signup-email',
   path: '/signup-email',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
   path: '/signup',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const SigninRoute = SigninRouteImport.update({
   id: '/signin',
   path: '/signin',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
   id: '/reset-password',
   path: '/reset-password',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const PrivacyPolicyRoute = PrivacyPolicyRouteImport.update({
   id: '/privacy-policy',
   path: '/privacy-policy',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ConfirmEmailRoute = ConfirmEmailRouteImport.update({
   id: '/confirm-email',
   path: '/confirm-email',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LayoutRoute = LayoutRouteImport.update({
   id: '/_layout',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LayoutIndexRoute = LayoutIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => LayoutRoute,
-} as any)
+} as any);
 const ApiTitleGeneratorRoute = ApiTitleGeneratorRouteImport.update({
   id: '/api/title-generator',
   path: '/api/title-generator',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiPromptGeneratorRoute = ApiPromptGeneratorRouteImport.update({
   id: '/api/prompt-generator',
   path: '/api/prompt-generator',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiParametricChatRoute = ApiParametricChatRouteImport.update({
   id: '/api/parametric-chat',
   path: '/api/parametric-chat',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiMeshRoute = ApiMeshRouteImport.update({
   id: '/api/mesh',
   path: '/api/mesh',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiFalWebhookRoute = ApiFalWebhookRouteImport.update({
   id: '/api/fal-webhook',
   path: '/api/fal-webhook',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiDeleteUserRoute = ApiDeleteUserRouteImport.update({
   id: '/api/delete-user',
   path: '/api/delete-user',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiCreativeChatRoute = ApiCreativeChatRouteImport.update({
   id: '/api/creative-chat',
   path: '/api/creative-chat',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiBillingStatusRoute = ApiBillingStatusRouteImport.update({
   id: '/api/billing-status',
   path: '/api/billing-status',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiBillingProductsRoute = ApiBillingProductsRouteImport.update({
   id: '/api/billing-products',
   path: '/api/billing-products',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiBillingPortalRoute = ApiBillingPortalRouteImport.update({
   id: '/api/billing-portal',
   path: '/api/billing-portal',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiBillingCheckoutRoute = ApiBillingCheckoutRouteImport.update({
   id: '/api/billing-checkout',
   path: '/api/billing-checkout',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LayoutAuthRoute = LayoutAuthRouteImport.update({
   id: '/_auth',
   getParentRoute: () => LayoutRoute,
-} as any)
+} as any);
 const LayoutSplatRoute = LayoutSplatRouteImport.update({
   id: '/$',
   path: '/$',
   getParentRoute: () => LayoutRoute,
-} as any)
+} as any);
 const ApiJacksonPollockSplatRoute = ApiJacksonPollockSplatRouteImport.update({
   id: '/api/jackson-pollock/$',
   path: '/api/jackson-pollock/$',
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LayoutShareIdRoute = LayoutShareIdRouteImport.update({
   id: '/share/$id',
   path: '/share/$id',
   getParentRoute: () => LayoutRoute,
-} as any)
+} as any);
 const LayoutAuthSubscriptionRoute = LayoutAuthSubscriptionRouteImport.update({
   id: '/subscription',
   path: '/subscription',
   getParentRoute: () => LayoutAuthRoute,
-} as any)
+} as any);
 const LayoutAuthSettingsRoute = LayoutAuthSettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
   getParentRoute: () => LayoutAuthRoute,
-} as any)
+} as any);
 const LayoutAuthHistoryRoute = LayoutAuthHistoryRouteImport.update({
   id: '/history',
   path: '/history',
   getParentRoute: () => LayoutAuthRoute,
-} as any)
+} as any);
+const ApiInternalAccountDeleteRoute =
+  ApiInternalAccountDeleteRouteImport.update({
+    id: '/api/internal/account/delete',
+    path: '/api/internal/account/delete',
+    getParentRoute: () => rootRouteImport,
+  } as any);
 const LayoutAuthEditorIdRoute = LayoutAuthEditorIdRouteImport.update({
   id: '/editor/$id',
   path: '/editor/$id',
   getParentRoute: () => LayoutAuthRoute,
-} as any)
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof LayoutIndexRoute
-  '/confirm-email': typeof ConfirmEmailRoute
-  '/privacy-policy': typeof PrivacyPolicyRoute
-  '/reset-password': typeof ResetPasswordRoute
-  '/signin': typeof SigninRoute
-  '/signup': typeof SignupRoute
-  '/signup-email': typeof SignupEmailRoute
-  '/terms-of-service': typeof TermsOfServiceRoute
-  '/update-password': typeof UpdatePasswordRoute
-  '/$': typeof LayoutSplatRoute
-  '/api/billing-checkout': typeof ApiBillingCheckoutRoute
-  '/api/billing-portal': typeof ApiBillingPortalRoute
-  '/api/billing-products': typeof ApiBillingProductsRoute
-  '/api/billing-status': typeof ApiBillingStatusRoute
-  '/api/creative-chat': typeof ApiCreativeChatRoute
-  '/api/delete-user': typeof ApiDeleteUserRoute
-  '/api/fal-webhook': typeof ApiFalWebhookRoute
-  '/api/mesh': typeof ApiMeshRoute
-  '/api/parametric-chat': typeof ApiParametricChatRoute
-  '/api/prompt-generator': typeof ApiPromptGeneratorRoute
-  '/api/title-generator': typeof ApiTitleGeneratorRoute
-  '/history': typeof LayoutAuthHistoryRoute
-  '/settings': typeof LayoutAuthSettingsRoute
-  '/subscription': typeof LayoutAuthSubscriptionRoute
-  '/share/$id': typeof LayoutShareIdRoute
-  '/api/jackson-pollock/$': typeof ApiJacksonPollockSplatRoute
-  '/editor/$id': typeof LayoutAuthEditorIdRoute
+  '/': typeof LayoutIndexRoute;
+  '/confirm-email': typeof ConfirmEmailRoute;
+  '/privacy-policy': typeof PrivacyPolicyRoute;
+  '/reset-password': typeof ResetPasswordRoute;
+  '/signin': typeof SigninRoute;
+  '/signup': typeof SignupRoute;
+  '/signup-email': typeof SignupEmailRoute;
+  '/terms-of-service': typeof TermsOfServiceRoute;
+  '/update-password': typeof UpdatePasswordRoute;
+  '/$': typeof LayoutSplatRoute;
+  '/api/billing-checkout': typeof ApiBillingCheckoutRoute;
+  '/api/billing-portal': typeof ApiBillingPortalRoute;
+  '/api/billing-products': typeof ApiBillingProductsRoute;
+  '/api/billing-status': typeof ApiBillingStatusRoute;
+  '/api/creative-chat': typeof ApiCreativeChatRoute;
+  '/api/delete-user': typeof ApiDeleteUserRoute;
+  '/api/fal-webhook': typeof ApiFalWebhookRoute;
+  '/api/mesh': typeof ApiMeshRoute;
+  '/api/parametric-chat': typeof ApiParametricChatRoute;
+  '/api/prompt-generator': typeof ApiPromptGeneratorRoute;
+  '/api/title-generator': typeof ApiTitleGeneratorRoute;
+  '/history': typeof LayoutAuthHistoryRoute;
+  '/settings': typeof LayoutAuthSettingsRoute;
+  '/subscription': typeof LayoutAuthSubscriptionRoute;
+  '/share/$id': typeof LayoutShareIdRoute;
+  '/api/jackson-pollock/$': typeof ApiJacksonPollockSplatRoute;
+  '/editor/$id': typeof LayoutAuthEditorIdRoute;
+  '/api/internal/account/delete': typeof ApiInternalAccountDeleteRoute;
 }
 export interface FileRoutesByTo {
-  '/confirm-email': typeof ConfirmEmailRoute
-  '/privacy-policy': typeof PrivacyPolicyRoute
-  '/reset-password': typeof ResetPasswordRoute
-  '/signin': typeof SigninRoute
-  '/signup': typeof SignupRoute
-  '/signup-email': typeof SignupEmailRoute
-  '/terms-of-service': typeof TermsOfServiceRoute
-  '/update-password': typeof UpdatePasswordRoute
-  '/$': typeof LayoutSplatRoute
-  '/': typeof LayoutIndexRoute
-  '/api/billing-checkout': typeof ApiBillingCheckoutRoute
-  '/api/billing-portal': typeof ApiBillingPortalRoute
-  '/api/billing-products': typeof ApiBillingProductsRoute
-  '/api/billing-status': typeof ApiBillingStatusRoute
-  '/api/creative-chat': typeof ApiCreativeChatRoute
-  '/api/delete-user': typeof ApiDeleteUserRoute
-  '/api/fal-webhook': typeof ApiFalWebhookRoute
-  '/api/mesh': typeof ApiMeshRoute
-  '/api/parametric-chat': typeof ApiParametricChatRoute
-  '/api/prompt-generator': typeof ApiPromptGeneratorRoute
-  '/api/title-generator': typeof ApiTitleGeneratorRoute
-  '/history': typeof LayoutAuthHistoryRoute
-  '/settings': typeof LayoutAuthSettingsRoute
-  '/subscription': typeof LayoutAuthSubscriptionRoute
-  '/share/$id': typeof LayoutShareIdRoute
-  '/api/jackson-pollock/$': typeof ApiJacksonPollockSplatRoute
-  '/editor/$id': typeof LayoutAuthEditorIdRoute
+  '/confirm-email': typeof ConfirmEmailRoute;
+  '/privacy-policy': typeof PrivacyPolicyRoute;
+  '/reset-password': typeof ResetPasswordRoute;
+  '/signin': typeof SigninRoute;
+  '/signup': typeof SignupRoute;
+  '/signup-email': typeof SignupEmailRoute;
+  '/terms-of-service': typeof TermsOfServiceRoute;
+  '/update-password': typeof UpdatePasswordRoute;
+  '/$': typeof LayoutSplatRoute;
+  '/': typeof LayoutIndexRoute;
+  '/api/billing-checkout': typeof ApiBillingCheckoutRoute;
+  '/api/billing-portal': typeof ApiBillingPortalRoute;
+  '/api/billing-products': typeof ApiBillingProductsRoute;
+  '/api/billing-status': typeof ApiBillingStatusRoute;
+  '/api/creative-chat': typeof ApiCreativeChatRoute;
+  '/api/delete-user': typeof ApiDeleteUserRoute;
+  '/api/fal-webhook': typeof ApiFalWebhookRoute;
+  '/api/mesh': typeof ApiMeshRoute;
+  '/api/parametric-chat': typeof ApiParametricChatRoute;
+  '/api/prompt-generator': typeof ApiPromptGeneratorRoute;
+  '/api/title-generator': typeof ApiTitleGeneratorRoute;
+  '/history': typeof LayoutAuthHistoryRoute;
+  '/settings': typeof LayoutAuthSettingsRoute;
+  '/subscription': typeof LayoutAuthSubscriptionRoute;
+  '/share/$id': typeof LayoutShareIdRoute;
+  '/api/jackson-pollock/$': typeof ApiJacksonPollockSplatRoute;
+  '/editor/$id': typeof LayoutAuthEditorIdRoute;
+  '/api/internal/account/delete': typeof ApiInternalAccountDeleteRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/_layout': typeof LayoutRouteWithChildren
-  '/confirm-email': typeof ConfirmEmailRoute
-  '/privacy-policy': typeof PrivacyPolicyRoute
-  '/reset-password': typeof ResetPasswordRoute
-  '/signin': typeof SigninRoute
-  '/signup': typeof SignupRoute
-  '/signup-email': typeof SignupEmailRoute
-  '/terms-of-service': typeof TermsOfServiceRoute
-  '/update-password': typeof UpdatePasswordRoute
-  '/_layout/$': typeof LayoutSplatRoute
-  '/_layout/_auth': typeof LayoutAuthRouteWithChildren
-  '/api/billing-checkout': typeof ApiBillingCheckoutRoute
-  '/api/billing-portal': typeof ApiBillingPortalRoute
-  '/api/billing-products': typeof ApiBillingProductsRoute
-  '/api/billing-status': typeof ApiBillingStatusRoute
-  '/api/creative-chat': typeof ApiCreativeChatRoute
-  '/api/delete-user': typeof ApiDeleteUserRoute
-  '/api/fal-webhook': typeof ApiFalWebhookRoute
-  '/api/mesh': typeof ApiMeshRoute
-  '/api/parametric-chat': typeof ApiParametricChatRoute
-  '/api/prompt-generator': typeof ApiPromptGeneratorRoute
-  '/api/title-generator': typeof ApiTitleGeneratorRoute
-  '/_layout/': typeof LayoutIndexRoute
-  '/_layout/_auth/history': typeof LayoutAuthHistoryRoute
-  '/_layout/_auth/settings': typeof LayoutAuthSettingsRoute
-  '/_layout/_auth/subscription': typeof LayoutAuthSubscriptionRoute
-  '/_layout/share/$id': typeof LayoutShareIdRoute
-  '/api/jackson-pollock/$': typeof ApiJacksonPollockSplatRoute
-  '/_layout/_auth/editor/$id': typeof LayoutAuthEditorIdRoute
+  __root__: typeof rootRouteImport;
+  '/_layout': typeof LayoutRouteWithChildren;
+  '/confirm-email': typeof ConfirmEmailRoute;
+  '/privacy-policy': typeof PrivacyPolicyRoute;
+  '/reset-password': typeof ResetPasswordRoute;
+  '/signin': typeof SigninRoute;
+  '/signup': typeof SignupRoute;
+  '/signup-email': typeof SignupEmailRoute;
+  '/terms-of-service': typeof TermsOfServiceRoute;
+  '/update-password': typeof UpdatePasswordRoute;
+  '/_layout/$': typeof LayoutSplatRoute;
+  '/_layout/_auth': typeof LayoutAuthRouteWithChildren;
+  '/api/billing-checkout': typeof ApiBillingCheckoutRoute;
+  '/api/billing-portal': typeof ApiBillingPortalRoute;
+  '/api/billing-products': typeof ApiBillingProductsRoute;
+  '/api/billing-status': typeof ApiBillingStatusRoute;
+  '/api/creative-chat': typeof ApiCreativeChatRoute;
+  '/api/delete-user': typeof ApiDeleteUserRoute;
+  '/api/fal-webhook': typeof ApiFalWebhookRoute;
+  '/api/mesh': typeof ApiMeshRoute;
+  '/api/parametric-chat': typeof ApiParametricChatRoute;
+  '/api/prompt-generator': typeof ApiPromptGeneratorRoute;
+  '/api/title-generator': typeof ApiTitleGeneratorRoute;
+  '/_layout/': typeof LayoutIndexRoute;
+  '/_layout/_auth/history': typeof LayoutAuthHistoryRoute;
+  '/_layout/_auth/settings': typeof LayoutAuthSettingsRoute;
+  '/_layout/_auth/subscription': typeof LayoutAuthSubscriptionRoute;
+  '/_layout/share/$id': typeof LayoutShareIdRoute;
+  '/api/jackson-pollock/$': typeof ApiJacksonPollockSplatRoute;
+  '/_layout/_auth/editor/$id': typeof LayoutAuthEditorIdRoute;
+  '/api/internal/account/delete': typeof ApiInternalAccountDeleteRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
+  fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
     | '/'
     | '/confirm-email'
@@ -303,7 +313,8 @@ export interface FileRouteTypes {
     | '/share/$id'
     | '/api/jackson-pollock/$'
     | '/editor/$id'
-  fileRoutesByTo: FileRoutesByTo
+    | '/api/internal/account/delete';
+  fileRoutesByTo: FileRoutesByTo;
   to:
     | '/confirm-email'
     | '/privacy-policy'
@@ -332,6 +343,7 @@ export interface FileRouteTypes {
     | '/share/$id'
     | '/api/jackson-pollock/$'
     | '/editor/$id'
+    | '/api/internal/account/delete';
   id:
     | '__root__'
     | '/_layout'
@@ -363,245 +375,254 @@ export interface FileRouteTypes {
     | '/_layout/share/$id'
     | '/api/jackson-pollock/$'
     | '/_layout/_auth/editor/$id'
-  fileRoutesById: FileRoutesById
+    | '/api/internal/account/delete';
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  LayoutRoute: typeof LayoutRouteWithChildren
-  ConfirmEmailRoute: typeof ConfirmEmailRoute
-  PrivacyPolicyRoute: typeof PrivacyPolicyRoute
-  ResetPasswordRoute: typeof ResetPasswordRoute
-  SigninRoute: typeof SigninRoute
-  SignupRoute: typeof SignupRoute
-  SignupEmailRoute: typeof SignupEmailRoute
-  TermsOfServiceRoute: typeof TermsOfServiceRoute
-  UpdatePasswordRoute: typeof UpdatePasswordRoute
-  ApiBillingCheckoutRoute: typeof ApiBillingCheckoutRoute
-  ApiBillingPortalRoute: typeof ApiBillingPortalRoute
-  ApiBillingProductsRoute: typeof ApiBillingProductsRoute
-  ApiBillingStatusRoute: typeof ApiBillingStatusRoute
-  ApiCreativeChatRoute: typeof ApiCreativeChatRoute
-  ApiDeleteUserRoute: typeof ApiDeleteUserRoute
-  ApiFalWebhookRoute: typeof ApiFalWebhookRoute
-  ApiMeshRoute: typeof ApiMeshRoute
-  ApiParametricChatRoute: typeof ApiParametricChatRoute
-  ApiPromptGeneratorRoute: typeof ApiPromptGeneratorRoute
-  ApiTitleGeneratorRoute: typeof ApiTitleGeneratorRoute
-  ApiJacksonPollockSplatRoute: typeof ApiJacksonPollockSplatRoute
+  LayoutRoute: typeof LayoutRouteWithChildren;
+  ConfirmEmailRoute: typeof ConfirmEmailRoute;
+  PrivacyPolicyRoute: typeof PrivacyPolicyRoute;
+  ResetPasswordRoute: typeof ResetPasswordRoute;
+  SigninRoute: typeof SigninRoute;
+  SignupRoute: typeof SignupRoute;
+  SignupEmailRoute: typeof SignupEmailRoute;
+  TermsOfServiceRoute: typeof TermsOfServiceRoute;
+  UpdatePasswordRoute: typeof UpdatePasswordRoute;
+  ApiBillingCheckoutRoute: typeof ApiBillingCheckoutRoute;
+  ApiBillingPortalRoute: typeof ApiBillingPortalRoute;
+  ApiBillingProductsRoute: typeof ApiBillingProductsRoute;
+  ApiBillingStatusRoute: typeof ApiBillingStatusRoute;
+  ApiCreativeChatRoute: typeof ApiCreativeChatRoute;
+  ApiDeleteUserRoute: typeof ApiDeleteUserRoute;
+  ApiFalWebhookRoute: typeof ApiFalWebhookRoute;
+  ApiMeshRoute: typeof ApiMeshRoute;
+  ApiParametricChatRoute: typeof ApiParametricChatRoute;
+  ApiPromptGeneratorRoute: typeof ApiPromptGeneratorRoute;
+  ApiTitleGeneratorRoute: typeof ApiTitleGeneratorRoute;
+  ApiJacksonPollockSplatRoute: typeof ApiJacksonPollockSplatRoute;
+  ApiInternalAccountDeleteRoute: typeof ApiInternalAccountDeleteRoute;
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/update-password': {
-      id: '/update-password'
-      path: '/update-password'
-      fullPath: '/update-password'
-      preLoaderRoute: typeof UpdatePasswordRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/update-password';
+      path: '/update-password';
+      fullPath: '/update-password';
+      preLoaderRoute: typeof UpdatePasswordRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/terms-of-service': {
-      id: '/terms-of-service'
-      path: '/terms-of-service'
-      fullPath: '/terms-of-service'
-      preLoaderRoute: typeof TermsOfServiceRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/terms-of-service';
+      path: '/terms-of-service';
+      fullPath: '/terms-of-service';
+      preLoaderRoute: typeof TermsOfServiceRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/signup-email': {
-      id: '/signup-email'
-      path: '/signup-email'
-      fullPath: '/signup-email'
-      preLoaderRoute: typeof SignupEmailRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/signup-email';
+      path: '/signup-email';
+      fullPath: '/signup-email';
+      preLoaderRoute: typeof SignupEmailRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/signup': {
-      id: '/signup'
-      path: '/signup'
-      fullPath: '/signup'
-      preLoaderRoute: typeof SignupRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/signup';
+      path: '/signup';
+      fullPath: '/signup';
+      preLoaderRoute: typeof SignupRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/signin': {
-      id: '/signin'
-      path: '/signin'
-      fullPath: '/signin'
-      preLoaderRoute: typeof SigninRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/signin';
+      path: '/signin';
+      fullPath: '/signin';
+      preLoaderRoute: typeof SigninRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/reset-password': {
-      id: '/reset-password'
-      path: '/reset-password'
-      fullPath: '/reset-password'
-      preLoaderRoute: typeof ResetPasswordRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/reset-password';
+      path: '/reset-password';
+      fullPath: '/reset-password';
+      preLoaderRoute: typeof ResetPasswordRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/privacy-policy': {
-      id: '/privacy-policy'
-      path: '/privacy-policy'
-      fullPath: '/privacy-policy'
-      preLoaderRoute: typeof PrivacyPolicyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/privacy-policy';
+      path: '/privacy-policy';
+      fullPath: '/privacy-policy';
+      preLoaderRoute: typeof PrivacyPolicyRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/confirm-email': {
-      id: '/confirm-email'
-      path: '/confirm-email'
-      fullPath: '/confirm-email'
-      preLoaderRoute: typeof ConfirmEmailRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/confirm-email';
+      path: '/confirm-email';
+      fullPath: '/confirm-email';
+      preLoaderRoute: typeof ConfirmEmailRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/_layout': {
-      id: '/_layout'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof LayoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/_layout';
+      path: '';
+      fullPath: '/';
+      preLoaderRoute: typeof LayoutRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/_layout/': {
-      id: '/_layout/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof LayoutIndexRouteImport
-      parentRoute: typeof LayoutRoute
-    }
+      id: '/_layout/';
+      path: '/';
+      fullPath: '/';
+      preLoaderRoute: typeof LayoutIndexRouteImport;
+      parentRoute: typeof LayoutRoute;
+    };
     '/api/title-generator': {
-      id: '/api/title-generator'
-      path: '/api/title-generator'
-      fullPath: '/api/title-generator'
-      preLoaderRoute: typeof ApiTitleGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/title-generator';
+      path: '/api/title-generator';
+      fullPath: '/api/title-generator';
+      preLoaderRoute: typeof ApiTitleGeneratorRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/prompt-generator': {
-      id: '/api/prompt-generator'
-      path: '/api/prompt-generator'
-      fullPath: '/api/prompt-generator'
-      preLoaderRoute: typeof ApiPromptGeneratorRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/prompt-generator';
+      path: '/api/prompt-generator';
+      fullPath: '/api/prompt-generator';
+      preLoaderRoute: typeof ApiPromptGeneratorRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/parametric-chat': {
-      id: '/api/parametric-chat'
-      path: '/api/parametric-chat'
-      fullPath: '/api/parametric-chat'
-      preLoaderRoute: typeof ApiParametricChatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/parametric-chat';
+      path: '/api/parametric-chat';
+      fullPath: '/api/parametric-chat';
+      preLoaderRoute: typeof ApiParametricChatRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/mesh': {
-      id: '/api/mesh'
-      path: '/api/mesh'
-      fullPath: '/api/mesh'
-      preLoaderRoute: typeof ApiMeshRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/mesh';
+      path: '/api/mesh';
+      fullPath: '/api/mesh';
+      preLoaderRoute: typeof ApiMeshRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/fal-webhook': {
-      id: '/api/fal-webhook'
-      path: '/api/fal-webhook'
-      fullPath: '/api/fal-webhook'
-      preLoaderRoute: typeof ApiFalWebhookRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/fal-webhook';
+      path: '/api/fal-webhook';
+      fullPath: '/api/fal-webhook';
+      preLoaderRoute: typeof ApiFalWebhookRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/delete-user': {
-      id: '/api/delete-user'
-      path: '/api/delete-user'
-      fullPath: '/api/delete-user'
-      preLoaderRoute: typeof ApiDeleteUserRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/delete-user';
+      path: '/api/delete-user';
+      fullPath: '/api/delete-user';
+      preLoaderRoute: typeof ApiDeleteUserRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/creative-chat': {
-      id: '/api/creative-chat'
-      path: '/api/creative-chat'
-      fullPath: '/api/creative-chat'
-      preLoaderRoute: typeof ApiCreativeChatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/creative-chat';
+      path: '/api/creative-chat';
+      fullPath: '/api/creative-chat';
+      preLoaderRoute: typeof ApiCreativeChatRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/billing-status': {
-      id: '/api/billing-status'
-      path: '/api/billing-status'
-      fullPath: '/api/billing-status'
-      preLoaderRoute: typeof ApiBillingStatusRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/billing-status';
+      path: '/api/billing-status';
+      fullPath: '/api/billing-status';
+      preLoaderRoute: typeof ApiBillingStatusRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/billing-products': {
-      id: '/api/billing-products'
-      path: '/api/billing-products'
-      fullPath: '/api/billing-products'
-      preLoaderRoute: typeof ApiBillingProductsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/billing-products';
+      path: '/api/billing-products';
+      fullPath: '/api/billing-products';
+      preLoaderRoute: typeof ApiBillingProductsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/billing-portal': {
-      id: '/api/billing-portal'
-      path: '/api/billing-portal'
-      fullPath: '/api/billing-portal'
-      preLoaderRoute: typeof ApiBillingPortalRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/billing-portal';
+      path: '/api/billing-portal';
+      fullPath: '/api/billing-portal';
+      preLoaderRoute: typeof ApiBillingPortalRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/api/billing-checkout': {
-      id: '/api/billing-checkout'
-      path: '/api/billing-checkout'
-      fullPath: '/api/billing-checkout'
-      preLoaderRoute: typeof ApiBillingCheckoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/billing-checkout';
+      path: '/api/billing-checkout';
+      fullPath: '/api/billing-checkout';
+      preLoaderRoute: typeof ApiBillingCheckoutRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/_layout/_auth': {
-      id: '/_layout/_auth'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof LayoutAuthRouteImport
-      parentRoute: typeof LayoutRoute
-    }
+      id: '/_layout/_auth';
+      path: '';
+      fullPath: '/';
+      preLoaderRoute: typeof LayoutAuthRouteImport;
+      parentRoute: typeof LayoutRoute;
+    };
     '/_layout/$': {
-      id: '/_layout/$'
-      path: '/$'
-      fullPath: '/$'
-      preLoaderRoute: typeof LayoutSplatRouteImport
-      parentRoute: typeof LayoutRoute
-    }
+      id: '/_layout/$';
+      path: '/$';
+      fullPath: '/$';
+      preLoaderRoute: typeof LayoutSplatRouteImport;
+      parentRoute: typeof LayoutRoute;
+    };
     '/api/jackson-pollock/$': {
-      id: '/api/jackson-pollock/$'
-      path: '/api/jackson-pollock/$'
-      fullPath: '/api/jackson-pollock/$'
-      preLoaderRoute: typeof ApiJacksonPollockSplatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+      id: '/api/jackson-pollock/$';
+      path: '/api/jackson-pollock/$';
+      fullPath: '/api/jackson-pollock/$';
+      preLoaderRoute: typeof ApiJacksonPollockSplatRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/_layout/share/$id': {
-      id: '/_layout/share/$id'
-      path: '/share/$id'
-      fullPath: '/share/$id'
-      preLoaderRoute: typeof LayoutShareIdRouteImport
-      parentRoute: typeof LayoutRoute
-    }
+      id: '/_layout/share/$id';
+      path: '/share/$id';
+      fullPath: '/share/$id';
+      preLoaderRoute: typeof LayoutShareIdRouteImport;
+      parentRoute: typeof LayoutRoute;
+    };
     '/_layout/_auth/subscription': {
-      id: '/_layout/_auth/subscription'
-      path: '/subscription'
-      fullPath: '/subscription'
-      preLoaderRoute: typeof LayoutAuthSubscriptionRouteImport
-      parentRoute: typeof LayoutAuthRoute
-    }
+      id: '/_layout/_auth/subscription';
+      path: '/subscription';
+      fullPath: '/subscription';
+      preLoaderRoute: typeof LayoutAuthSubscriptionRouteImport;
+      parentRoute: typeof LayoutAuthRoute;
+    };
     '/_layout/_auth/settings': {
-      id: '/_layout/_auth/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof LayoutAuthSettingsRouteImport
-      parentRoute: typeof LayoutAuthRoute
-    }
+      id: '/_layout/_auth/settings';
+      path: '/settings';
+      fullPath: '/settings';
+      preLoaderRoute: typeof LayoutAuthSettingsRouteImport;
+      parentRoute: typeof LayoutAuthRoute;
+    };
     '/_layout/_auth/history': {
-      id: '/_layout/_auth/history'
-      path: '/history'
-      fullPath: '/history'
-      preLoaderRoute: typeof LayoutAuthHistoryRouteImport
-      parentRoute: typeof LayoutAuthRoute
-    }
+      id: '/_layout/_auth/history';
+      path: '/history';
+      fullPath: '/history';
+      preLoaderRoute: typeof LayoutAuthHistoryRouteImport;
+      parentRoute: typeof LayoutAuthRoute;
+    };
+    '/api/internal/account/delete': {
+      id: '/api/internal/account/delete';
+      path: '/api/internal/account/delete';
+      fullPath: '/api/internal/account/delete';
+      preLoaderRoute: typeof ApiInternalAccountDeleteRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/_layout/_auth/editor/$id': {
-      id: '/_layout/_auth/editor/$id'
-      path: '/editor/$id'
-      fullPath: '/editor/$id'
-      preLoaderRoute: typeof LayoutAuthEditorIdRouteImport
-      parentRoute: typeof LayoutAuthRoute
-    }
+      id: '/_layout/_auth/editor/$id';
+      path: '/editor/$id';
+      fullPath: '/editor/$id';
+      preLoaderRoute: typeof LayoutAuthEditorIdRouteImport;
+      parentRoute: typeof LayoutAuthRoute;
+    };
   }
 }
 
 interface LayoutAuthRouteChildren {
-  LayoutAuthHistoryRoute: typeof LayoutAuthHistoryRoute
-  LayoutAuthSettingsRoute: typeof LayoutAuthSettingsRoute
-  LayoutAuthSubscriptionRoute: typeof LayoutAuthSubscriptionRoute
-  LayoutAuthEditorIdRoute: typeof LayoutAuthEditorIdRoute
+  LayoutAuthHistoryRoute: typeof LayoutAuthHistoryRoute;
+  LayoutAuthSettingsRoute: typeof LayoutAuthSettingsRoute;
+  LayoutAuthSubscriptionRoute: typeof LayoutAuthSubscriptionRoute;
+  LayoutAuthEditorIdRoute: typeof LayoutAuthEditorIdRoute;
 }
 
 const LayoutAuthRouteChildren: LayoutAuthRouteChildren = {
@@ -609,17 +630,17 @@ const LayoutAuthRouteChildren: LayoutAuthRouteChildren = {
   LayoutAuthSettingsRoute: LayoutAuthSettingsRoute,
   LayoutAuthSubscriptionRoute: LayoutAuthSubscriptionRoute,
   LayoutAuthEditorIdRoute: LayoutAuthEditorIdRoute,
-}
+};
 
 const LayoutAuthRouteWithChildren = LayoutAuthRoute._addFileChildren(
   LayoutAuthRouteChildren,
-)
+);
 
 interface LayoutRouteChildren {
-  LayoutSplatRoute: typeof LayoutSplatRoute
-  LayoutAuthRoute: typeof LayoutAuthRouteWithChildren
-  LayoutIndexRoute: typeof LayoutIndexRoute
-  LayoutShareIdRoute: typeof LayoutShareIdRoute
+  LayoutSplatRoute: typeof LayoutSplatRoute;
+  LayoutAuthRoute: typeof LayoutAuthRouteWithChildren;
+  LayoutIndexRoute: typeof LayoutIndexRoute;
+  LayoutShareIdRoute: typeof LayoutShareIdRoute;
 }
 
 const LayoutRouteChildren: LayoutRouteChildren = {
@@ -627,10 +648,10 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutAuthRoute: LayoutAuthRouteWithChildren,
   LayoutIndexRoute: LayoutIndexRoute,
   LayoutShareIdRoute: LayoutShareIdRoute,
-}
+};
 
 const LayoutRouteWithChildren =
-  LayoutRoute._addFileChildren(LayoutRouteChildren)
+  LayoutRoute._addFileChildren(LayoutRouteChildren);
 
 const rootRouteChildren: RootRouteChildren = {
   LayoutRoute: LayoutRouteWithChildren,
@@ -654,16 +675,17 @@ const rootRouteChildren: RootRouteChildren = {
   ApiPromptGeneratorRoute: ApiPromptGeneratorRoute,
   ApiTitleGeneratorRoute: ApiTitleGeneratorRoute,
   ApiJacksonPollockSplatRoute: ApiJacksonPollockSplatRoute,
-}
+  ApiInternalAccountDeleteRoute: ApiInternalAccountDeleteRoute,
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();
 
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
+import type { getRouter } from './router.tsx';
+import type { createStart } from '@tanstack/react-start';
 declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
+    ssr: true;
+    router: Awaited<ReturnType<typeof getRouter>>;
   }
 }

--- a/src/routes/api/delete-user.ts
+++ b/src/routes/api/delete-user.ts
@@ -1,36 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { billing, BillingClientError } from '@/server/billingClient';
 import { isRecord, json, methodNotAllowed, preflight } from '@/server/api';
+import { getServiceRoleSupabaseClient } from '@/server/supabaseClient';
 import {
-  getServiceRoleSupabaseClient,
-  type SupabaseClient,
-} from '@/server/supabaseClient';
-
-type CancellationFeedback =
-  | 'customer_service'
-  | 'low_quality'
-  | 'missing_features'
-  | 'other'
-  | 'switched_service'
-  | 'too_complex'
-  | 'too_expensive'
-  | 'unused';
-
-function isCancellationFeedback(value: unknown): value is CancellationFeedback {
-  switch (value) {
-    case 'customer_service':
-    case 'low_quality':
-    case 'missing_features':
-    case 'other':
-    case 'switched_service':
-    case 'too_complex':
-    case 'too_expensive':
-    case 'unused':
-      return true;
-    default:
-      return false;
-  }
-}
+  isCancellationFeedback,
+  teardownUser,
+} from '@/server/deleteUserTeardown';
 
 export const Route = createFileRoute('/api/delete-user')({
   server: {
@@ -52,106 +26,16 @@ export const Route = createFileRoute('/api/delete-user')({
           return json({ error: 'Unauthorized' }, 401);
 
         try {
-          const subscription = await billing.cancelSubscription(
-            data.user.email,
-            { feedback: reason },
+          await teardownUser(
+            supabase,
+            { id: data.user.id, email: data.user.email },
+            { reason },
           );
-          if (!subscription.canceled) {
-            switch (subscription.reason) {
-              case 'no_subscription':
-              case 'already_canceled':
-                break;
-              default: {
-                const unknownReason: never = subscription.reason;
-                throw new Error(
-                  `Unknown subscription cancellation reason: ${unknownReason}`,
-                );
-              }
-            }
-          }
-        } catch (subscriptionError) {
-          if (subscriptionError instanceof BillingClientError) {
-            console.error('Failed to cancel user subscription:', {
-              status: subscriptionError.status,
-              body: subscriptionError.body,
-            });
-          } else {
-            console.error(
-              'Failed to cancel user subscription:',
-              subscriptionError,
-            );
-          }
+        } catch {
+          return json({ error: 'Failed to delete user' }, 500);
         }
-        const { error: deleteError } = await supabase.auth.admin.deleteUser(
-          data.user.id,
-        );
-        if (deleteError) return json({ error: 'Failed to delete user' }, 500);
-
-        runBackgroundTask(deleteUserStorageItems(supabase, data.user.id));
         return json({ success: true });
       },
     },
   },
 });
-
-function runBackgroundTask(task: Promise<unknown>) {
-  const loggedTask = task.catch((error) => {
-    console.error('Failed to delete user storage items:', error);
-  });
-  const requestContext = Reflect.get(
-    globalThis,
-    Symbol.for('@vercel/request-context'),
-  );
-  if (isRecord(requestContext) && typeof requestContext.get === 'function') {
-    const context = requestContext.get();
-    if (isRecord(context) && typeof context.waitUntil === 'function') {
-      context.waitUntil(loggedTask);
-      return;
-    }
-  }
-  void loggedTask;
-}
-
-async function deleteUserStorageItems(
-  supabase: SupabaseClient,
-  userId: string,
-): Promise<void> {
-  for (const bucket of ['images', 'meshes', 'previews']) {
-    try {
-      const paths = await listAllPaths(supabase, bucket, userId);
-      for (let i = 0; i < paths.length; i += 1000) {
-        const { error } = await supabase.storage
-          .from(bucket)
-          .remove(paths.slice(i, i + 1000));
-        if (error) throw error;
-      }
-    } catch (error) {
-      console.error(`Failed to delete ${bucket} storage items:`, error);
-    }
-  }
-}
-
-async function listAllPaths(
-  supabase: SupabaseClient,
-  bucket: string,
-  folder: string,
-): Promise<string[]> {
-  const paths: string[] = [];
-  const limit = 1000;
-  for (let offset = 0; ; offset += limit) {
-    const { data, error } = await supabase.storage.from(bucket).list(folder, {
-      limit,
-      offset,
-      sortBy: { column: 'name', order: 'asc' },
-    });
-    if (error) throw error;
-    if (!data.length) break;
-    for (const item of data) {
-      const path = `${folder}/${item.name}`;
-      if ('id' in item && item.id) paths.push(path);
-      else paths.push(...(await listAllPaths(supabase, bucket, path)));
-    }
-    if (data.length < limit) break;
-  }
-  return paths;
-}

--- a/src/routes/api/internal/account/delete.ts
+++ b/src/routes/api/internal/account/delete.ts
@@ -1,0 +1,100 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { timingSafeEqual } from 'node:crypto';
+import { isRecord, json, methodNotAllowed, preflight } from '@/server/api';
+import { env } from '@/server/env';
+import { logApiError } from '@/server/serverLog';
+import { getServiceRoleSupabaseClient } from '@/server/supabaseClient';
+import { findAuthUserByEmail, teardownUser } from '@/server/deleteUserTeardown';
+
+const FN = 'internal-account-delete';
+
+/**
+ * Constant-time comparison of the presented bearer token against the
+ * configured purge secret. Never logs either value. Returns false on any
+ * length mismatch (comparing unequal-length buffers with `timingSafeEqual`
+ * throws, so we guard the length first — the length itself is not secret).
+ */
+function bearerMatches(presented: string, expected: string): boolean {
+  const a = Buffer.from(presented);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Internal, server-to-server account purge endpoint. Called by the workspace
+ * account-purge worker once a user's 30-day grace window elapses to erase that
+ * user's data in this satellite.
+ *
+ * Contract:
+ *   - POST only.
+ *   - `Authorization: Bearer <ACCOUNT_PURGE_SECRET>` (constant-time compare).
+ *     503 if the secret is unconfigured; 401 if missing/mismatched.
+ *   - Body: { email: string, subject?: string }. `email` is the cross-system
+ *     join key; `subject` is the Adam user id, logging only.
+ *   - Idempotent: 200 { deleted: false } when no matching user exists,
+ *     200 { deleted: true } when a user was found and erased. Never 404.
+ *   - 500 only on a genuine failure so the worker retries.
+ *
+ * This endpoint is provider-agnostic: the shared secret and the service-role
+ * Supabase credentials are entirely env-driven, with no hardcoded host or
+ * tenant-specific value.
+ */
+export const Route = createFileRoute('/api/internal/account/delete')({
+  server: {
+    handlers: {
+      GET: methodNotAllowed,
+      OPTIONS: preflight,
+      POST: async ({ request }) => {
+        // Unconfigured secret must hard-fail every request; never authorize
+        // when there is nothing to compare against.
+        const secret = env('ACCOUNT_PURGE_SECRET');
+        if (!secret) {
+          return json({ error: 'not_configured' }, 503);
+        }
+
+        const presented = request.headers
+          .get('Authorization')
+          ?.replace(/^Bearer /, '');
+        if (!presented || !bearerMatches(presented, secret)) {
+          return json({ error: 'Unauthorized' }, 401);
+        }
+
+        const body = await request.json().catch(() => ({}));
+        const email =
+          isRecord(body) && typeof body.email === 'string' ? body.email : '';
+        const subject =
+          isRecord(body) && typeof body.subject === 'string'
+            ? body.subject
+            : undefined;
+        if (!email.trim()) {
+          return json({ error: 'email_required' }, 400);
+        }
+
+        try {
+          const supabase = getServiceRoleSupabaseClient();
+          const user = await findAuthUserByEmail(supabase, email);
+          if (!user) {
+            // Already gone — idempotent success, not a 404.
+            return json({ deleted: false });
+          }
+          // awaitStorage: a background purge with no user waiting — block on
+          // storage-first deletion so a 200 means the blobs are actually gone
+          // and any failure is retryable.
+          await teardownUser(supabase, user, { awaitStorage: true });
+          return json({ deleted: true });
+        } catch (error) {
+          logApiError(error, {
+            functionName: FN,
+            apiName: 'internal-account-delete',
+            statusCode: 500,
+            // `subject` is the Adam user id (logging only). Email is a PII
+            // join key and is intentionally not logged here.
+            requestData: subject ? { subject } : undefined,
+          });
+          return json({ error: 'internal_error' }, 500);
+        }
+      },
+    },
+  },
+});

--- a/src/server/deleteUserTeardown.ts
+++ b/src/server/deleteUserTeardown.ts
@@ -1,0 +1,210 @@
+import { billing, BillingClientError } from '@/server/billingClient';
+import { isRecord } from '@/server/api';
+import {
+  getServiceRoleSupabaseClient,
+  type SupabaseClient,
+} from '@/server/supabaseClient';
+
+export type CancellationFeedback =
+  | 'customer_service'
+  | 'low_quality'
+  | 'missing_features'
+  | 'other'
+  | 'switched_service'
+  | 'too_complex'
+  | 'too_expensive'
+  | 'unused';
+
+export function isCancellationFeedback(
+  value: unknown,
+): value is CancellationFeedback {
+  switch (value) {
+    case 'customer_service':
+    case 'low_quality':
+    case 'missing_features':
+    case 'other':
+    case 'switched_service':
+    case 'too_complex':
+    case 'too_expensive':
+    case 'unused':
+      return true;
+    default:
+      return false;
+  }
+}
+
+export type TeardownOptions = {
+  reason?: CancellationFeedback;
+  /**
+   * Await storage deletion BEFORE removing the auth user, and let a storage
+   * failure propagate. Used by the server-to-server purge route so its 200
+   * only means "actually erased" and a failure leaves the auth user intact for
+   * a safe retry (the retry re-lists and finishes the job). The default
+   * (session-initiated delete) removes the auth user first and cleans storage
+   * in the background, for a fast user-facing response.
+   */
+  awaitStorage?: boolean;
+};
+
+/**
+ * Runs the full teardown for a single user: cancels the email-keyed billing
+ * subscription, deletes the Supabase auth user (which cascades sessions,
+ * accounts, and user-keyed rows via FK / RLS cascade), and removes the user's
+ * storage buckets. Both the session-authed `delete-user` route and the
+ * internal server-to-server `internal/account/delete` route call this so the
+ * teardown behavior stays identical.
+ *
+ * Billing cancellation is always best-effort (logged, never fatal). Storage
+ * ordering depends on `awaitStorage` (see TeardownOptions).
+ */
+export async function teardownUser(
+  supabase: SupabaseClient,
+  user: { id: string; email: string },
+  options: TeardownOptions = {},
+): Promise<void> {
+  try {
+    const subscription = await billing.cancelSubscription(user.email, {
+      feedback: options.reason,
+    });
+    if (!subscription.canceled) {
+      switch (subscription.reason) {
+        case 'no_subscription':
+        case 'already_canceled':
+          break;
+        default: {
+          const unknownReason: never = subscription.reason;
+          throw new Error(
+            `Unknown subscription cancellation reason: ${unknownReason}`,
+          );
+        }
+      }
+    }
+  } catch (subscriptionError) {
+    if (subscriptionError instanceof BillingClientError) {
+      console.error('Failed to cancel user subscription:', {
+        status: subscriptionError.status,
+        body: subscriptionError.body,
+      });
+    } else {
+      console.error('Failed to cancel user subscription:', subscriptionError);
+    }
+  }
+
+  if (options.awaitStorage) {
+    // Storage-first, awaited: if this throws the auth user still exists, so the
+    // caller's retry re-lists and completes — no silently-orphaned blobs.
+    await deleteUserStorageItems(supabase, user.id);
+    const { error: deleteError } = await supabase.auth.admin.deleteUser(
+      user.id,
+    );
+    if (deleteError) {
+      throw new Error(`Failed to delete auth user: ${deleteError.message}`);
+    }
+    return;
+  }
+
+  // Default user-facing path: delete the auth user now, clean storage in the
+  // background so the response is fast.
+  const { error: deleteError } = await supabase.auth.admin.deleteUser(user.id);
+  if (deleteError) {
+    throw new Error(`Failed to delete auth user: ${deleteError.message}`);
+  }
+  runBackgroundTask(deleteUserStorageItems(supabase, user.id));
+}
+
+/**
+ * Look up a Supabase auth user by email (case-insensitive, trimmed). Returns
+ * null when no user matches. Uses the admin `listUsers` pagination because the
+ * installed auth-js does not expose a direct get-by-email admin method.
+ */
+export async function findAuthUserByEmail(
+  supabase: SupabaseClient,
+  email: string,
+): Promise<{ id: string; email: string } | null> {
+  const normalized = email.trim().toLowerCase();
+  if (!normalized) return null;
+
+  const perPage = 1000;
+  for (let page = 1; ; page += 1) {
+    const { data, error } = await supabase.auth.admin.listUsers({
+      page,
+      perPage,
+    });
+    if (error) {
+      throw new Error(`Failed to list auth users: ${error.message}`);
+    }
+    for (const candidate of data.users) {
+      if (candidate.email?.trim().toLowerCase() === normalized) {
+        return { id: candidate.id, email: candidate.email };
+      }
+    }
+    if (data.users.length < perPage) break;
+  }
+  return null;
+}
+
+export { getServiceRoleSupabaseClient };
+
+function runBackgroundTask(task: Promise<unknown>) {
+  const loggedTask = task.catch((error) => {
+    console.error('Failed to delete user storage items:', error);
+  });
+  const requestContext = Reflect.get(
+    globalThis,
+    Symbol.for('@vercel/request-context'),
+  );
+  if (isRecord(requestContext) && typeof requestContext.get === 'function') {
+    const context = requestContext.get();
+    if (isRecord(context) && typeof context.waitUntil === 'function') {
+      context.waitUntil(loggedTask);
+      return;
+    }
+  }
+  void loggedTask;
+}
+
+/**
+ * Delete every object the user owns across the storage buckets. Errors
+ * PROPAGATE (they used to be swallowed): the background caller wraps this in
+ * runBackgroundTask (which logs), while the awaited purge caller relies on the
+ * throw to retry. Idempotent — a retry re-lists and removes only what remains.
+ */
+async function deleteUserStorageItems(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<void> {
+  for (const bucket of ['images', 'meshes', 'previews']) {
+    const paths = await listAllPaths(supabase, bucket, userId);
+    for (let i = 0; i < paths.length; i += 1000) {
+      const { error } = await supabase.storage
+        .from(bucket)
+        .remove(paths.slice(i, i + 1000));
+      if (error) throw error;
+    }
+  }
+}
+
+async function listAllPaths(
+  supabase: SupabaseClient,
+  bucket: string,
+  folder: string,
+): Promise<string[]> {
+  const paths: string[] = [];
+  const limit = 1000;
+  for (let offset = 0; ; offset += limit) {
+    const { data, error } = await supabase.storage.from(bucket).list(folder, {
+      limit,
+      offset,
+      sortBy: { column: 'name', order: 'asc' },
+    });
+    if (error) throw error;
+    if (!data.length) break;
+    for (const item of data) {
+      const path = `${folder}/${item.name}`;
+      if ('id' in item && item.id) paths.push(path);
+      else paths.push(...(await listAllPaths(supabase, bucket, path)));
+    }
+    if (data.length < limit) break;
+  }
+  return paths;
+}


### PR DESCRIPTION
Part of the account-management unification: when a unified Adam account is deleted, the identity provider's purge worker must erase the user's data in every satellite. This adds CADAM's satellite endpoint.

## What
- `POST /api/internal/account/delete` — internal, server-to-server. Bearer `ACCOUNT_PURGE_SECRET` (constant-time compare; **503 when unset** so it never authorizes unconfigured). Body `{ email }`.
- Idempotent: `200 {deleted:false}` when no such user, `{deleted:true}` when erased, `500` only on genuine failure so the worker retries.
- Shared teardown extracted to `server/deleteUserTeardown.ts` and reused by the existing session-authed `/api/delete-user` — both behave identically.
- `teardownUser` gains `awaitStorage`: the purge path deletes storage **first + awaited** (a failure leaves the auth user intact for a safe retry — no orphaned blobs), while the user-facing path keeps the fast background-cleanup behavior. Storage deletion now propagates errors so the awaited path is retry-safe.

## Notes
- Provider-agnostic / GPL-clean: secret + service-role creds are env-driven, no `adam.new` hardcoded. Unset `ACCOUNT_PURGE_SECRET` = endpoint disabled.
- Operator step: set `ACCOUNT_PURGE_SECRET` in each deploy env, shared with the upstream purge worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an internal server-to-server purge endpoint to erase a user’s data when their unified account is deleted. Also extracted a shared, retry-safe teardown used by both purge and user-initiated deletes.

- **New Features**
  - `POST /api/internal/account/delete` with `Bearer` `ACCOUNT_PURGE_SECRET` (constant-time compare; returns 503 when unset). Body `{ email }`.
  - Idempotent responses: `200 {deleted:false}` if no user, `200 {deleted:true}` if erased; `500` only on real failure for worker retries.
  - Purge path deletes storage first and awaits it; failures keep the auth user for a safe retry. `/api/delete-user` now reuses the same teardown.

- **Migration**
  - Set `ACCOUNT_PURGE_SECRET` in each environment (shared with the upstream purge worker). Leave unset to disable the endpoint.

<sup>Written for commit 3b6778ead0506e0424635ceb17204a5d35df6c8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

