### PR TITLE
feat(models): swap Fable 5 for Fable 5.1 and Gemini 3.7 Flash for 3.8 Flash

### DIFF
--- a/shared/models.ts
+++ b/shared/models.ts
@@ -5,7 +5,9 @@ import type { Model } from './types';
 // so old conversations keep resolving to a routable, correctly priced model.
 export const LEGACY_MODEL_IDS: Record<string, Model> = {
   'openai/gpt-5.5': 'openai/gpt-5.6-sol',
-  'google/gemini-3.6-flash': 'google/gemini-3.7-flash',
+  'google/gemini-3.6-flash': 'google/gemini-3.8-flash',
+  'google/gemini-3.7-flash': 'google/gemini-3.8-flash',
+  'anthropic/claude-fable-5': 'anthropic/claude-fable-5.1',
   'z-ai/glm-5.2': 'z-ai/glm-5.3',
   'stealth/ox-alpha': 'z-ai/glm-5.3-flash',
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -246,8 +246,8 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'google/gemini-3.7-flash',
-    name: 'Gemini 3.7 Flash',
+    id: 'google/gemini-3.8-flash',
+    name: 'Gemini 3.8 Flash',
     description: 'Fast, token-efficient Google model for everyday tasks',
     provider: 'Google',
     supportsTools: true,
@@ -255,8 +255,8 @@ export const PARAMETRIC_MODELS: ModelConfig[] = [
     supportsVision: true,
   },
   {
-    id: 'anthropic/claude-fable-5',
-    name: 'Claude Fable 5',
+    id: 'anthropic/claude-fable-5.1',
+    name: 'Claude Fable 5.1',
     description: 'Most capable Anthropic model; best reasoning at highest cost',
     provider: 'Anthropic',
     supportsTools: true,

--- a/src/server/aiChat.ts
+++ b/src/server/aiChat.ts
@@ -53,7 +53,15 @@ const MODEL_PRICES: Record<
   { input: number; output: number; cacheRead?: number; cacheWrite?: number }
 > = {
   // Anthropic
-  'anthropic/claude-fable-5': { input: 10, output: 50 },
+  // Fable 5.1 cache reads bill at 0.025x input ($0.25/M), not the 0.1x
+  // default applied below, so they are listed explicitly; 5-min cache
+  // writes stay at the standard 1.25x.
+  'anthropic/claude-fable-5.1': {
+    input: 10,
+    output: 50,
+    cacheRead: 0.25,
+    cacheWrite: 12.5,
+  },
   'anthropic/claude-opus-4.8': { input: 5, output: 25 },
   'anthropic/claude-sonnet-5': { input: 2, output: 10 },
   'anthropic/claude-opus-4': { input: 15, output: 75 },
@@ -62,7 +70,7 @@ const MODEL_PRICES: Record<
   'anthropic/claude-haiku-4.5': { input: 1, output: 5 },
 
   // Google — cached content reads bill at a fraction of input price
-  // (~25% for 3.1 Pro, 10% for 3.7 Flash); there is no cache-write
+  // (~25% for 3.1 Pro, 10% for 3.8 Flash); there is no cache-write
   // surcharge (cache storage is billed per-hour, which we don't track
   // here).
   'google/gemini-3.1-pro-preview': {
@@ -71,9 +79,9 @@ const MODEL_PRICES: Record<
     cacheRead: 0.31,
     cacheWrite: 1.25,
   },
-  // 3.7 Flash rates are Google's introductory pricing through Dec 31,
+  // 3.8 Flash rates are Google's introductory pricing through Dec 31,
   // 2026; they double on Jan 1, 2027 (to 1.5 / 7.5 / 0.15).
-  'google/gemini-3.7-flash': {
+  'google/gemini-3.8-flash': {
     input: 0.75,
     output: 3.75,
     cacheRead: 0.075,

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -194,7 +194,7 @@ function ConversationEditor() {
       ? normalizeModelId(conversation.settings.model)
       : conversation.type === 'creative'
         ? 'quality'
-        : 'google/gemini-3.7-flash',
+        : 'google/gemini-3.8-flash',
   );
   const [activePreview, setActivePreview] = useState<ActivePreview>(null);
   const [parameters, setParameters] = useState<Parameter[]>([]);

--- a/src/views/PromptView.tsx
+++ b/src/views/PromptView.tsx
@@ -51,7 +51,7 @@ export function PromptView() {
 
   const [type, setType] = useState<'parametric' | 'creative'>('parametric');
 
-  const [model, setModel] = useState<Model>('google/gemini-3.7-flash');
+  const [model, setModel] = useState<Model>('google/gemini-3.8-flash');
 
   const handleTypeChange = (newType: 'parametric' | 'creative') => {
     setType(newType);
@@ -59,7 +59,7 @@ export function PromptView() {
     if (newType === 'creative') {
       setModel('quality');
     } else {
-      setModel('google/gemini-3.7-flash');
+      setModel('google/gemini-3.8-flash');
     }
   };
 


### PR DESCRIPTION
## Summary

- Replace `anthropic/claude-fable-5` with `anthropic/claude-fable-5.1` and `google/gemini-3.7-flash` with `google/gemini-3.8-flash` in `PARAMETRIC_MODELS`. Capabilities (tools, thinking, vision) are unchanged for both.
- Gemini 3.8 Flash becomes the default parametric model in `PromptView` and `EditorView`.
- Pricing: Fable 5.1 keeps $10/M input and $50/M output, but Anthropic bills its cache reads at 0.025x input ($0.25/M) rather than the 0.1x default `MODEL_PRICES` applies when `cacheRead` is omitted, so the row lists `cacheRead` and the standard 1.25x `cacheWrite` ($12.50/M) explicitly. Gemini 3.8 Flash carries the same introductory rates as 3.7 Flash ($0.75 / $3.75 / $0.075 through Dec 31, 2026).
- Map the retired `claude-fable-5` and `gemini-3.7-flash` ids to their successors in `LEGACY_MODEL_IDS`. `gemini-3.6-flash` is repointed straight at 3.8 because `normalizeModelId` does a single lookup and would otherwise resolve it to the now-retired 3.7 id.
- Billing runs on the normalized id, so the retired pricing rows are dropped (same as the gemini-3.6-flash and ox-alpha swaps).

No routing or capability-gate changes: `anthropic/` ids still hit the first-party API with dots normalized to dashes (`claude-fable-5-1`), and the existing `^claude-[a-z]+-5\b` and `^claude-(?:fable|mythos)\b` gates already match the new id.

Sources: [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing), [Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing).

## Test plan

- [x] `npm run typecheck`
- [x] `eslint` and `prettier --check` on the changed files
- [ ] Pick Fable 5.1 and Gemini 3.8 Flash in the parametric picker and run a generation
- [ ] Open a conversation persisted with `claude-fable-5` / `gemini-3.7-flash` / `gemini-3.6-flash` and confirm it resolves to the new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uctPdq2Yp87LZGLHxEk3f


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swaps `anthropic/claude-fable-5` for `anthropic/claude-fable-5.1` and `google/gemini-3.7-flash` for `google/gemini-3.8-flash` in the parametric catalog, and makes Gemini 3.8 Flash the default parametric model. Tools, thinking, and vision support are unchanged, and Anthropic routing still normalizes dots to dashes for the first-party API.

**Pricing**
- Fable 5.1 keeps the same input/output rates but bills cache reads at 0.025x input, so its row now sets `cacheRead` ($0.25/M) and `cacheWrite` ($12.50/M) explicitly.
- Gemini 3.8 Flash carries over 3.7 Flash's introductory rates ($0.75 / $3.75 / $0.075) through Dec 31, 2026.

**Legacy model IDs**
- Adds `LEGACY_MODEL_IDS` entries so `anthropic/claude-fable-5` and `google/gemini-3.7-flash` conversations resolve to the new models.
- Repoints `google/gemini-3.6-flash` directly to 3.8 because normalization does a single lookup.
- Billing uses the normalized id, so the retired pricing rows are removed.

<sup>Written for commit 783a79302c1403ca6e099be99d1eca102fc25597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adam-CAD/CADAM/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

