### PR TITLE
feat(models): replace GPT-5.5 with GPT-5.6 Sol

### DIFF
--- a/shared/models.ts
+++ b/shared/models.ts
@@ -1,0 +1,12 @@
+import type { Model } from './types';
+
+// Model ids persisted in conversation settings (and submitted by stale
+// clients) outlive the picker catalog. Map retired ids to their successors
+// so old conversations keep resolving to a routable, correctly priced model.
+export const LEGACY_MODEL_IDS: Record<string, Model> = {
+  'openai/gpt-5.5': 'openai/gpt-5.6-sol',
+};
+
+export function normalizeModelId(model: Model): Model {
+  return LEGACY_MODEL_IDS[model] ?? model;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -273,8 +273,8 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'openai/gpt-5.5',
-    name: 'GPT-5.5',
+    id: 'openai/gpt-5.6-sol',
+    name: 'GPT-5.6 Sol',
     description: 'Latest OpenAI model for reliable CAD generation',
     provider: 'OpenAI',
     supportsTools: true,

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -5,6 +5,7 @@ import { chatTools, type AppUIMessage, type AppTools } from '@shared/chatAi';
 import { cleanAssistantText, getParametricText } from '@shared/parametricParts';
 import { imageIdFromFilename, imageStoragePath } from '@shared/imageRefs';
 import { normalizeConversationSuggestions } from '@shared/suggestions';
+import { normalizeModelId } from '@shared/models';
 import type { Conversation, Message, MeshFileType, Model } from '@shared/types';
 import {
   convertToModelMessages,
@@ -71,7 +72,12 @@ const MODEL_PRICES: Record<
   },
 
   // OpenAI — prompt-cache reads at 10% of input, cache writes at 1.25x.
-  'openai/gpt-5.6-sol': { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+  'openai/gpt-5.6-sol': {
+    input: 5,
+    output: 30,
+    cacheRead: 0.5,
+    cacheWrite: 6.25,
+  },
 
   // MoonshotAI
   'moonshotai/kimi-k2.6': { input: 0.6, output: 2.5 },
@@ -949,7 +955,7 @@ function chatModel(conversation: ConversationAccess, model: Model) {
   if (conversation.type === 'creative') {
     return 'anthropic/claude-sonnet-4.5';
   }
-  return model;
+  return normalizeModelId(model);
 }
 
 function systemPrompt(conversation: ConversationAccess) {

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -70,8 +70,8 @@ const MODEL_PRICES: Record<
     cacheWrite: 1.25,
   },
 
-  // OpenAI — prompt-cache reads at 50% of input.
-  'openai/gpt-5.5': { input: 5, output: 20, cacheRead: 2.5, cacheWrite: 5 },
+  // OpenAI — prompt-cache reads at 10% of input, cache writes at 1.25x.
+  'openai/gpt-5.6-sol': { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
 
   // MoonshotAI
   'moonshotai/kimi-k2.6': { input: 0.6, output: 2.5 },

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -23,6 +23,7 @@ import {
   type ChatMessage,
 } from '@/lib/aiMessages';
 import parseParameters from '@shared/parseParameters';
+import { normalizeModelId } from '@shared/models';
 import { supabase } from '@/lib/supabase';
 import { updateParameter } from '@/lib/utils';
 import {
@@ -189,10 +190,11 @@ function ConversationEditor() {
 
   // ── Per-conversation UI state ───────────────────────────────────────────
   const [model, setModel] = useState<Model>(
-    conversation.settings?.model ??
-      (conversation.type === 'creative'
+    conversation.settings?.model
+      ? normalizeModelId(conversation.settings.model)
+      : conversation.type === 'creative'
         ? 'quality'
-        : 'google/gemini-3.1-pro-preview'),
+        : 'google/gemini-3.1-pro-preview',
   );
   const [activePreview, setActivePreview] = useState<ActivePreview>(null);
   const [parameters, setParameters] = useState<Parameter[]>([]);


### PR DESCRIPTION
## Summary
- Swap the OpenAI model entry from `openai/gpt-5.5` to `openai/gpt-5.6-sol` in the model picker (`src/lib/utils.ts`)
- Update the pricing table in `src/server/aiChat.ts` per OpenAI's published pricing: output $20 → $30/M, cache reads at 10% of input ($0.50/M), cache writes at 1.25× input ($6.25/M)

## Notes
- Capability flags (tools, thinking, vision) unchanged.
- OpenAI bills prompts over 272K input tokens at 2× input / 1.5× output for the full request; the flat pricing table doesn't model that, so estimates undercount very large prompts (same limitation as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swapped `openai/gpt-5.5` to `openai/gpt-5.6-sol` with legacy-id normalization so old conversations keep working and bill correctly; capability flags unchanged. Updated pricing to output $30/M, cache reads $0.50/M (10% of input), cache writes $6.25/M (1.25× input).

<sup>Written for commit c9ea7180b2321122a00398a2928a5015dd4944bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

