### PR TITLE
feat(models): add Kimi K3 to the model picker

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -291,6 +291,16 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
+    id: 'moonshotai/kimi-k3',
+    name: 'Kimi K3',
+    description:
+      'Moonshot AI reasoning model for complex coding and agentic work',
+    provider: 'Moonshot AI',
+    supportsTools: true,
+    supportsThinking: true,
+    supportsVision: true,
+  },
+  {
     id: 'z-ai/glm-5.2',
     name: 'GLM 5.2',
     description: 'Z.AI model with strong agentic coding and reasoning',

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -82,8 +82,9 @@ const MODEL_PRICES: Record<
   // xAI — cached input reads at 25% of input; no cache-write surcharge.
   'x-ai/grok-4.5': { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 2 },
 
-  // MoonshotAI
+  // MoonshotAI — cached input reads at 10% of input; no cache-write surcharge.
   'moonshotai/kimi-k2.6': { input: 0.6, output: 2.5 },
+  'moonshotai/kimi-k3': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3 },
 
   // Z.AI
   'z-ai/glm-5.2': { input: 1.2, output: 4.1 },


### PR DESCRIPTION
## Summary
- Add `moonshotai/kimi-k3` to `PARAMETRIC_MODELS` with tools, thinking, and vision enabled (all confirmed via OpenRouter's model metadata)
- Price it in `MODEL_PRICES` at $3/M input, $15/M output, cache reads at 10% of input ($0.30/M); `cacheWrite` is set to the input rate explicitly since Moonshot has no cache-write surcharge and the omitted-field fallback would bill 1.25x

No routing changes needed: non-Anthropic/Google ids already flow through OpenRouter.

## Test plan
- [x] `npm run typecheck` passes
- [ ] Select Kimi K3 in the picker and run a parametric generation end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `moonshotai/kimi-k3` to the model picker with tools, thinking, and vision enabled. Set pricing and cache rates for accurate billing via OpenRouter.

- **New Features**
  - Added `moonshotai/kimi-k3` to `PARAMETRIC_MODELS` (tools, thinking, vision).
  - Set `MODEL_PRICES`: input $3/M, output $15/M, `cacheRead` $0.30/M, `cacheWrite` $3/M.
  - No routing changes needed; non-Anthropic/Google IDs already go through OpenRouter.

<sup>Written for commit 2e375c0c95e0dfb663d1345fbf7bb431a4bfa02a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

