### PR TITLE
fix(parametric): surface OpenSCAD stderr to the agent so BOSL2 builds self-correct

### DIFF
--- a/src/hooks/useOpenSCAD.ts
+++ b/src/hooks/useOpenSCAD.ts
@@ -5,6 +5,7 @@ import {
   WorkerMessageType,
 } from '@/worker/types';
 import OpenSCADError from '@/lib/OpenSCADError';
+import { errorFromWorker } from '@/worker/workerError';
 import { normalizeOpenSCADDxf } from '@/utils/dxfUtils';
 
 // Type for pending request resolvers
@@ -59,7 +60,7 @@ export function useOpenSCAD() {
       pendingRequestsRef.current.delete(id);
 
       if (err) {
-        pending.reject(new Error(err.message || 'Worker operation failed'));
+        pending.reject(errorFromWorker(err));
       } else {
         pending.resolve(event.data.data);
       }

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -166,9 +166,10 @@ Geometry:
 - Use modules for repeated or meaningful model parts.
 
 BOSL2 library guidance:
-- BOSL2 is available to OpenSCAD code when the generated source includes the
-  literal token \`BOSL2\`. Include \`<BOSL2/std.scad>\` plus the specific module
-  file whenever the request needs a higher-level CAD primitive.
+- BOSL2 is available to OpenSCAD code when the generated source contains an
+  \`include <BOSL2/...>\` or \`use <BOSL2/...>\` statement. Include
+  \`<BOSL2/std.scad>\` plus the specific module file whenever the request needs
+  a higher-level CAD primitive.
 - For screws, bolts, nuts, threaded rods, or tapped/threaded holes, use BOSL2
   instead of trying to build threads from \`cylinder()\`, \`linear_extrude()\`,
   or hand-rolled helices. Include \`<BOSL2/screws.scad>\` for \`screw()\`,

--- a/src/worker/openSCAD.ts
+++ b/src/worker/openSCAD.ts
@@ -323,14 +323,22 @@ class OpenSCADWrapper {
     }
 
     for (const library of libraries) {
+      // Match a real `include <BOSL2/...>` / `use <BOSL2/...>` statement, not a
+      // bare substring: "BOSL2" contains "BOSL", so substring matching mounted
+      // BOSL alongside BOSL2 on every compile, and a library name in a comment
+      // triggered a pointless fetch.
+      const libraryStatement = new RegExp(`(include|use)\\s*<${library.name}/`);
       if (
-        code.includes(library.name) &&
+        libraryStatement.test(code) &&
         !importLibraries.includes(library.name)
       ) {
         importLibraries.push(library.name);
 
         try {
           const response = await fetch(library.url);
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status} fetching ${library.url}`);
+          }
 
           // Unzip the file
           const zip = await response.blob();
@@ -364,7 +372,14 @@ class OpenSCADWrapper {
               }),
           );
         } catch (error) {
-          console.error('Error importing library', library.name, error);
+          // Fail the compile rather than continuing without the library:
+          // OpenSCAD would only report "Ignoring unknown module ..." per call
+          // site, which hides the real cause from both the user and the AI
+          // build loop.
+          throw new Error(
+            `Failed to load OpenSCAD library ${library.name}: ` +
+              (error instanceof Error ? error.message : String(error)),
+          );
         }
       }
     }
@@ -384,11 +399,16 @@ class OpenSCADWrapper {
     try {
       exitCode = instance.callMain(args);
     } catch (error) {
-      if (error instanceof Error) {
-        throw new Error('Adam exited with an error: ' + error.message);
-      } else {
-        throw new Error('Adam exited with an error');
-      }
+      // Throw OpenSCADError (not plain Error) so the stderr OpenSCAD printed
+      // before dying survives the worker boundary — it usually names the real
+      // problem (syntax error, unknown module) while the thrown value is often
+      // just an opaque number from the wasm runtime.
+      throw new OpenSCADError(
+        'Adam exited with an error' +
+          (error instanceof Error ? ': ' + error.message : ''),
+        code,
+        this.log.stdErr,
+      );
     }
 
     if (exitCode === 0) {

--- a/src/worker/openSCAD.ts
+++ b/src/worker/openSCAD.ts
@@ -24,6 +24,51 @@ const EXPORT_FORMAT_FLAGS: Record<string, string> = {
   dxf: 'dxf',
 };
 
+/**
+ * Blank out string literals and comments so library detection only sees
+ * active code. Regexes can't do this reliably (a `//` inside a string, a
+ * quote inside a comment), so this is a single-pass scanner over OpenSCAD's
+ * lexical shapes: double-quoted strings with backslash escapes, `//` line
+ * comments, and slash-star block comments. Replaced spans become spaces so a
+ * detection regex can never match across a removed region; newlines are kept
+ * so nothing merges across lines.
+ *
+ * Without this, a commented-out `include <BOSL2/std.scad>` (or one quoted in
+ * an `echo()`) would trigger a library fetch — and a failed fetch is fatal to
+ * the compile, which must never happen for a library the code doesn't use.
+ */
+export function stripStringsAndComments(code: string): string {
+  let out = '';
+  let i = 0;
+  const n = code.length;
+  while (i < n) {
+    const ch = code[i];
+    if (ch === '"') {
+      i++;
+      while (i < n && code[i] !== '"') {
+        if (code[i] === '\n') out += '\n';
+        i += code[i] === '\\' ? 2 : 1;
+      }
+      i++;
+      out += ' ';
+    } else if (ch === '/' && code[i + 1] === '/') {
+      while (i < n && code[i] !== '\n') i++;
+    } else if (ch === '/' && code[i + 1] === '*') {
+      i += 2;
+      while (i < n && !(code[i] === '*' && code[i + 1] === '/')) {
+        if (code[i] === '\n') out += '\n';
+        i++;
+      }
+      i += 2;
+      out += ' ';
+    } else {
+      out += ch;
+      i++;
+    }
+  }
+  return out;
+}
+
 let defaultFont: ArrayBuffer;
 
 class OpenSCADWrapper {
@@ -322,14 +367,17 @@ class OpenSCADWrapper {
       instance.FS.mkdir('/libraries');
     }
 
+    // Detect against comment- and string-stripped source so only ACTIVE
+    // statements count — a commented-out include must not trigger a (now
+    // fatal-on-failure) library fetch.
+    const activeCode = stripStringsAndComments(code);
     for (const library of libraries) {
       // Match a real `include <BOSL2/...>` / `use <BOSL2/...>` statement, not a
       // bare substring: "BOSL2" contains "BOSL", so substring matching mounted
-      // BOSL alongside BOSL2 on every compile, and a library name in a comment
-      // triggered a pointless fetch.
+      // BOSL alongside BOSL2 on every compile.
       const libraryStatement = new RegExp(`(include|use)\\s*<${library.name}/`);
       if (
-        libraryStatement.test(code) &&
+        libraryStatement.test(activeCode) &&
         !importLibraries.includes(library.name)
       ) {
         importLibraries.push(library.name);

--- a/src/worker/toolWorker.ts
+++ b/src/worker/toolWorker.ts
@@ -19,6 +19,7 @@ import {
   WorkerMessage,
   WorkerMessageType,
 } from '@/worker/types';
+import { errorFromWorker } from '@/worker/workerError';
 
 type PendingRequest = {
   resolve: (value: OpenSCADWorkerResponseData) => void;
@@ -40,7 +41,9 @@ function getToolWorker(): Worker {
     if (!req) return;
     pending.delete(id);
     if (err) {
-      req.reject(new Error(err.message || 'Worker operation failed'));
+      // This rejection becomes the build tool's errorText — keep the
+      // compiler's stderr so the model can self-correct the OpenSCAD.
+      req.reject(errorFromWorker(err));
     } else {
       req.resolve(event.data.data);
     }

--- a/src/worker/workerError.ts
+++ b/src/worker/workerError.ts
@@ -1,0 +1,42 @@
+// Rebuild a useful Error from the `err` field of a worker response message.
+//
+// OpenSCAD compile failures cross the worker boundary as a serialized
+// OpenSCADError carrying `stdErr` — the compiler's actual diagnostics
+// ("Ignoring unknown module 'cuboid'", syntax errors with line numbers).
+// The promise-based callers (tool builds, thumbnail compiles, exports) used
+// to reject with `new Error(err.message)`, which reduced every failure to
+// "Adam did not exit correctly" — so the AI build loop had nothing to
+// self-correct against. Fold stderr into the message here so every consumer
+// of the rejection sees the real diagnostics.
+
+// Enough to include full BOSL2 assertion backtraces without letting a
+// runaway ECHO loop flood the model context.
+const MAX_STDERR_LINES = 100;
+
+type SerializedWorkerError = {
+  message?: string;
+  stdErr?: string[];
+};
+
+export function errorFromWorker(err: SerializedWorkerError): Error {
+  const message = err.message || 'Worker operation failed';
+  const stdErr = Array.isArray(err.stdErr)
+    ? err.stdErr.filter((line) => line.trim().length > 0)
+    : [];
+
+  if (stdErr.length === 0) return new Error(message);
+
+  // Diagnostics cluster at both ends: the first bad include/module up top,
+  // the fatal assertion or "Can't parse" at the bottom. Keep both halves.
+  const half = MAX_STDERR_LINES / 2;
+  const lines =
+    stdErr.length > MAX_STDERR_LINES
+      ? [
+          ...stdErr.slice(0, half),
+          `... ${stdErr.length - MAX_STDERR_LINES} more lines ...`,
+          ...stdErr.slice(-half),
+        ]
+      : stdErr;
+
+  return new Error(`${message}\n${lines.join('\n')}`);
+}


### PR DESCRIPTION
## Problem

The agent is prompted to use BOSL2 (screws, threading, path_sweep) and the library is bundled and mounted — but its write → compile → fix loop was blind. Compile failures cross the worker boundary as `OpenSCADError` carrying the compiler's stderr, and both promise bridges rejected with `new Error(err.message)`, reducing every failure to **"Adam did not exit correctly"**. The model had no diagnostics to correct against, so any BOSL2 mistake (typo'd module, bad include, wrong arg) dead-ended the build loop.

## Changes

- **`src/worker/workerError.ts` (new)** — `errorFromWorker()` folds stderr into the rejection message (capped at 100 lines, head + tail kept, since diagnostics cluster at both ends) so the build tool's `errorText` carries the real compiler output.
- **`src/worker/toolWorker.ts` / `src/hooks/useOpenSCAD.ts`** — both pending-promise bridges reject with the rich error. The state-based viewer path (Fix with AI button) already passed the full error object through and is unchanged.
- **`src/worker/openSCAD.ts`**
  - `callMain` crash path throws `OpenSCADError` instead of plain `Error`, so stderr survives wasm-level crashes too (the thrown value is often an opaque number).
  - Library zip fetch/unzip failures now fail the compile with a clear message instead of `console.error` + downstream "Ignoring unknown module" noise.
  - Library detection matches a real `include <NAME/` / `use <NAME/` statement instead of substring: `BOSL2` no longer drags in BOSL on every compile, and a library name in a comment no longer triggers a fetch.
- **`src/server/aiChat.ts`** — the prompt's BOSL2 availability rule now matches the statement-based detection.

## Verification

Drove the real vendored wasm + bundled `BOSL2.zip` in Node with the worker's exact FS layout and flags (`/libraries/BOSL2/...`, `--backend=manifold --enable=lazy-union --enable=roof`, dual `-o /out.stl -o /out.off`; binstl flags for the export path). 8/8 checks:

```
PASS  BOSL2 screws.scad compiles (preview flags)  — stl=3174990B off=417605B
PASS  only BOSL2 mounted (not BOSL)  — ["BOSL2"]
PASS  BOSL2 threading.scad compiles  — stl=2944945B
PASS  BOSL2 skin/beziers path_sweep compiles  — stl=487836B
PASS  BOSL2 export path (binstl) compiles  — stl=7884B
PASS  failed compile stderr names the bad module  — WARNING: Ignoring unknown module 'cubooid' in file /input.scad, line 2
PASS  errorFromWorker puts the diagnostic in errorText
PASS  comment mention mounts nothing  — mounted=[]
```

`npm run typecheck` clean; eslint on changed files clean (two pre-existing warnings in `useOpenSCAD.ts` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces OpenSCAD stderr in worker rejections and mounts libraries only for active include/use statements. This replaces generic “did not exit correctly” errors with compiler diagnostics and prevents false BOSL/BOSL2 mounts.

- Both worker bridges now reject with `errorFromWorker()` including capped stderr (100 lines, head+tail); previously only `err.message` was propagated.
- `openSCAD`: throw `OpenSCADError` from `callMain` so stderr survives; detect libraries via real `include <NAME/...>` / `use <NAME/...>` against code with strings/comments stripped; fail the compile on library fetch/unzip errors with a clear message.
- Prompt guidance updated to match statement-based library detection.
- Side effects: error messages are longer; commented-out or echoed includes no longer mount libraries; compiles halt on missing libraries. No migration required.

<sup>Written for commit f1f3af41d7f8bdbcab4e10d6308096dec53d84c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

