### PR TITLE
fix: polyfill crypto.randomUUID for self-hosted HTTP (insecure context)

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -1,3 +1,4 @@
+import './lib/ensureRandomUUID';
 import * as Sentry from '@sentry/react';
 import { StartClient } from '@tanstack/react-start/client';
 import { StrictMode, startTransition } from 'react';

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -1,4 +1,5 @@
 import './lib/ensureRandomUUID';
+
 import * as Sentry from '@sentry/react';
 import { StartClient } from '@tanstack/react-start/client';
 import { StrictMode, startTransition } from 'react';

--- a/src/lib/ensureRandomUUID.ts
+++ b/src/lib/ensureRandomUUID.ts
@@ -30,9 +30,13 @@ function installRandomUUIDPolyfill(): void {
     const hex = Array.from(bytes, (byte) =>
       byte.toString(16).padStart(2, '0'),
     ).join('');
-    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}` as ReturnType<
-      Crypto['randomUUID']
-    >;
+    // A string built at runtime cannot be statically checked against the
+    // template-literal type that crypto.randomUUID() returns, so a single
+    // assertion to that exact type is unavoidable here.
+    const uuid =
+      `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-` +
+      `${hex.slice(16, 20)}-${hex.slice(20)}`;
+    return uuid as `${string}-${string}-${string}-${string}-${string}`;
   };
 }
 

--- a/src/lib/ensureRandomUUID.ts
+++ b/src/lib/ensureRandomUUID.ts
@@ -1,0 +1,39 @@
+/**
+ * Ensures `crypto.randomUUID()` exists, even in insecure browsing contexts.
+ *
+ * The Web Crypto `randomUUID()` method is only exposed in *secure contexts*
+ * (HTTPS pages, or `http://localhost`). A self-hosted CADAM instance served
+ * over plain HTTP on a LAN address — e.g. `http://192.168.1.50:3000` — is not a
+ * secure context, so `crypto.randomUUID` is `undefined` there and the app
+ * crashes on startup with `TypeError: crypto.randomUUID is not a function`.
+ *
+ * `crypto.getRandomValues()` *is* available in insecure contexts, so we use it
+ * to build a spec-compliant RFC 4122 v4 UUID as a fallback. The native
+ * implementation is always preferred when present, so this is a no-op on HTTPS
+ * and on localhost.
+ *
+ * Imported for its side effect at the very top of the client entry point.
+ */
+function installRandomUUIDPolyfill(): void {
+  if (
+    typeof crypto === 'undefined' ||
+    typeof crypto.getRandomValues !== 'function' ||
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return;
+  }
+
+  crypto.randomUUID = function randomUUID() {
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
+    const hex = Array.from(bytes, (byte) =>
+      byte.toString(16).padStart(2, '0'),
+    ).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}` as ReturnType<
+      Crypto['randomUUID']
+    >;
+  };
+}
+
+installRandomUUIDPolyfill();


### PR DESCRIPTION
## Problem

`crypto.randomUUID()` is only available in secure contexts — HTTPS pages, or
`http://localhost`. A self-hosted CADAM instance served over plain HTTP on a LAN
address (e.g. `http://192.168.1.50:3000`) is **not** a secure context, so
`crypto.randomUUID` is `undefined` there.

The app calls it from several client components (`PromptView`, `EditorView`,
`TextAreaChat`, `messageService`, …), so it crashes on startup with:

    TypeError: crypto.randomUUID is not a function

The error is swallowed by the root error boundary, so the user only sees the
"Oops! Something went wrong" screen. This makes the app unusable for anyone
self-hosting over HTTP on a LAN — a setup the README supports.

**Reproduce:** serve the app on any non-localhost HTTP origin and open it → blank error screen.

## Fix

Add a small polyfill (`src/lib/ensureRandomUUID.ts`), imported for its side
effect at the very top of the client entry point (`src/client.tsx`) so it runs
before anything calls `randomUUID`. It derives a spec-compliant RFC 4122 v4 UUID
from `crypto.getRandomValues()` (which *is* available in insecure contexts) only
when the native method is missing.

- No-op on HTTPS and on `localhost` (native implementation always preferred).
- No new dependencies.
- Server code untouched (Node exposes `crypto.randomUUID` natively).

## Testing

- `tsc -b` and `eslint` pass.
- Verified on a self-hosted instance served over HTTP on a LAN IP: without the
  patch the app shows the error boundary; with it, the app loads and generation works.