### PR TITLE
fix(auth): read SSO profile fields (name, picture) from the live identity, not stale user_metadata

### DIFF
--- a/src/components/chat/UserAvatar.tsx
+++ b/src/components/chat/UserAvatar.tsx
@@ -2,21 +2,23 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useProfile, useAvatarUrl } from '@/services/profileService';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { getInitials } from '@/lib/utils';
-import { ssoManaged } from '@/lib/supabase';
+import { ssoClaims, ssoManaged } from '@/lib/supabase';
 
 export function UserAvatar({ className }: { className?: string }) {
   const { user } = useAuth();
   const { data: profile } = useProfile();
   const { data: avatarUrl } = useAvatarUrl(profile?.avatar_path);
 
-  // Supabase GoTrue stores the OIDC `picture` claim in user_metadata (as
-  // `avatar_url`, and sometimes `picture`), so `providerAvatar` is the SSO
-  // account's photo; `avatarUrl` is the CADAM-local, self-uploaded picture.
-  // Provider-agnostic — works for any Supabase OAuth provider.
+  // The provider photo. Under SSO read it from the fresh identity claims (the
+  // same source as the name) — NOT user_metadata, which GoTrue leaves stale. In
+  // self-host, fall back to whatever the OAuth provider put in user_metadata.
+  const claims = ssoClaims(user);
   const metadata = user?.user_metadata as
     | { avatar_url?: string; picture?: string }
     | undefined;
-  const providerAvatar = metadata?.avatar_url || metadata?.picture;
+  const providerAvatar = claims
+    ? claims.picture || claims.avatar_url
+    : metadata?.avatar_url || metadata?.picture;
 
   // When Adam owns the profile (shared `ssoManaged` flag) the provider photo is
   // the single source of truth and wins, so a stale CADAM-local upload can't

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Session, User } from '@supabase/supabase-js';
-import { supabase } from '@/lib/supabase';
+import { supabase, ssoClaims } from '@/lib/supabase';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import posthog from 'posthog-js';
@@ -217,7 +217,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     ) {
       posthog.identify(user.id, {
         email: user.email,
-        full_name: profile?.full_name,
+        full_name: ssoClaims(user)?.name || profile?.full_name,
         subscription: getLevel(billing),
         has_trialed: billing?.user.hasTrialed ?? false,
       });

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,4 @@
-import { createClient, Provider } from '@supabase/supabase-js';
+import { createClient, Provider, User } from '@supabase/supabase-js';
 import { Database } from '@shared/database';
 
 const rawSupabaseUrl = import.meta.env.VITE_SUPABASE_URL;
@@ -34,6 +34,18 @@ export const accountUrl = (import.meta.env.VITE_ACCOUNT_URL || '') as string;
 // useProfile) imports THIS constant, so the condition can't drift between them.
 // False in self-host, or SSO without an account page (in-app controls win).
 export const ssoManaged = Boolean(ssoProvider && accountUrl);
+
+// The fresh provider-owned claims for the signed-in user: the SSO identity's
+// identity_data, which GoTrue refreshes from the OIDC token on EVERY sign-in.
+// This is the ONE source for provider-owned profile fields (name, picture, …)
+// under SSO — `user_metadata` is NOT refreshed by GoTrue (it keeps the
+// first-login value), so it must never be read for these. Matched by the
+// configured provider, so it's the Adam identity here (and the right provider
+// for a self-hoster). undefined when SSO isn't managing the profile.
+export function ssoClaims(user: User | null) {
+  if (!ssoManaged || !user) return undefined;
+  return user.identities?.find((i) => i.provider === ssoProvider)?.identity_data;
+}
 
 // Fallback values keep the client constructable so imports don't throw
 // when env vars are missing. The app should gate on isSupabaseConfigMissing

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,24 +1,15 @@
 import { User } from '@supabase/supabase-js';
 import { useAuth } from '@/contexts/AuthContext';
-import { supabase, ssoProvider, ssoManaged } from '@/lib/supabase';
+import { supabase, ssoClaims } from '@/lib/supabase';
 import { Profile } from '@shared/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-// Under SSO the display name is owned by the identity provider (Adam). Read it
-// from the linked identity's identity_data, which GoTrue refreshes from the
-// OIDC `name` claim on every sign-in. Two things matter here, both learned the
-// hard way:
-//   - Use `identity_data`, NOT `user_metadata`: GoTrue refreshes the identity
-//     on each login but leaves user_metadata at its first-login value.
-//   - Use the `name` claim specifically. identity_data also carries a
-//     `full_name` that Adam does NOT keep current (it lags the rename), so
-//     `full_name || name` returns the stale value. `name` is the live one.
-// !ssoManaged (in-app editor live, or self-host) → return undefined and let the
-// local profiles mirror win.
+// Under SSO the display name is owned by the identity provider (Adam): the live
+// `name` claim from ssoClaims (GoTrue refreshes it every sign-in). NOT the
+// `full_name` claim — Adam's identity_data carries a stale full_name while
+// `name` is current. undefined off-SSO → the local profiles mirror wins.
 function ssoDisplayName(user: User | null): string | undefined {
-  if (!ssoManaged || !user) return undefined;
-  const identity = user.identities?.find((i) => i.provider === ssoProvider);
-  return identity?.identity_data?.name || undefined;
+  return ssoClaims(user)?.name || undefined;
 }
 
 export function useProfile() {


### PR DESCRIPTION
Follow-up to #231. Same root cause (GoTrue refreshes `identity_data` every login, never `user_metadata`), swept across every remaining field:

- **Avatar** — `UserAvatar` read `user_metadata.avatar_url/picture` (stale) → now reads the SSO identity's fresh `picture`.
- **PostHog** — `AuthProvider` sent `profile.full_name` from its own query (not `useProfile`), stale under SSO → now the fresh identity name.
- Centralized into one `ssoClaims(user)` helper so name + picture + analytics read the single fresh source and can't drift.
- `user.email` is the canonical GoTrue field, not a mirror — left as-is.

Verified against the live GoTrue record; will confirm the rendered avatar in-browser after deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SSO profile name and avatar to read from the live identity (`identity_data`) instead of stale `user_metadata`, so avatars and analytics stay current. Adds `ssoClaims(user)` and uses it for avatar, analytics, and display name.

- **Bug Fixes**
  - Avatar: `UserAvatar` now uses the SSO identity `picture`; falls back to `user_metadata` only when not SSO-managed.
  - Analytics: `AuthProvider` sends the fresh identity `name` to PostHog instead of `profile.full_name`.
  - Profile: `ssoDisplayName` reads the live `name` claim and avoids stale `full_name`.

- **Refactors**
  - Introduced `ssoClaims(user)` in `@/lib/supabase` to provide a single source for SSO-owned fields (name, picture).

<sup>Written for commit d1da4e6a8d394f3e9dddfefb5f6e68222141bbec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

