### PR TITLE
fix(assets): return uncacheable 404 for missing assets instead of SPA shell

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,9 @@
 
 @layer base {
   :root {
+    /* Rotates the CSS bundle hash so browsers that cached the poisoned
+       index-BBgs0KEz.css (June 2026 CDN incident) fetch a fresh URL. */
+    --cache-generation: 2;
     --background: 0 0% 100%;
     --foreground: 0 0% 3.9%;
     --card: 0 0% 100%;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as PrivacyPolicyRouteImport } from './routes/privacy-policy';
 import { Route as ConfirmEmailRouteImport } from './routes/confirm-email';
 import { Route as LayoutRouteImport } from './routes/_layout';
 import { Route as LayoutIndexRouteImport } from './routes/_layout/index';
+import { Route as AssetsSplatRouteImport } from './routes/assets.$';
 import { Route as ApiTitleGeneratorRouteImport } from './routes/api/title-generator';
 import { Route as ApiPromptGeneratorRouteImport } from './routes/api/prompt-generator';
 import { Route as ApiParametricChatRouteImport } from './routes/api/parametric-chat';
@@ -88,6 +89,11 @@ const LayoutIndexRoute = LayoutIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => LayoutRoute,
+} as any);
+const AssetsSplatRoute = AssetsSplatRouteImport.update({
+  id: '/assets/$',
+  path: '/assets/$',
+  getParentRoute: () => rootRouteImport,
 } as any);
 const ApiTitleGeneratorRoute = ApiTitleGeneratorRouteImport.update({
   id: '/api/title-generator',
@@ -212,6 +218,7 @@ export interface FileRoutesByFullPath {
   '/api/parametric-chat': typeof ApiParametricChatRoute;
   '/api/prompt-generator': typeof ApiPromptGeneratorRoute;
   '/api/title-generator': typeof ApiTitleGeneratorRoute;
+  '/assets/$': typeof AssetsSplatRoute;
   '/history': typeof LayoutAuthHistoryRoute;
   '/settings': typeof LayoutAuthSettingsRoute;
   '/subscription': typeof LayoutAuthSubscriptionRoute;
@@ -242,6 +249,7 @@ export interface FileRoutesByTo {
   '/api/parametric-chat': typeof ApiParametricChatRoute;
   '/api/prompt-generator': typeof ApiPromptGeneratorRoute;
   '/api/title-generator': typeof ApiTitleGeneratorRoute;
+  '/assets/$': typeof AssetsSplatRoute;
   '/history': typeof LayoutAuthHistoryRoute;
   '/settings': typeof LayoutAuthSettingsRoute;
   '/subscription': typeof LayoutAuthSubscriptionRoute;
@@ -274,6 +282,7 @@ export interface FileRoutesById {
   '/api/parametric-chat': typeof ApiParametricChatRoute;
   '/api/prompt-generator': typeof ApiPromptGeneratorRoute;
   '/api/title-generator': typeof ApiTitleGeneratorRoute;
+  '/assets/$': typeof AssetsSplatRoute;
   '/_layout/': typeof LayoutIndexRoute;
   '/_layout/_auth/history': typeof LayoutAuthHistoryRoute;
   '/_layout/_auth/settings': typeof LayoutAuthSettingsRoute;
@@ -307,6 +316,7 @@ export interface FileRouteTypes {
     | '/api/parametric-chat'
     | '/api/prompt-generator'
     | '/api/title-generator'
+    | '/assets/$'
     | '/history'
     | '/settings'
     | '/subscription'
@@ -337,6 +347,7 @@ export interface FileRouteTypes {
     | '/api/parametric-chat'
     | '/api/prompt-generator'
     | '/api/title-generator'
+    | '/assets/$'
     | '/history'
     | '/settings'
     | '/subscription'
@@ -368,6 +379,7 @@ export interface FileRouteTypes {
     | '/api/parametric-chat'
     | '/api/prompt-generator'
     | '/api/title-generator'
+    | '/assets/$'
     | '/_layout/'
     | '/_layout/_auth/history'
     | '/_layout/_auth/settings'
@@ -399,6 +411,7 @@ export interface RootRouteChildren {
   ApiParametricChatRoute: typeof ApiParametricChatRoute;
   ApiPromptGeneratorRoute: typeof ApiPromptGeneratorRoute;
   ApiTitleGeneratorRoute: typeof ApiTitleGeneratorRoute;
+  AssetsSplatRoute: typeof AssetsSplatRoute;
   ApiJacksonPollockSplatRoute: typeof ApiJacksonPollockSplatRoute;
   ApiInternalAccountDeleteRoute: typeof ApiInternalAccountDeleteRoute;
 }
@@ -474,6 +487,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/';
       preLoaderRoute: typeof LayoutIndexRouteImport;
       parentRoute: typeof LayoutRoute;
+    };
+    '/assets/$': {
+      id: '/assets/$';
+      path: '/assets/$';
+      fullPath: '/assets/$';
+      preLoaderRoute: typeof AssetsSplatRouteImport;
+      parentRoute: typeof rootRouteImport;
     };
     '/api/title-generator': {
       id: '/api/title-generator';
@@ -674,6 +694,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiParametricChatRoute: ApiParametricChatRoute,
   ApiPromptGeneratorRoute: ApiPromptGeneratorRoute,
   ApiTitleGeneratorRoute: ApiTitleGeneratorRoute,
+  AssetsSplatRoute: AssetsSplatRoute,
   ApiJacksonPollockSplatRoute: ApiJacksonPollockSplatRoute,
   ApiInternalAccountDeleteRoute: ApiInternalAccountDeleteRoute,
 };

--- a/src/routes/assets.$.ts
+++ b/src/routes/assets.$.ts
@@ -1,0 +1,26 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+// Existing files under /assets are served by the static layer and never reach
+// the server function, so any request that lands here is for an asset that
+// does not exist (e.g. a stale hash during deploy skew). It must be a 404 and
+// must not be cacheable: the Vercel route config stamps a one-year immutable
+// cache-control on every /assets path, and letting that header onto a
+// fallthrough response poisons CDN and browser caches (see the June 2026
+// incident where the SPA shell was cached as index-*.css for 20 days).
+const missingAsset = () =>
+  new Response('Not Found', {
+    status: 404,
+    headers: {
+      'cache-control': 'no-store',
+      'content-type': 'text/plain; charset=utf-8',
+    },
+  });
+
+export const Route = createFileRoute('/assets/$')({
+  server: {
+    handlers: {
+      GET: missingAsset,
+      HEAD: missingAsset,
+    },
+  },
+});

--- a/src/routes/assets.$.ts
+++ b/src/routes/assets.$.ts
@@ -7,20 +7,22 @@ import { createFileRoute } from '@tanstack/react-router';
 // cache-control on every /assets path, and letting that header onto a
 // fallthrough response poisons CDN and browser caches (see the June 2026
 // incident where the SPA shell was cached as index-*.css for 20 days).
-const missingAsset = () =>
-  new Response('Not Found', {
-    status: 404,
-    headers: {
-      'cache-control': 'no-store',
-      'content-type': 'text/plain; charset=utf-8',
-    },
-  });
+const missingAssetHeaders = {
+  'cache-control': 'no-store',
+  'content-type': 'text/plain; charset=utf-8',
+};
 
 export const Route = createFileRoute('/assets/$')({
   server: {
     handlers: {
-      GET: missingAsset,
-      HEAD: missingAsset,
+      GET: () =>
+        new Response('Not Found', {
+          status: 404,
+          headers: missingAssetHeaders,
+        }),
+      // RFC 9110 §9.3.2: HEAD responses must not carry a body.
+      HEAD: () =>
+        new Response(null, { status: 404, headers: missingAssetHeaders }),
     },
   },
 });


### PR DESCRIPTION
## Problem

CADAM rendered completely unstyled for every browser in France for ~20 days (reported for Chromium, later Safari too). The CSS request returned 200, making it look like a browser problem — it wasn't.

**Root cause:** Nitro's Vercel preset emits a path-based route rule that stamps `cache-control: public, max-age=31536000, immutable` on **every** `/cadam/assets/*` URL *before* filesystem matching. During a deploy-skew window on ~June 19, a request for `index-BBgs0KEz.css` missed the static layer, fell through to the SSR catch-all, and the SPA-shell **HTML** went out with the year-long immutable header. Cloudflare's Paris POP (correctly) cached what it was told to: HTML as a `.css` URL, for a year. Browsers strictly enforce MIME types for stylesheets, so `text/html` stylesheets are silently discarded → unstyled app for anyone routed through CDG.

Reproduced directly against origin: `GET /cadam/assets/index-DOESNOTEXIST.css` → `200`, `content-type: text/html`, `cache-control: immutable` (`cf-cache-status: MISS`, i.e. straight from Vercel).

## Fix

- **`src/routes/assets.$.ts`** — catch-all server route for `/assets/*`. Real files are served by the static layer and never reach the function, so anything landing here is a missing asset: respond `404` with `cache-control: no-store`. The function's header takes precedence over the route-level immutable stamp, so a fallthrough response can never be long-cached again — by any CDN or browser.
- **`src/index.css`** — no-op `--cache-generation` custom property to rotate the CSS bundle hash (`index-BBgs0KEz.css` → `index-CIEKUh_u.css`). Required because browsers in France hold the poisoned object under the old URL with a year-long TTL; a build without a CSS content change reproduces the identical hash and would not bust them.
- **`src/routeTree.gen.ts`** — regenerated.

## Verification

Local (built server, `node .output/server/index.mjs`):
- Missing asset GET/HEAD → `404` + `no-store`; real CSS/JS → 200 with correct MIME; `/cadam/` SSR + prerender intact; `tsc -b` and eslint clean.

Vercel preview deployment (real routing layer, where the immutable stamp is applied):
- `GET /cadam/assets/index-DOESNOTEXIST.css` → **`404` + `cache-control: no-store`** (previously `200` HTML + 1-year immutable)
- `index-CIEKUh_u.css` → 200 `text/css`, 115 kB; `/cadam/` → 200 HTML

## Notes

- Deploying this alone un-poisons France: HTML is never cached, so it immediately points everyone at the fresh hash. No Cloudflare purge required (optional for fixing things in the minutes before deploy).
- Follow-up worth considering: Vercel Skew Protection to eliminate the deploy-skew trigger entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve missing assets as uncacheable 404s instead of the SPA shell to prevent long-lived cache poisoning under asset URLs. Rotate the CSS bundle hash to bust previously cached bad responses and restore styles.

- **Bug Fixes**
  - Add `/assets/$` server route (via `@tanstack/react-router`) to return 404 with `cache-control: no-store` for asset misses (overrides Vercel’s immutable header); support GET/HEAD and omit the body for HEAD per RFC 9110.
  - Bump a no-op CSS variable to change the bundle filename and force refetch.
  - Regenerate `routeTree.gen.ts`.

<sup>Written for commit 3c591cf8a561d2ca0db24599882b6587a980b776. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

