### PR TITLE
feat(models): add Grok 4.5 to the model picker

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -282,6 +282,15 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
+    id: 'x-ai/grok-4.5',
+    name: 'Grok 4.5',
+    description: 'Latest xAI model with frontier coding and STEM performance',
+    provider: 'xAI',
+    supportsTools: true,
+    supportsThinking: true,
+    supportsVision: true,
+  },
+  {
     id: 'z-ai/glm-5.2',
     name: 'GLM 5.2',
     description: 'Z.AI model with strong agentic coding and reasoning',

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -79,6 +79,9 @@ const MODEL_PRICES: Record<
     cacheWrite: 6.25,
   },
 
+  // xAI — cached input reads at 25% of input; no cache-write surcharge.
+  'x-ai/grok-4.5': { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 2 },
+
   // MoonshotAI
   'moonshotai/kimi-k2.6': { input: 0.6, output: 2.5 },
 


### PR DESCRIPTION
## Summary
- Add `x-ai/grok-4.5` to `PARAMETRIC_MODELS` so it shows up in the model picker, with tools, thinking, and vision enabled — all confirmed against OpenRouter's model metadata (reasoning is mandatory on this model, and it accepts image input).
- Add pricing to `MODEL_PRICES`: $2/M input, $6/M output, cache reads at 25% of input ($0.50/M). `cacheWrite` is set to the input rate explicitly because xAI has no cache-write surcharge and omitting it would bill writes at the 1.25× fallback.

No routing or type changes needed: `providerFor()` already sends anything that isn't `anthropic/` or `google/` through OpenRouter, `Model` is a plain string, and the picker UI doesn't key off the provider name.

## Test plan
- [x] `npm run typecheck` passes
- [ ] Select Grok 4.5 in the picker and run a parametric generation end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `x-ai/grok-4.5` to the model picker with tools, thinking, and vision enabled, and configures pricing for correct billing via OpenRouter. No routing or type changes needed.

- **New Features**
  - Exposes `x-ai/grok-4.5` in the picker; supports tools, thinking (required), and vision (image input).
  - Pricing: $2/M input, $6/M output; `cacheRead` $0.50/M (25% of input); `cacheWrite` $2/M.

<sup>Written for commit a4538e4f750b2de086a2261a304dd17d05ab3f07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

