### PR TITLE
feat(models): add Gemini 3.6 Flash to the model picker

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -246,6 +246,15 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
+    id: 'google/gemini-3.6-flash',
+    name: 'Gemini 3.6 Flash',
+    description: 'Fast, token-efficient Google model for everyday tasks',
+    provider: 'Google',
+    supportsTools: true,
+    supportsThinking: true,
+    supportsVision: true,
+  },
+  {
     id: 'anthropic/claude-fable-5',
     name: 'Claude Fable 5',
     description: 'Most capable Anthropic model; best reasoning at highest cost',

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -61,14 +61,21 @@ const MODEL_PRICES: Record<
   'anthropic/claude-sonnet-4.5': { input: 3, output: 15 },
   'anthropic/claude-haiku-4.5': { input: 1, output: 5 },
 
-  // Google — cached content reads bill at ~25% of input price; there is
-  // no cache-write surcharge (cache storage is billed per-hour, which
-  // we don't track here).
+  // Google — cached content reads bill at a fraction of input price
+  // (~25% for 3.1 Pro, 10% for 3.6 Flash); there is no cache-write
+  // surcharge (cache storage is billed per-hour, which we don't track
+  // here).
   'google/gemini-3.1-pro-preview': {
     input: 1.25,
     output: 10,
     cacheRead: 0.31,
     cacheWrite: 1.25,
+  },
+  'google/gemini-3.6-flash': {
+    input: 1.5,
+    output: 7.5,
+    cacheRead: 0.15,
+    cacheWrite: 1.5,
   },
 
   // OpenAI — prompt-cache reads at 10% of input, cache writes at 1.25x.


### PR DESCRIPTION
## Summary
- Add `google/gemini-3.6-flash` to `PARAMETRIC_MODELS` (tools, thinking, and vision all supported per [Google's model docs](https://deepmind.google/models/gemini/flash/))
- Price it per [Google's pricing page](https://ai.google.dev/gemini-api/docs/pricing): $1.50/M input, $7.50/M output, cache reads at 10% of input ($0.15/M). `cacheWrite` is set to the input rate explicitly since Google has no cache-write surcharge and the fallback would bill 1.25x
- Fix the Google pricing comment, which claimed ~25% cache reads across the board — that holds for 3.1 Pro but Flash reads at 10%

No routing or UI changes needed: `google/`-prefixed ids already route directly to the Google AI SDK (which receives the correct bare id `gemini-3.6-flash`), and the provider logo is keyed by `provider: 'Google'`, which already exists.

## Test plan
- [x] `npm run typecheck` passes
- [x] eslint on both changed files passes
- [ ] Verify Gemini 3.6 Flash appears in the model picker with the Google logo and generates a model end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `google/gemini-3.6-flash` to the model picker and configures accurate pricing, including cache rates. No routing or UI changes needed.

- **New Features**
  - Added `google/gemini-3.6-flash` to `PARAMETRIC_MODELS` (tools, thinking, vision supported).
  - Added pricing: $1.50/M input, $7.50/M output, cacheRead $0.15/M (10%), cacheWrite $1.50/M.
  - Corrected Google pricing comment to note 10% cache reads for 3.6 Flash (vs ~25% for 3.1 Pro).

<sup>Written for commit 4adb11c3bae4f1d3ecf48764d00061df76c4b0aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

