### PR TITLE
feat(models): swap Grok 4.5 for Grok 4.6 in the model picker

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -291,8 +291,8 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'x-ai/grok-4.5',
-    name: 'Grok 4.5',
+    id: 'x-ai/grok-4.6',
+    name: 'Grok 4.6',
     description: 'Latest xAI model with frontier coding and STEM performance',
     provider: 'xAI',
     supportsTools: true,

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -87,7 +87,7 @@ const MODEL_PRICES: Record<
   },
 
   // xAI — cached input reads at 25% of input; no cache-write surcharge.
-  'x-ai/grok-4.5': { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 2 },
+  'x-ai/grok-4.6': { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 2 },
 
   // MoonshotAI — cached input reads at 10% of input; no cache-write surcharge.
   'moonshotai/kimi-k2.6': { input: 0.6, output: 2.5 },


### PR DESCRIPTION
## Summary
- Replace Grok 4.5 with Grok 4.6 (`x-ai/grok-4.6`) in the model picker
- Update the pricing map key in `aiChat.ts`; pricing is unchanged ($2/$6 per 1M tokens, cached reads at 25% of input) per OpenRouter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces `x-ai/grok-4.5` with `x-ai/grok-4.6` in the model picker so users select the latest xAI model. Pricing remains unchanged ($2/$6 per 1M tokens; cached reads at 25% of input).

- Updates `PARAMETRIC_MODELS` entry and switches the `MODEL_PRICES` key to `x-ai/grok-4.6`.
- Update any configs, feature flags, or saved preferences referencing `x-ai/grok-4.5` to `x-ai/grok-4.6`; no alias for the old id.

<sup>Written for commit 637250d068f0698f509615e91f3912a86b46d1b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

