### PR TITLE
feat(models): swap Gemini 3.6 Flash for Gemini 3.7 Flash in the model picker

### DIFF
--- a/shared/models.ts
+++ b/shared/models.ts
@@ -5,6 +5,7 @@ import type { Model } from './types';
 // so old conversations keep resolving to a routable, correctly priced model.
 export const LEGACY_MODEL_IDS: Record<string, Model> = {
   'openai/gpt-5.5': 'openai/gpt-5.6-sol',
+  'google/gemini-3.6-flash': 'google/gemini-3.7-flash',
 };
 
 export function normalizeModelId(model: Model): Model {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -246,8 +246,8 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'google/gemini-3.6-flash',
-    name: 'Gemini 3.6 Flash',
+    id: 'google/gemini-3.7-flash',
+    name: 'Gemini 3.7 Flash',
     description: 'Fast, token-efficient Google model for everyday tasks',
     provider: 'Google',
     supportsTools: true,

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -62,7 +62,7 @@ const MODEL_PRICES: Record<
   'anthropic/claude-haiku-4.5': { input: 1, output: 5 },
 
   // Google — cached content reads bill at a fraction of input price
-  // (~25% for 3.1 Pro, 10% for 3.6 Flash); there is no cache-write
+  // (~25% for 3.1 Pro, 10% for 3.7 Flash); there is no cache-write
   // surcharge (cache storage is billed per-hour, which we don't track
   // here).
   'google/gemini-3.1-pro-preview': {
@@ -71,11 +71,13 @@ const MODEL_PRICES: Record<
     cacheRead: 0.31,
     cacheWrite: 1.25,
   },
-  'google/gemini-3.6-flash': {
-    input: 1.5,
-    output: 7.5,
-    cacheRead: 0.15,
-    cacheWrite: 1.5,
+  // 3.7 Flash rates are Google's introductory pricing through Dec 31,
+  // 2026; they double on Jan 1, 2027 (to 1.5 / 7.5 / 0.15).
+  'google/gemini-3.7-flash': {
+    input: 0.75,
+    output: 3.75,
+    cacheRead: 0.075,
+    cacheWrite: 0.75,
   },
 
   // OpenAI — prompt-cache reads at 10% of input, cache writes at 1.25x.


### PR DESCRIPTION
## Summary
- Replace `google/gemini-3.6-flash` with `google/gemini-3.7-flash` in `PARAMETRIC_MODELS` (tools, thinking, and vision all still supported); picker description and capability flags unchanged
- Update `MODEL_PRICES` to Google's introductory rates: $0.75/M input, $3.75/M output, cache reads at 10% of input ($0.075/M), `cacheWrite` equal to input since Google has no cache-write surcharge
- Intro pricing runs through Dec 31, 2026 and doubles Jan 1, 2027 (to $1.50 / $7.50 / $0.15) — noted in a comment so the table gets bumped then

No routing or UI changes needed: `google/`-prefixed ids already route to the Google AI SDK and the provider logo is keyed by provider name.

Note: OpenRouter currently lists 3.7 Flash at $0.375/$1.875 with a "50% off" launch tag; this PR uses Google's official intro price as the durable number, matching how 3.6 Flash was priced.

## Test plan
- [x] `npm run typecheck` passes
- [x] Verified no remaining `gemini-3.6-flash` references in `src/` or `shared/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swap `google/gemini-3.6-flash` for `google/gemini-3.7-flash` in the model picker and use Google’s introductory pricing. Persisted 3.6 ids now remap to 3.7 so old conversations route and bill correctly.

- Update `PARAMETRIC_MODELS`: id/name now 3.7 Flash; same tools, thinking, and vision support.
- Add `LEGACY_MODEL_IDS` mapping: `google/gemini-3.6-flash` → `google/gemini-3.7-flash` for normalize and pricing.
- Set `MODEL_PRICES` for 3.7 Flash: $0.75/M input, $3.75/M output, `cacheRead` $0.075/M, `cacheWrite` $0.75/M; comment notes Jan 1, 2027 doubling.
- No routing/UI or config/schema changes; `google/` ids already route and logos resolve by provider. Persisted 3.6 ids require no migration.

<sup>Written for commit 4f4be2fd690c091e66122dff765c391c70065572. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

