### PR TITLE
feat(models): make GPT-5.6 Sol the default parametric model

### DIFF
--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -194,7 +194,7 @@ function ConversationEditor() {
       ? normalizeModelId(conversation.settings.model)
       : conversation.type === 'creative'
         ? 'quality'
-        : 'google/gemini-3.1-pro-preview',
+        : 'openai/gpt-5.6-sol',
   );
   const [activePreview, setActivePreview] = useState<ActivePreview>(null);
   const [parameters, setParameters] = useState<Parameter[]>([]);

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -51,7 +51,7 @@ export function PromptView() {
 
   const [type, setType] = useState<'parametric' | 'creative'>('parametric');
 
-  const [model, setModel] = useState<Model>('google/gemini-3.1-pro-preview');
+  const [model, setModel] = useState<Model>('openai/gpt-5.6-sol');
 
   const handleTypeChange = (newType: 'parametric' | 'creative') => {
     setType(newType);
@@ -59,7 +59,7 @@ export function PromptView() {
     if (newType === 'creative') {
       setModel('quality');
     } else {
-      setModel('google/gemini-3.1-pro-preview');
+      setModel('openai/gpt-5.6-sol');
     }
   };
 


### PR DESCRIPTION
## Summary
- Switch the default parametric model from Gemini 3.1 Pro to GPT-5.6 Sol (`openai/gpt-5.6-sol`) in the three places the default is hardcoded:
  - `PromptView` initial state
  - `PromptView` reset when toggling back from creative to parametric
  - `EditorView` fallback for conversations without a saved model setting
- Conversations with a saved model keep it; the creative-mode default (`quality`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the default parametric model to `openai/gpt-5.6-sol` to standardize new parametric conversations.

- New Features
  - Applied in `PromptView` initial state, parametric reset on toggle, and `EditorView` fallback when no model is saved.
  - Saved conversation models and the creative default (`quality`) are unchanged.

<sup>Written for commit 42458ac650a686e82a8c99793a5d7685c085e889. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

