### PR TITLE
fix(auth): read the SSO name from the identity's `name` claim, not stale `full_name`

### DIFF
--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -4,17 +4,21 @@ import { supabase, ssoProvider, ssoManaged } from '@/lib/supabase';
 import { Profile } from '@shared/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-// Under SSO the display name is owned by the identity provider (Adam), whose
-// current value rides in the session — GoTrue refreshes the linked identity on
-// every sign-in. Prefer it over the local `profiles` mirror so a rename on the
-// Adam account page shows up everywhere — gated on the same shared `ssoManaged`
-// flag UserAvatar uses for the photo, so name and avatar can't diverge. When
-// !ssoManaged (in-app editor live, or self-host) the local mirror wins.
+// Under SSO the display name is owned by the identity provider (Adam). Read it
+// from the linked identity's identity_data, which GoTrue refreshes from the
+// OIDC `name` claim on every sign-in. Two things matter here, both learned the
+// hard way:
+//   - Use `identity_data`, NOT `user_metadata`: GoTrue refreshes the identity
+//     on each login but leaves user_metadata at its first-login value.
+//   - Use the `name` claim specifically. identity_data also carries a
+//     `full_name` that Adam does NOT keep current (it lags the rename), so
+//     `full_name || name` returns the stale value. `name` is the live one.
+// !ssoManaged (in-app editor live, or self-host) → return undefined and let the
+// local profiles mirror win.
 function ssoDisplayName(user: User | null): string | undefined {
   if (!ssoManaged || !user) return undefined;
   const identity = user.identities?.find((i) => i.provider === ssoProvider);
-  const claims = { ...user.user_metadata, ...identity?.identity_data };
-  return claims.full_name || claims.name || undefined;
+  return identity?.identity_data?.name || undefined;
 }
 
 export function useProfile() {


### PR DESCRIPTION
Follow-up to #230. The name was still stale because the code read `full_name || name` off `{...user_metadata, ...identity_data}`.

**Verified against the live GoTrue `/user` record for a renamed account:**
- `identity_data.name` = current name ✅ (GoTrue refreshes this every sign-in)
- `identity_data.full_name` = **pre-rename** name ❌ (Adam doesn't keep this current)
- `user_metadata.full_name` = pre-rename name ❌ (GoTrue never refreshes user_metadata)

So `full_name || name` grabbed the stale value and never reached the fresh `name`. Fix: read `identity_data.name` directly — the OIDC-standard claim GoTrue refreshes on every login. No user_metadata, no full_name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale SSO display names by reading `identity_data.name` (OIDC `name` claim) instead of `full_name` or `user_metadata`, so renamed users see the correct name. Applies only when `ssoManaged` is true; non-SSO keeps using the local profile.

- **Bug Fixes**
  - Use `identity_data.name` directly, which GoTrue refreshes on each sign-in.
  - Drop `user_metadata` and `identity_data.full_name` to avoid stale values.

<sup>Written for commit d816b54ddcc32add80f0fe131878d7be12c5b3b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

