### PR TITLE
fix(auth): show the SSO provider's name, not the stale local mirror

### DIFF
--- a/src/components/chat/UserAvatar.tsx
+++ b/src/components/chat/UserAvatar.tsx
@@ -2,7 +2,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useProfile, useAvatarUrl } from '@/services/profileService';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { getInitials } from '@/lib/utils';
-import { accountUrl, ssoProvider } from '@/lib/supabase';
+import { ssoManaged } from '@/lib/supabase';
 
 export function UserAvatar({ className }: { className?: string }) {
   const { user } = useAuth();
@@ -18,11 +18,9 @@ export function UserAvatar({ className }: { className?: string }) {
     | undefined;
   const providerAvatar = metadata?.avatar_url || metadata?.picture;
 
-  // When SSO owns the identity (same condition SettingsView uses to make the
-  // account read-only), the provider photo is the single source of truth, so it
-  // wins — a stale CADAM-local upload can no longer diverge from the Adam photo.
-  // In self-host mode the self-uploaded avatar keeps winning.
-  const ssoManaged = Boolean(ssoProvider && accountUrl);
+  // When Adam owns the profile (shared `ssoManaged` flag) the provider photo is
+  // the single source of truth and wins, so a stale CADAM-local upload can't
+  // diverge from the Adam photo. In self-host mode the self-uploaded avatar wins.
   const src = ssoManaged
     ? providerAvatar || avatarUrl || undefined
     : avatarUrl || providerAvatar || undefined;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -28,6 +28,13 @@ export const ssoProvider = (import.meta.env.VITE_SSO_PROVIDER ||
 // point it anywhere or leave it blank.
 export const accountUrl = (import.meta.env.VITE_ACCOUNT_URL || '') as string;
 
+// The single "Adam owns this profile" flag: true only when SSO is on AND an
+// external account page exists — i.e. name / avatar / password / delete are
+// managed by the provider, not in-app. Every SSO gate (UserAvatar, SettingsView,
+// useProfile) imports THIS constant, so the condition can't drift between them.
+// False in self-host, or SSO without an account page (in-app controls win).
+export const ssoManaged = Boolean(ssoProvider && accountUrl);
+
 // Fallback values keep the client constructable so imports don't throw
 // when env vars are missing. The app should gate on isSupabaseConfigMissing
 // and avoid making real requests in this state.

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,7 +1,21 @@
+import { User } from '@supabase/supabase-js';
 import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/lib/supabase';
+import { supabase, ssoProvider, ssoManaged } from '@/lib/supabase';
 import { Profile } from '@shared/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+// Under SSO the display name is owned by the identity provider (Adam), whose
+// current value rides in the session — GoTrue refreshes the linked identity on
+// every sign-in. Prefer it over the local `profiles` mirror so a rename on the
+// Adam account page shows up everywhere — gated on the same shared `ssoManaged`
+// flag UserAvatar uses for the photo, so name and avatar can't diverge. When
+// !ssoManaged (in-app editor live, or self-host) the local mirror wins.
+function ssoDisplayName(user: User | null): string | undefined {
+  if (!ssoManaged || !user) return undefined;
+  const identity = user.identities?.find((i) => i.provider === ssoProvider);
+  const claims = { ...user.user_metadata, ...identity?.identity_data };
+  return claims.full_name || claims.name || undefined;
+}
 
 export function useProfile() {
   const { user } = useAuth();
@@ -24,6 +38,12 @@ export function useProfile() {
       return data;
     },
     enabled: !!user?.id,
+    // Every name read flows through here, so resolve it in one place: under SSO
+    // the provider's name wins over the local mirror (which is display-only).
+    select: (profile) => {
+      const name = ssoDisplayName(user);
+      return name ? { ...profile, full_name: name } : profile;
+    },
   });
 }
 

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -18,7 +18,7 @@ import { useProfile, useUpdateProfile } from '@/services/profileService';
 import { AvatarUpdateDialog } from '@/components/auth/AvatarUpdateDialog';
 import { useTokenPacks } from '@/hooks/useTokenPacks';
 import { PLAN_DISPLAY_NAMES } from '@/config/plan-features';
-import { accountUrl, ssoProvider } from '@/lib/supabase';
+import { accountUrl, ssoManaged } from '@/lib/supabase';
 import { UserAvatar } from '@/components/chat/UserAvatar';
 
 function formatPeriodEnd(iso: string | null | undefined): string | null {
@@ -142,8 +142,8 @@ export default function SettingsView() {
   // When SSO owns the identity and an external account page is configured,
   // profile / email / password / delete are managed there (the
   // accounts.google.com model) rather than edited in-app. Self-host (no SSO
-  // or no account URL) keeps the native controls.
-  const ssoManaged = Boolean(ssoProvider && accountUrl);
+  // or no account URL) keeps the native controls. `ssoManaged` is imported from
+  // @/lib/supabase so every SSO gate shares one definition.
 
   const tierLabel = `Adam ${PLAN_DISPLAY_NAMES[level]}`;
 


### PR DESCRIPTION
## Bug
Under redirect-only SSO, CADAM's displayed name is owned by Adam, but the app rendered `profiles.full_name` — a row written **once** by the `handle_new_user()` trigger at account creation and never re-synced. So a rename on the Adam account page never reached the sidebar, Settings, or avatar initials (even across sign-out/in).

## Fix
Resolve the name in the **one place every read already flows through** — `useProfile()`'s `select`. Under SSO the provider's current name (from the session's linked identity, which GoTrue refreshes on every sign-in; `user_metadata` fallback) wins over the local mirror.

- **Consistent with #227** — that's exactly how `UserAvatar` already derives the photo. Name and avatar now follow the same rule.
- **No mirror, no write-back, no effect** — `profiles.full_name` is client-display only, so there's nothing to persist; the value is derived live.
- **Gated on `ssoProvider`** — self-host keeps its locally-edited name untouched.
- **Zero read-site churn** — the sidebar, Settings, PromptView, and avatar initials all read through `useProfile`, so one `select` fixes them all.

Supersedes the earlier useEffect-sync approach (over-engineered — deriving at read is simpler and matches the avatar).