### PR TITLE
feat(models): make Gemini 3.7 Flash the default model

### DIFF
--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -194,7 +194,7 @@ function ConversationEditor() {
       ? normalizeModelId(conversation.settings.model)
       : conversation.type === 'creative'
         ? 'quality'
-        : 'openai/gpt-5.6-sol',
+        : 'google/gemini-3.7-flash',
   );
   const [activePreview, setActivePreview] = useState<ActivePreview>(null);
   const [parameters, setParameters] = useState<Parameter[]>([]);

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -51,7 +51,7 @@ export function PromptView() {
 
   const [type, setType] = useState<'parametric' | 'creative'>('parametric');
 
-  const [model, setModel] = useState<Model>('openai/gpt-5.6-sol');
+  const [model, setModel] = useState<Model>('google/gemini-3.7-flash');
 
   const handleTypeChange = (newType: 'parametric' | 'creative') => {
     setType(newType);
@@ -59,7 +59,7 @@ export function PromptView() {
     if (newType === 'creative') {
       setModel('quality');
     } else {
-      setModel('openai/gpt-5.6-sol');
+      setModel('google/gemini-3.7-flash');
     }
   };
 


### PR DESCRIPTION
## Summary
- Change the default parametric model from GPT-5.6 Sol to Gemini 3.7 Flash in the three places the default was hardcoded:
  - `PromptView.tsx` initial model state
  - `PromptView.tsx` reset default when switching back to parametric mode
  - `EditorView.tsx` fallback for conversations with no saved model setting

GPT-5.6 Sol stays available in the picker, and conversations with a saved model setting keep their choice. The server already has a config entry for `google/gemini-3.7-flash`, so no backend changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `google/gemini-3.7-flash` the default parametric model instead of `openai/gpt-5.6-sol`. This affects new parametric prompts and conversations without a saved model; existing saved choices do not change.

- Updated defaults in:
  - `PromptView.tsx` initial model state.
  - `PromptView.tsx` reset when switching back to parametric.
  - `EditorView.tsx` fallback for conversations with no saved model.
- Side effects:
  - GPT-5.6 Sol remains available in the picker.
  - No backend changes; server already configures `google/gemini-3.7-flash`.
  - No migration required.

<sup>Written for commit 912ccf2e128488a38e792ef5b36c86536941e279. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

